### PR TITLE
fix: correct ecosystem.config.js cwd path

### DIFF
--- a/deploy/ecosystem.config.js
+++ b/deploy/ecosystem.config.js
@@ -2,7 +2,7 @@ module.exports = {
   apps: [
     {
       name: 'flowtask-api',
-      cwd: '/opt/flowtask-repo/backend',
+      cwd: '/opt/flowtask/backend',
       script: 'dist/server.js',
       instances: 1,
       autorestart: true,


### PR DESCRIPTION
## Summary
- `deploy/ecosystem.config.js` had `cwd: '/opt/flowtask-repo/backend'` — старый путь, которого нет на сервере
- Деплой кладёт файлы в `/opt/flowtask/backend/`, поэтому PM2 не мог найти `dist/server.js`
- Исправлено на `/opt/flowtask/backend`

## Root cause
PM2 лог показывал:
```
Error: Cannot find module '/opt/flowtask-repo/backend/dist/server.js'
```
После деплоя rsync копировал обновлённый `ecosystem.config.js` на сервер, но PM2 перезапускался с неверным `cwd`.

## Test plan
- [ ] Merge → запустить Deploy workflow вручную
- [ ] Health check должен пройти: `✓ Backend healthy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to reflect new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->