### PR TITLE
fix: равномерное распределение колонок канбана и плиток по всей ширине экрана

### DIFF
--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -364,7 +364,7 @@ export default function BoardPage() {
                     <div
                       key={status.id}
                       style={{
-                        width: 290, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 0,
+                        flex: '1 1 0', minWidth: 260, maxWidth: 400, display: 'flex', flexDirection: 'column', gap: 0,
                         opacity: draggingFromStatusId && !isDropAllowed ? 0.4 : 1,
                         transition: 'opacity 0.15s',
                       }}

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -92,7 +92,7 @@ function BoardCard({ board, onClick, c, isDark }: {
     <div
       onClick={onClick}
       style={{
-        display: 'flex', flexDirection: 'column', width: 416,
+        display: 'flex', flexDirection: 'column', width: '100%',
         background: c.cardBg, border: `1px solid ${c.cardBorder}`,
         borderRadius: 14, padding: '22px 24px', cursor: 'pointer',
         boxShadow: isDark ? 'none' : '0 2px 8px rgba(79,110,247,0.06)',
@@ -358,7 +358,7 @@ export default function WorkspaceDashboardPage() {
             </button>
           </div>
         ) : (
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 20 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(380px, 1fr))', gap: 20 }}>
             {boards.map(board => (
               <BoardCard
                 key={board.id} board={board} c={c} isDark={isDark}

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -118,9 +118,9 @@ function WorkspaceCard({ ws, idx, onClick, C, isDark }: {
         boxShadow: hovered
           ? `${C.cardShadow}, 0 0 0 1px ${isDark ? '#2A3352' : '#D1CBF0'}`
           : C.cardShadow,
-        boxSizing: 'border-box', cursor: 'pointer', flexShrink: 0,
+        boxSizing: 'border-box', cursor: 'pointer',
         overflow: 'clip', paddingBlock: 24, paddingInline: 24,
-        position: 'relative', width: 380,
+        position: 'relative', width: '100%',
         transition: 'box-shadow 0.15s',
       }}
     >
@@ -432,13 +432,13 @@ export default function WorkspacesPage() {
 
       {/* Cards grid */}
       {loading ? (
-        <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 24 }}>
           {[0, 1].map(i => (
-            <div key={i} style={{ backgroundColor: C.cardBg, border: `1px solid ${C.cardBorder}`, borderRadius: 12, flexShrink: 0, height: 200, opacity: 0.4, width: 380 }}/>
+            <div key={i} style={{ backgroundColor: C.cardBg, border: `1px solid ${C.cardBorder}`, borderRadius: 12, height: 200, opacity: 0.4 }}/>
           ))}
         </div>
       ) : (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 24 }}>
           {workspaces.map((ws: Workspace, idx: number) => (
             <WorkspaceCard key={ws.id} ws={ws} idx={idx} C={C} isDark={mode !== 'light'} onClick={() => navigate(`/w/${ws.slug}`)}/>
           ))}


### PR DESCRIPTION
## Summary

- **WorkspacesPage**: CSS Grid `repeat(auto-fill, minmax(340px, 1fr))` вместо flex с фиксированной шириной 380px
- **WorkspaceDashboardPage**: CSS Grid `repeat(auto-fill, minmax(380px, 1fr))` вместо flex с фиксированной шириной 416px
- **BoardPage (Kanban)**: колонки с `flex: 1 1 0` + `minWidth: 260` + `maxWidth: 400` вместо фиксированных 290px

## Test plan

- [ ] Проверить страницу воркспейсов — карточки распределяются равномерно по ширине
- [ ] Проверить дашборд воркспейса — карточки досок заполняют строку
- [ ] Проверить канбан-доску — колонки растягиваются на всю ширину экрана
- [ ] Проверить адаптивность при разных размерах окна

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Enhanced responsive layout for Kanban board columns to adjust dynamically to available space.
* Improved dashboard and workspace cards layout to reflow responsively across different screen widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->