### PR TITLE
feat: повышение роли суперадмина + feedback в GitHub Issues

### DIFF
--- a/backend/src/__tests__/admin.test.ts
+++ b/backend/src/__tests__/admin.test.ts
@@ -150,7 +150,7 @@ describe('Admin', () => {
         .send({ name: 'Admin Created User', emailPrefix });
       expect(res.status).toBe(201);
       expect(res.body.user).toBeDefined();
-      expect(res.body.generatedPassword).toBeUndefined(); // password not returned for security
+      expect(res.body.generatedPassword).toBeDefined();
       expect(res.body.user.email).toBe(`${emailPrefix}@${config.REGISTRATION_DOMAIN}`);
     });
 

--- a/backend/src/modules/admin/admin.dto.ts
+++ b/backend/src/modules/admin/admin.dto.ts
@@ -9,5 +9,10 @@ export const reviewRequestDto = z.object({
   action: z.enum(['approve', 'reject']),
 });
 
+export const updateUserDto = z.object({
+  isSuperadmin: z.boolean(),
+});
+
 export type CreateUserDto = z.infer<typeof createUserDto>;
 export type ReviewRequestDto = z.infer<typeof reviewRequestDto>;
+export type UpdateUserDto = z.infer<typeof updateUserDto>;

--- a/backend/src/modules/admin/admin.router.ts
+++ b/backend/src/modules/admin/admin.router.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { requireSuperadmin } from '../../shared/middleware/require-superadmin.js';
 import { validate } from '../../shared/middleware/validate.js';
-import { createUserDto, reviewRequestDto } from './admin.dto.js';
+import { createUserDto, reviewRequestDto, updateUserDto } from './admin.dto.js';
 import * as adminService from './admin.service.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 
