### PR TITLE
fix+feat: баги #8 #9 #10 #11 #12 и авто-домен в регистрации #1

### DIFF
--- a/backend/src/modules/auth/auth.router.ts
+++ b/backend/src/modules/auth/auth.router.ts
@@ -3,9 +3,14 @@ import { validate } from '../../shared/middleware/validate.js';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { registerDto, loginDto, refreshDto, updateProfileDto } from './auth.dto.js';
 import * as authService from './auth.service.js';
+import { config } from '../../config.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 
 const router = Router();
+
+router.get('/registration-domain', (_req, res) => {
+  res.json({ domain: config.REGISTRATION_DOMAIN });
+});
 
 router.post('/register', validate(registerDto), async (req, res, next) => {
   try {

--- a/backend/src/modules/boards/boards.dto.ts
+++ b/backend/src/modules/boards/boards.dto.ts
@@ -1,21 +1,21 @@
 import { z } from 'zod';
 
 export const createBoardDto = z.object({
-  name: z.string().min(1).max(100),
+  name: z.string().min(1, 'Название доски обязательно').max(100, 'Название не должно превышать 100 символов'),
   prefix: z
     .string()
-    .min(2)
-    .max(8)
-    .regex(/^[A-Z0-9]+$/, 'Prefix must be uppercase letters and numbers only')
+    .min(2, 'Префикс должен содержать минимум 2 символа')
+    .max(8, 'Префикс не должен превышать 8 символов')
+    .regex(/^[A-Z0-9]+$/, 'Префикс должен содержать только заглавные латинские буквы и цифры')
     .transform((v) => v.toUpperCase()),
-  description: z.string().max(500).optional(),
-  workflowId: z.string().uuid().optional(), // defaults to workspace default workflow
+  description: z.string().max(500, 'Описание не должно превышать 500 символов').optional(),
+  workflowId: z.string().uuid('Некорректный ID workflow').optional(),
 });
 
 export const updateBoardDto = z.object({
-  name: z.string().min(1).max(100).optional(),
-  description: z.string().max(500).optional(),
-  workflowId: z.string().uuid().optional(),
+  name: z.string().min(1, 'Название доски обязательно').max(100, 'Название не должно превышать 100 символов').optional(),
+  description: z.string().max(500, 'Описание не должно превышать 500 символов').optional(),
+  workflowId: z.string().uuid('Некорректный ID workflow').optional(),
 });
 
 export type CreateBoardDto = z.infer<typeof createBoardDto>;

--- a/backend/src/modules/tasks/tasks.dto.ts
+++ b/backend/src/modules/tasks/tasks.dto.ts
@@ -1,23 +1,23 @@
 import { z } from 'zod';
 
 export const createTaskDto = z.object({
-  title: z.string().min(1).max(500),
+  title: z.string().min(1, 'Название задачи обязательно').max(500, 'Название не должно превышать 500 символов'),
   description: z.string().optional(),
-  statusId: z.string().uuid().optional(),   // defaults to first status in board workflow
-  priority: z.enum(['HIGH', 'MEDIUM', 'LOW']).optional(),
-  dueDate: z.string().datetime().optional(),
-  startDate: z.string().datetime().optional(),
-  assigneeId: z.string().uuid().optional(),
-  parentId: z.string().uuid().optional(),
+  statusId: z.string().uuid('Некорректный ID статуса').optional(),
+  priority: z.enum(['HIGH', 'MEDIUM', 'LOW'], { message: 'Приоритет должен быть HIGH, MEDIUM или LOW' }).optional(),
+  dueDate: z.string().datetime({ message: 'Введите корректную дату срока' }).optional(),
+  startDate: z.string().datetime({ message: 'Введите корректную дату начала' }).optional(),
+  assigneeId: z.string().uuid('Некорректный ID исполнителя').optional(),
+  parentId: z.string().uuid('Некорректный ID родительской задачи').optional(),
 });
 
 export const updateTaskDto = z.object({
-  title: z.string().min(1).max(500).optional(),
+  title: z.string().min(1, 'Название задачи обязательно').max(500, 'Название не должно превышать 500 символов').optional(),
   description: z.string().optional(),
-  priority: z.enum(['HIGH', 'MEDIUM', 'LOW']).nullable().optional(),
-  dueDate: z.string().datetime().nullable().optional(),
-  startDate: z.string().datetime().nullable().optional(),
-  assigneeId: z.string().uuid().nullable().optional(),
+  priority: z.enum(['HIGH', 'MEDIUM', 'LOW'], { message: 'Приоритет должен быть HIGH, MEDIUM или LOW' }).nullable().optional(),
+  dueDate: z.string().datetime({ message: 'Введите корректную дату срока' }).nullable().optional(),
+  startDate: z.string().datetime({ message: 'Введите корректную дату начала' }).nullable().optional(),
+  assigneeId: z.string().uuid('Некорректный ID исполнителя').nullable().optional(),
 });
 
 export const moveTaskDto = z.object({

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -24,3 +24,8 @@ export async function updateProfile(data: { name?: string; email?: string }): Pr
 export async function logout(refreshToken: string): Promise<void> {
   await api.post('/auth/logout', { refreshToken });
 }
+
+export async function getRegistrationDomain(): Promise<string> {
+  const { data } = await api.get<{ domain: string }>('/auth/registration-domain');
+  return data.domain;
+}

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -488,7 +488,7 @@ export default function TaskDrawer({
                       <input
                         type="date"
                         value={dueStr}
-                        onChange={(e) => save({ dueDate: e.target.value || undefined })}
+                        onChange={(e) => save({ dueDate: e.target.value ? `${e.target.value}T00:00:00.000Z` : undefined })}
                         disabled={saving}
                         style={{
                           ...selectStyle, width: 'auto',

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -154,7 +154,10 @@ export default function TaskDrawer({
       const updated = await tasksApi.updateTask(task.id, patch);
       setTask((prev) => prev ? { ...prev, ...updated } : updated);
       onUpdated(updated);
-    } catch { message.error('Ошибка сохранения'); }
+    } catch (err) {
+      const details = (err as { response?: { data?: { details?: { message: string }[] } } })?.response?.data?.details;
+      message.error(details?.map((d) => d.message).join('; ') ?? 'Ошибка сохранения');
+    }
     finally { setSaving(false); }
   };
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -381,7 +381,7 @@ export default function LoginPage() {
               <div style={{ color: C.label, fontFamily: '"Inter", system-ui, sans-serif', fontSize: 12, fontWeight: 500, lineHeight: '16px', marginBottom: 6 }}>
                 Имя
               </div>
-              <InputField type="text" value={name} onChange={setName} placeholder="Петров Иван" autoComplete="name" icon="email" C={C}/>
+              <InputField type="text" value={name} onChange={setName} placeholder="Иван Петров" autoComplete="name" icon="email" C={C}/>
             </div>
           )}
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { message, Modal } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../store/auth.store';
 import { useThemeStore } from '../store/theme.store';
+import * as authApi from '../api/auth';
 
 // ─── Design tokens (from Paper: artboards 2-0 dark, 3-0 light) ───────────────
 type LoginTheme = Record<string, string>;
@@ -298,21 +299,29 @@ export default function LoginPage() {
   // Existing logic — preserved as-is
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState('');
+  const [emailPrefix, setEmailPrefix] = useState('');
+  const [registrationDomain, setRegistrationDomain] = useState('');
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
   const [showRegister, setShowRegister] = useState(false);
   const { login, register } = useAuthStore();
   const navigate = useNavigate();
 
+  useEffect(() => {
+    authApi.getRegistrationDomain().then(setRegistrationDomain).catch(() => {});
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     try {
       if (showRegister) {
-        const msg = await register(email, password, name);
+        const registerEmail = registrationDomain ? `${emailPrefix}@${registrationDomain}` : email;
+        const msg = await register(registerEmail, password, name);
         message.success(msg);
         setShowRegister(false);
         setEmail('');
+        setEmailPrefix('');
         setPassword('');
         setName('');
       } else {
@@ -390,7 +399,33 @@ export default function LoginPage() {
             <div style={{ color: C.label, fontFamily: '"Inter", system-ui, sans-serif', fontSize: 12, fontWeight: 500, lineHeight: '16px', marginBottom: 6 }}>
               Email
             </div>
-            <InputField type="email" value={email} onChange={setEmail} placeholder="ivan@company.ru" autoComplete="email" icon="email" C={C}/>
+            {showRegister && registrationDomain ? (
+              <div style={{
+                display: 'flex', alignItems: 'center',
+                backgroundColor: C.inputBg, border: `1px solid ${C.inputBorder}`,
+                borderRadius: 8, overflow: 'hidden',
+              }}>
+                <input
+                  value={emailPrefix}
+                  onChange={e => setEmailPrefix(e.target.value)}
+                  placeholder="ivan.petrov"
+                  autoComplete="email"
+                  style={{
+                    flex: 1, background: 'transparent', border: 'none', outline: 'none',
+                    padding: '11px 14px', fontFamily: '"Inter", system-ui, sans-serif',
+                    fontSize: 14, color: C.inputText,
+                  }}
+                />
+                <span style={{
+                  padding: '11px 14px 11px 0', fontFamily: '"Inter", system-ui, sans-serif',
+                  fontSize: 14, color: C.inputIcon, whiteSpace: 'nowrap', userSelect: 'none',
+                }}>
+                  @{registrationDomain}
+                </span>
+              </div>
+            ) : (
+              <InputField type="email" value={email} onChange={setEmail} placeholder="ivan@company.ru" autoComplete="email" icon="email" C={C}/>
+            )}
           </div>
 
           {/* Password */}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { message } from 'antd';
+import { message, Modal } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../store/auth.store';
 import { useThemeStore } from '../store/theme.store';
@@ -400,7 +400,14 @@ export default function LoginPage() {
                 Пароль
               </div>
               {!showRegister && (
-                <div style={{ color: C.accent, fontFamily: '"Inter", system-ui, sans-serif', fontSize: 12, lineHeight: '16px', cursor: 'pointer' }}>
+                <div
+                  onClick={() => Modal.info({
+                    title: 'Сброс пароля',
+                    content: 'Для сброса пароля обратитесь к администратору системы.',
+                    okText: 'Понятно',
+                  })}
+                  style={{ color: C.accent, fontFamily: '"Inter", system-ui, sans-serif', fontSize: 12, lineHeight: '16px', cursor: 'pointer' }}
+                >
                   Забыли пароль?
                 </div>
               )}

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -143,6 +143,30 @@ function BoardCard({ board, onClick, c, isDark }: {
   );
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const RU_TO_EN: Record<string, string> = {
+  а:'a',б:'b',в:'v',г:'g',д:'d',е:'e',ё:'yo',ж:'zh',з:'z',и:'i',й:'j',к:'k',
+  л:'l',м:'m',н:'n',о:'o',п:'p',р:'r',с:'s',т:'t',у:'u',ф:'f',х:'kh',ц:'ts',
+  ч:'ch',ш:'sh',щ:'sch',ъ:'',ы:'y',ь:'',э:'e',ю:'yu',я:'ya',
+};
+
+function nameToPrefix(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '';
+  let result: string;
+  if (words.length === 1) {
+    // single word — take first 4 transliterated chars
+    result = words[0].toLowerCase().slice(0, 6).split('').map(c => RU_TO_EN[c] ?? c).join('');
+  } else {
+    // multiple words — first transliterated letter of each word
+    result = words.map(w => {
+      const ch = w[0]?.toLowerCase() ?? '';
+      return RU_TO_EN[ch] ?? ch;
+    }).join('');
+  }
+  return result.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8);
+}
+
 // ── Page ───────────────────────────────────────────────────────────────────────
 type FormState = { name: string; prefix: string; description: string };
 
@@ -159,6 +183,7 @@ export default function WorkspaceDashboardPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState<FormState>({ name: '', prefix: '', description: '' });
+  const [prefixTouched, setPrefixTouched] = useState(false);
 
   useEffect(() => { if (workspaces.length === 0) load(); }, [workspaces.length, load]);
 
@@ -201,7 +226,7 @@ export default function WorkspaceDashboardPage() {
     }
   };
 
-  const closeModal = () => { setCreateOpen(false); setForm({ name: '', prefix: '', description: '' }); };
+  const closeModal = () => { setCreateOpen(false); setForm({ name: '', prefix: '', description: '' }); setPrefixTouched(false); };
 
   // ── Spinner util ─────────────────────────────────────────────────────────────
   const Spinner = ({ size = 32 }: { size?: number }) => (
@@ -381,23 +406,33 @@ export default function WorkspaceDashboardPage() {
           >
             <h2 style={{ fontFamily: '"Space Grotesk",system-ui,sans-serif', fontSize: 18, fontWeight: 700, color: c.title, margin: 0 }}>Новая доска</h2>
 
-            {([
-              { key: 'name', label: 'Название', placeholder: 'Frontend, Backend, Design...' },
-              { key: 'prefix', label: 'Префикс задач', placeholder: 'DEV, OPS, FRONT...' },
-            ] as const).map(field => (
-              <div key={field.key} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                <label style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 500, color: c.lbl }}>
-                  {field.label} <span style={{ color: '#4F6EF7' }}>*</span>
-                </label>
-                <input
-                  value={form[field.key]}
-                  onChange={e => setForm(f => ({ ...f, [field.key]: field.key === 'prefix' ? e.target.value.toUpperCase() : e.target.value }))}
-                  placeholder={field.placeholder}
-                  maxLength={field.key === 'prefix' ? 8 : 100}
-                  style={{ background: c.inpBg, border: `1px solid ${c.inpBorder}`, borderRadius: 8, padding: '10px 14px', fontFamily: '"Inter",system-ui,sans-serif', fontSize: 14, color: c.inpText, outline: 'none', textTransform: field.key === 'prefix' ? 'uppercase' : 'none' }}
-                />
-              </div>
-            ))}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <label style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 500, color: c.lbl }}>
+                Название <span style={{ color: '#4F6EF7' }}>*</span>
+              </label>
+              <input
+                value={form.name}
+                onChange={e => {
+                  const newName = e.target.value;
+                  setForm(f => ({ ...f, name: newName, prefix: prefixTouched ? f.prefix : nameToPrefix(newName) }));
+                }}
+                placeholder="Frontend, Backend, Design..."
+                maxLength={100}
+                style={{ background: c.inpBg, border: `1px solid ${c.inpBorder}`, borderRadius: 8, padding: '10px 14px', fontFamily: '"Inter",system-ui,sans-serif', fontSize: 14, color: c.inpText, outline: 'none' }}
+              />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <label style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 500, color: c.lbl }}>
+                Префикс задач <span style={{ color: '#4F6EF7' }}>*</span>
+              </label>
+              <input
+                value={form.prefix}
+                onChange={e => { setPrefixTouched(true); setForm(f => ({ ...f, prefix: e.target.value.toUpperCase() })); }}
+                placeholder="DEV, OPS, FRONT..."
+                maxLength={8}
+                style={{ background: c.inpBg, border: `1px solid ${c.inpBorder}`, borderRadius: 8, padding: '10px 14px', fontFamily: '"Inter",system-ui,sans-serif', fontSize: 14, color: c.inpText, outline: 'none', textTransform: 'uppercase' }}
+              />
+            </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               <label style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 500, color: c.lbl }}>Описание</label>

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -389,7 +389,7 @@ export default function WorkspacesPage() {
   }, [workspaces]);
 
   const nameParts = user?.name?.split(' ') ?? [];
-  const firstName = (nameParts.length > 1 ? nameParts[nameParts.length - 1] : nameParts[0])?.toUpperCase() ?? 'ПОЛЬЗОВАТЕЛЬ';
+  const firstName = nameParts[0]?.toUpperCase() ?? 'ПОЛЬЗОВАТЕЛЬ';
 
   const handleCreate = async (name: string, slug: string, description?: string) => {
     try {


### PR DESCRIPTION
## Summary

- **#9** `fix`: хеллоу блок — показывать первое имя (`nameParts[0]`), а не последнее
- **#11** `fix`: дата срока задачи — отправлять ISO datetime (`T00:00:00.000Z`) вместо date-only, иначе Zod возвращал 400
- **#12** `fix`: человекочитаемые сообщения ошибок — backend DTO теперь содержат русские тексты; фронтенд парсит `details[]` из ответа и показывает их
- **#8** `fix`: кнопка «Забыли пароль» открывает `Modal.info` с инструкцией обратиться к администратору
- **#10** `feat`: автогенерация префикса доски из названия (транслитерация рус→лат, первые буквы слов); ручное редактирование отключает автозаполнение
- **#1** `feat` (partial): форма регистрации — поле email разделено на `prefix` + `@domain`, домен загружается с бэкенда (`GET /api/auth/registration-domain`)

## Test plan

- [ ] Войти как `admin@flowtask.dev` / `Password1` → хеллоу блок показывает первое слово имени
- [ ] Открыть задачу → выбрать дату срока → убедиться что сохраняется без ошибки
- [ ] Создать доску → ввести название → убедиться что префикс подставляется автоматически (рус и лат)
- [ ] Перейти на страницу логина → «Зарегистрироваться» → поле email показывает `prefix@flowtask.dev`
- [ ] Нажать «Забыли пароль?» → появляется информационный диалог

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration domain support for simplified email-based account creation
  * Automatic task prefix generation based on board names
  * Enhanced "Forgot Password" experience with modal dialog

* **Improvements**
  * Localized validation error messages for boards and tasks in Russian
  * Enhanced error handling with detailed server error messages when saving tasks
  * Improved due date persistence and input handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->