### PR TITLE
fix: Redis недоступен — логин не блокировать 503

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -11,9 +11,7 @@ const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_SECONDS = 15 * 60;
 
 async function checkBruteForce(email: string): Promise<void> {
-  if (!await isRedisAvailable()) {
-    throw new AppError(503, 'Сервис временно недоступен. Попробуйте позже.');
-  }
+  if (!await isRedisAvailable()) return; // brute-force protection degraded gracefully
   const key = `auth:fail:${email.toLowerCase()}`;
   const attempts = (await getCachedJson<number>(key)) ?? 0;
   if (attempts >= MAX_LOGIN_ATTEMPTS) {
@@ -22,12 +20,14 @@ async function checkBruteForce(email: string): Promise<void> {
 }
 
 async function recordFailedAttempt(email: string): Promise<void> {
+  if (!await isRedisAvailable()) return;
   const key = `auth:fail:${email.toLowerCase()}`;
   const current = (await getCachedJson<number>(key)) ?? 0;
   await setCachedJson(key, current + 1, LOCKOUT_SECONDS);
 }
 
 async function clearFailedAttempts(email: string): Promise<void> {
+  if (!await isRedisAvailable()) return;
   const key = `auth:fail:${email.toLowerCase()}`;
   await setCachedJson(key, 0, 1);
 }


### PR DESCRIPTION
## Summary
Если Redis недоступен, brute-force защита деградирует gracefully (пропускается), вместо того чтобы блокировать весь логин с 503.

## Root cause
`checkBruteForce` бросал 503 при отсутствии Redis. На проде Redis не настроен → никто не мог войти.

## Behaviour after fix
- Redis есть → brute-force защита работает как прежде
- Redis нет → защита отключается, логин проходит нормально