### PR TITLE
fix: force pm2 delete+start to pick up new ecosystem config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,11 +113,9 @@ jobs:
               node_modules/.bin/prisma migrate deploy --schema=src/prisma/schema.prisma
 
             echo '→ Restarting PM2...'
-            if pm2 describe flowtask-api > /dev/null 2>&1; then
-              pm2 reload \$APP_DIR/ecosystem.config.js --env production
-            else
-              pm2 start \$APP_DIR/ecosystem.config.js --env production
-            fi
+            pm2 stop flowtask-api 2>/dev/null || true
+            pm2 delete flowtask-api 2>/dev/null || true
+            pm2 start \$APP_DIR/ecosystem.config.js --env production
             pm2 save
 
             echo '→ Health check...'


### PR DESCRIPTION
## Summary
- `pm2 reload` с новым конфигом **не обновляет** `cwd` запущенного процесса — PM2 использует закэшированное внутреннее состояние
- Заменил `reload` на `stop → delete → start` чтобы PM2 гарантированно стартовал с новым `cwd: /opt/flowtask/backend`
- Это устраняет `Error: Cannot find module '/opt/flowtask-repo/backend/dist/server.js'`

## Test plan
- [ ] Merge → запустить Deploy workflow вручную (staging)
- [ ] Проверить лог: `→ Restarting PM2...` → `✓ Backend healthy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment reliability by implementing a more deterministic application restart sequence during updates, ensuring consistent and predictable behavior across all deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->