### PR TITLE
fix: страница логина перезагружалась из-за 401-interceptor

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -30,7 +30,8 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const original = error.config;
-    if (error.response?.status === 401 && !original._retry) {
+    const isRefreshEndpoint = original.url?.includes('/auth/refresh');
+    if (error.response?.status === 401 && !original._retry && !isRefreshEndpoint) {
       original._retry = true;
       try {
         const { data } = await axios.post<{ accessToken: string }>(
@@ -43,7 +44,9 @@ api.interceptors.response.use(
         return api(original);
       } catch {
         inMemoryToken = null;
-        window.location.href = '/login';
+        if (window.location.pathname !== '/login') {
+          window.location.href = '/login';
+        }
       }
     }
     return Promise.reject(error);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -30,7 +30,9 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const original = error.config;
+    // config.url holds only the path (not baseURL), so this match is reliable
     const isRefreshEndpoint = original.url?.includes('/auth/refresh');
+    const PUBLIC_PATHS = ['/login', '/register', '/reset-password', '/forgot-password'];
     if (error.response?.status === 401 && !original._retry && !isRefreshEndpoint) {
       original._retry = true;
       try {
@@ -42,11 +44,12 @@ api.interceptors.response.use(
         inMemoryToken = data.accessToken;
         original.headers.Authorization = `Bearer ${data.accessToken}`;
         return api(original);
-      } catch {
+      } catch (refreshError) {
         inMemoryToken = null;
-        if (window.location.pathname !== '/login') {
+        if (!PUBLIC_PATHS.includes(window.location.pathname)) {
           window.location.href = '/login';
         }
+        return Promise.reject(refreshError);
       }
     }
     return Promise.reject(error);


### PR DESCRIPTION
## Summary
- Interceptor при 401 не трогает запросы к `/auth/refresh` (иначе рекурсия)
- Редирект на `/login` только если пользователь ещё не на `/login`

## Root cause
`loadUser` вызывает `/auth/refresh` → 401 → interceptor перехватывает → снова `/auth/refresh` → снова 401 → `window.location.href = '/login'` → перезагрузка страницы логина.