### PR TITLE
fix: adminка + searchMembers в БД + лимит задач

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -201,7 +201,9 @@ export async function getMe(userId: string) {
   });
   if (!user) throw new AppError(404, 'Пользователь не найден');
   const firstName = user.name.split(' ')[0] ?? user.name;
-  return { ...user, firstName };
+  // SUPERADMIN_EMAIL always has superadmin access even if DB flag not set
+  const isSuperadmin = user.isSuperadmin || user.email === config.SUPERADMIN_EMAIL;
+  return { ...user, isSuperadmin, firstName };
 }
 
 export async function requestPasswordReset(email: string) {

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -116,6 +116,7 @@ export async function listTasks(boardId: string, userId: string, filters: TaskFi
   return prisma.task.findMany({
     where,
     orderBy: [{ statusId: 'asc' }, { orderIndex: 'asc' }],
+    take: 500,
     omit: { assigneeId: true },
     include: {
       assignee: { select: { id: true, name: true, avatar: true } },
@@ -401,6 +402,7 @@ export async function listMyTasks(userId: string, filters: MyTasksFiltersDto) {
   return prisma.task.findMany({
     where,
     orderBy: [{ dueDate: 'asc' }, { createdAt: 'desc' }],
+    take: 500,
     include: {
       status: { select: { id: true, name: true, color: true, category: true } },
       board: {

--- a/backend/src/modules/workspaces/workspaces.service.ts
+++ b/backend/src/modules/workspaces/workspaces.service.ts
@@ -245,24 +245,24 @@ export async function removeMember(workspaceId: string, requesterId: string, tar
 // ─── Member Search ───────────────────────────────────────────────────────────
 
 export async function searchMembers(workspaceId: string, query: string) {
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const members = await prisma.workspaceMember.findMany({
-    where: { workspaceId },
+    where: {
+      workspaceId,
+      ...(q && {
+        user: {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' } },
+            { email: { contains: q, mode: 'insensitive' } },
+          ],
+        },
+      }),
+    },
     include: {
-      user: {
-        select: { id: true, name: true, email: true, avatar: true },
-      },
+      user: { select: { id: true, name: true, email: true, avatar: true } },
     },
   });
-
-  if (!q) return members.map(m => m.user);
-
-  return members
-    .filter(m =>
-      m.user.name.toLowerCase().includes(q) ||
-      m.user.email.toLowerCase().includes(q),
-    )
-    .map(m => m.user);
+  return members.map(m => m.user);
 }
 
 // ─── Workspace History ────────────────────────────────────────────────────────

--- a/backend/src/shared/middleware/require-superadmin.ts
+++ b/backend/src/shared/middleware/require-superadmin.ts
@@ -1,6 +1,7 @@
 import type { Response, NextFunction } from 'express';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from './error-handler.js';
+import { config } from '../../config.js';
 import type { AuthRequest } from '../types/index.js';
 
 export async function requireSuperadmin(req: AuthRequest, _res: Response, next: NextFunction) {
@@ -8,9 +9,10 @@ export async function requireSuperadmin(req: AuthRequest, _res: Response, next: 
     if (!req.user?.userId) return next(new AppError(403, 'Доступ запрещён'));
     const user = await prisma.user.findUnique({
       where: { id: req.user.userId },
-      select: { isSuperadmin: true },
+      select: { isSuperadmin: true, email: true },
     });
-    if (!user?.isSuperadmin) return next(new AppError(403, 'Доступ запрещён'));
+    const allowed = user?.isSuperadmin || user?.email === config.SUPERADMIN_EMAIL;
+    if (!allowed) return next(new AppError(403, 'Доступ запрещён'));
     next();
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Fixes

**Adminка (blocker)**
- `requireSuperadmin` теперь даёт доступ по `SUPERADMIN_EMAIL` из config, если `isSuperadmin=false` в БД — ломалось после миграции (default=false для всех)
- `getMe` возвращает `isSuperadmin: true` для SUPERADMIN_EMAIL → фронт показывает пункт «Пользователи»

**searchMembers — DB-фильтрация**
- Убрана in-memory фильтрация, теперь `WHERE user.name ILIKE` / `user.email ILIKE` через Prisma

**Safety cap на задачи**
- `listTasks` и `listMyTasks`: `take: 500` — защита от перегрузки пока нет полноценной пагинации