@@ -23,6 +23,15 @@ router.post('/users', validate(createUserDto), async (req, res, next) => {
   try {
     const result = await adminService.createUser(req.body);
     res.status(201).json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.patch('/users/:id', validate(updateUserDto), async (req, res, next) => {
+  try {
+    const user = await adminService.setUserSuperadmin(req.params.id as string, req.body.isSuperadmin);
+    res.json(user);
   } catch (err) {
     next(err);
   }

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -15,8 +15,19 @@ export async function listUsers() {
       loginCount: true,
       lastLoginAt: true,
       createdAt: true,
+      isSuperadmin: true,
     },
     orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function setUserSuperadmin(userId: string, isSuperadmin: boolean) {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new AppError(404, 'Пользователь не найден');
+  return prisma.user.update({
+    where: { id: userId },
+    data: { isSuperadmin },
+    select: { id: true, email: true, name: true, isSuperadmin: true },
   });
 }
 
@@ -37,7 +48,7 @@ export async function createUser(dto: CreateUserDto) {
   });
 
   console.info(`[ADMIN] User created: ${user.email} — deliver generated password via secure channel`);
-  return { user };
+  return { user, generatedPassword };
 }
 
 export async function listRegistrationRequests() {

--- a/backend/src/modules/feedback/feedback.router.ts
+++ b/backend/src/modules/feedback/feedback.router.ts
@@ -10,6 +10,7 @@ const router = Router();
 router.post('/', authenticate, validate(feedbackDto), async (req: AuthRequest, res, next) => {
   try {
     const result = await feedbackService.submitFeedback(req.body, {
+      id: req.user!.userId,
       name: req.user!.name ?? req.user!.email,
       email: req.user!.email,
     });

--- a/backend/src/modules/feedback/feedback.service.ts
+++ b/backend/src/modules/feedback/feedback.service.ts
@@ -1,8 +1,10 @@
 import { config } from '../../config.js';
+import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import type { FeedbackDto } from './feedback.dto.js';
 
 interface FeedbackUser {
+  id: string;
   name: string;
   email: string;
 }
@@ -36,5 +38,10 @@ export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
   }
 
   const issue = await response.json() as { html_url: string; number: number };
+
+  await prisma.feedback.create({
+    data: { userId: user.id, type: dto.type, title: dto.title, body: dto.body, githubUrl: issue.html_url, githubNum: issue.number },
+  });
+
   return { url: issue.html_url, number: issue.number };
 }

--- a/backend/src/prisma/migrations/20260420_add_feedback/migration.sql
+++ b/backend/src/prisma/migrations/20260420_add_feedback/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "feedbacks" (
+  "id"        TEXT         NOT NULL,
+  "userId"    TEXT         NOT NULL,
+  "type"      TEXT         NOT NULL,
+  "title"     TEXT         NOT NULL,
+  "body"      TEXT         NOT NULL,
+  "githubUrl" TEXT,
+  "githubNum" INTEGER,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "feedbacks_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "feedbacks_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   taskHistories        TaskHistory[]
   workspaceEvents      WorkspaceEvent[]
   reviewedRegistrations RegistrationRequest[] @relation("RegistrationReviewer")
+  feedbacks             Feedback[]
 
   @@map("users")
 }
@@ -352,6 +353,23 @@ model WorkspaceEvent {
 
   @@index([workspaceId, createdAt])
   @@map("workspace_events")
+}
+
+// ─── Feedback ─────────────────────────────────────────────────────────────────
+
+model Feedback {
+  id        String   @id @default(uuid())
+  userId    String
+  type      String   // "bug" | "idea"
+  title     String
+  body      String
+  githubUrl String?
+  githubNum Int?
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("feedbacks")
 }
 
 // ─── Task History ─────────────────────────────────────────────────────────────

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -19,3 +19,8 @@ export async function listRegistrationRequests(): Promise<RegistrationRequest[]>
 export async function reviewRegistrationRequest(id: string, action: 'approve' | 'reject'): Promise<void> {
   await api.patch(`/admin/registration-requests/${id}`, { action });
 }
+
+export async function setUserSuperadmin(userId: string, isSuperadmin: boolean): Promise<AdminUser> {
+  const { data } = await api.patch<AdminUser>(`/admin/users/${userId}`, { isSuperadmin });
+  return data;
+}

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -146,6 +146,7 @@ export default function AdminUsersPage() {
 
   // Review action
   const [reviewingId, setReviewingId] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!user?.isSuperadmin) {
@@ -196,6 +197,20 @@ export default function AdminUsersPage() {
       message.error(e.response?.data?.error || 'Ошибка создания пользователя');
     } finally {
       setCreating(false);
+    }
+  }
+
+  async function handleToggleSuperadmin(u: AdminUser) {
+    if (u.id === user?.id) { message.warning('Нельзя изменить свою роль'); return; }
+    setTogglingId(u.id);
+    try {
+      const updated = await adminApi.setUserSuperadmin(u.id, !u.isSuperadmin);
+      setUsers(prev => prev.map(p => p.id === updated.id ? { ...p, isSuperadmin: updated.isSuperadmin } : p));
+      message.success(updated.isSuperadmin ? `${u.name} назначен суперадминистратором` : `${u.name} снят с роли суперадминистратора`);
+    } catch {
+      message.error('Ошибка изменения роли');
+    } finally {
+      setTogglingId(null);
     }
   }
 
@@ -265,7 +280,7 @@ export default function AdminUsersPage() {
               <>
                 {/* Header row */}
                 <div style={{
-                  display: 'grid', gridTemplateColumns: '1fr 220px 80px 110px 110px',
+                  display: 'grid', gridTemplateColumns: '1fr 200px 70px 110px 110px 130px',
                   padding: '10px 20px', borderBottom: `1px solid ${C.border}`,
                   fontSize: 11, fontWeight: 600, color: C.muted, letterSpacing: '0.06em', textTransform: 'uppercase',
                 }}>
@@ -274,10 +289,11 @@ export default function AdminUsersPage() {
                   <span>Входов</span>
                   <span>Последний вход</span>
                   <span>Создан</span>
+                  <span>Роль</span>
                 </div>
                 {users.map((u, i) => (
                   <div key={u.id} style={{
-                    display: 'grid', gridTemplateColumns: '1fr 220px 80px 110px 110px',
+                    display: 'grid', gridTemplateColumns: '1fr 200px 70px 110px 110px 130px',
                     padding: '12px 20px', alignItems: 'center',
                     borderBottom: i < users.length - 1 ? `1px solid ${C.border}` : 'none',
                     transition: 'background .1s',
@@ -295,6 +311,27 @@ export default function AdminUsersPage() {
                     <span style={{ fontSize: 13, color: C.text }}>{u.loginCount}</span>
                     <span style={{ fontSize: 12, color: C.muted }}>{formatDate(u.lastLoginAt)}</span>
                     <span style={{ fontSize: 12, color: C.muted }}>{formatDate(u.createdAt)}</span>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      {u.isSuperadmin && (
+                        <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 20, background: 'rgba(79,110,247,0.12)', color: '#4F6EF7' }}>
+                          Суперадмин
+                        </span>
+                      )}
+                      {u.id !== user?.id && (
+                        <button
+                          onClick={() => handleToggleSuperadmin(u)}
+                          disabled={togglingId === u.id}
+                          style={{
+                            fontSize: 11, fontWeight: 500, padding: '3px 8px', borderRadius: 6, cursor: 'pointer',
+                            background: 'transparent', border: `1px solid ${u.isSuperadmin ? 'rgba(239,68,68,0.35)' : 'rgba(79,110,247,0.35)'}`,
+                            color: u.isSuperadmin ? '#EF4444' : '#4F6EF7', opacity: togglingId === u.id ? 0.5 : 1,
+                            ...font,
+                          }}
+                        >
+                          {u.isSuperadmin ? 'Снять' : 'Назначить'}
+                        </button>
+                      )}
+                    </div>
                   </div>
                 ))}
               </>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -20,6 +20,7 @@ export interface AdminUser {
   loginCount: number;
   lastLoginAt?: string;
   createdAt: string;
+  isSuperadmin: boolean;
 }
 
 export type RegistrationStatus = 'PENDING' | 'APPROVED' | 'REJECTED';


### PR DESCRIPTION
## Changes

**Повышение роли ИБ до суперадмина**
- Новый endpoint `PATCH /api/admin/users/:id` принимает `{ isSuperadmin: boolean }`
- AdminUsersPage: колонка «Роль» со значком + кнопка «Назначить»/«Снять» (себя изменить нельзя)
- `listUsers` теперь возвращает `isSuperadmin`

**Feedback → обязательно в GitHub Issues**
- GitHub Issues остаётся обязательным (без токена → 503 как раньше)
- Дополнительно сохраняем каждое обращение в таблицу `feedbacks` (новая Prisma-миграция)

**createUser → возвращает generatedPassword**
- Пароль снова возвращается в ответе — нужен администратору для передачи сотруднику