### PR TITLE
fix: убрать дублирование assigneeId в ответах tasks API

### DIFF
--- a/backend/src/__tests__/tasks-filters-rbac.test.ts
+++ b/backend/src/__tests__/tasks-filters-rbac.test.ts
@@ -124,7 +124,7 @@ describe('Tasks — filters and RBAC', () => {
       const res = await api.get(`/api/boards/${boardId}/tasks?assigneeId=${ownerId}`).set(auth(ownerToken));
       expect(res.status).toBe(200);
       expect(res.body.length).toBeGreaterThan(0);
-      expect(res.body.every((t: { assigneeId: string | null }) => t.assigneeId === ownerId)).toBe(true);
+      expect(res.body.every((t: { assignee: { id: string } | null }) => t.assignee?.id === ownerId)).toBe(true);
     });
   });
 
@@ -221,8 +221,8 @@ describe('Tasks — filters and RBAC', () => {
       const res = await api.get(`/api/boards/${boardId}/tasks?assigneeId=${ownerId}&priority=HIGH`)
         .set(auth(ownerToken));
       expect(res.status).toBe(200);
-      res.body.forEach((t: { assigneeId: string; priority: string }) => {
-        expect(t.assigneeId).toBe(ownerId);
+      res.body.forEach((t: { assignee: { id: string } | null; priority: string }) => {
+        expect(t.assignee?.id).toBe(ownerId);
         expect(t.priority).toBe('HIGH');
       });
     });

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -112,6 +112,7 @@ export async function listTasks(boardId: string, userId: string, filters: TaskFi
   return prisma.task.findMany({
     where,
     orderBy: [{ statusId: 'asc' }, { orderIndex: 'asc' }],
+    omit: { assigneeId: true },
     include: {
       assignee: { select: { id: true, name: true, avatar: true } },
       status: { select: { id: true, name: true, color: true, category: true } },
@@ -172,6 +173,7 @@ export async function createTask(boardId: string, userId: string, dto: CreateTas
       depth,
       orderIndex,
     },
+    omit: { assigneeId: true },
     include: {
       assignee: { select: { id: true, name: true, avatar: true } },
       status: { select: { id: true, name: true, color: true, category: true } },
@@ -187,6 +189,7 @@ export async function getTask(taskId: string, userId: string) {
 
   return prisma.task.findUniqueOrThrow({
     where: { id: taskId },
+    omit: { assigneeId: true },
     include: {
       status: true,
       assignee: { select: { id: true, name: true, email: true, avatar: true } },
@@ -194,6 +197,7 @@ export async function getTask(taskId: string, userId: string) {
       parent: { select: { id: true, title: true, issueKey: true } },
       children: {
         orderBy: { orderIndex: 'asc' },
+        omit: { assigneeId: true },
         include: {
           assignee: { select: { id: true, name: true, avatar: true } },
           status: { select: { id: true, name: true, color: true, category: true } },
@@ -227,6 +231,7 @@ export async function getSubtree(taskId: string, userId: string) {
       path: { startsWith: `${task.path}${taskId}/` },
     },
     orderBy: [{ depth: 'asc' }, { orderIndex: 'asc' }],
+    omit: { assigneeId: true },
     include: {
       assignee: { select: { id: true, name: true, avatar: true } },
       status: { select: { id: true, name: true, color: true, category: true } },
@@ -280,6 +285,7 @@ export async function updateTask(taskId: string, userId: string, dto: UpdateTask
     prisma.task.update({
       where: { id: taskId },
       data,
+      omit: { assigneeId: true },
       include: {
         status: true,
         assignee: { select: { id: true, name: true, avatar: true } },
@@ -325,6 +331,7 @@ export async function moveTask(taskId: string, userId: string, toStatusId: strin
     prisma.task.update({
       where: { id: taskId },
       data: { statusId: toStatusId, orderIndex },
+      omit: { assigneeId: true },
       include: {
         status: true,
         assignee: { select: { id: true, name: true, avatar: true } },


### PR DESCRIPTION
## Summary

- Prisma при `include: { assignee }` автоматически включает FK-поле `assigneeId` в ответ, дублируя `assignee.id`
- Добавлен `omit: { assigneeId: true }` в 6 запросов: `listTasks`, `createTask`, `getTask` (+ nested `children`), `getSubtree`, `updateTask`, `moveTask`
- TypeScript проверка (`tsc --noEmit`) прошла без ошибок

## Test plan

- [ ] `GET /boards/:id/tasks` — ответ содержит `assignee.id`, но не `assigneeId`
- [ ] `POST /boards/:id/tasks` — то же самое
- [ ] `GET /tasks/:id` — детальная задача и её `children` без `assigneeId`
- [ ] `PATCH /tasks/:id` — update-ответ без `assigneeId`
- [ ] `POST /tasks/:id/move` — move-ответ без `assigneeId`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Task objects returned by the backend no longer expose a top-level raw assigneeId; assignee information remains available via the nested assignee object, improving consistency of task data across retrieval and management.
* **Tests**
  * Updated test expectations to match the adjusted task response shape (checks now use assignee.id or allow null assignee).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->