### PR TITLE
feat: pagination + Redis deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,12 +102,14 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           ssh "$DEPLOY_USER@$DEPLOY_HOST" "
+            set -e
             if ! command -v redis-server > /dev/null 2>&1; then
               sudo apt-get update -qq && sudo apt-get install -y redis-server
             fi
             sudo systemctl enable redis-server
-            sudo systemctl start redis-server || true
-            grep -q 'REDIS_URL' /opt/flowtask/backend/.env \
+            sudo systemctl start redis-server
+            redis-cli ping | grep -q PONG || { echo '✗ Redis not responding after start'; exit 1; }
+            grep -qE '^REDIS_URL=' /opt/flowtask/backend/.env \
               || echo 'REDIS_URL=redis://127.0.0.1:6379' >> /opt/flowtask/backend/.env
           "
 
@@ -115,15 +117,14 @@ jobs:
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           ssh "$DEPLOY_USER@$DEPLOY_HOST" "
             set -e
             APP_DIR=/opt/flowtask
-            export DATABASE_URL='$DATABASE_URL'
 
             echo '→ Running migrations...'
             cd \$APP_DIR/backend
+            set -a && source .env && set +a
             NODE_PATH=\$APP_DIR/backend/node_modules \
               node_modules/.bin/prisma migrate deploy --schema=src/prisma/schema.prisma
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,21 @@ jobs:
           # Sync ecosystem config
           $RSYNC deploy/ecosystem.config.js "$DEPLOY_USER@$DEPLOY_HOST:$APP_DIR/ecosystem.config.js"
 
+      - name: Ensure Redis is running
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" "
+            if ! command -v redis-server > /dev/null 2>&1; then
+              sudo apt-get update -qq && sudo apt-get install -y redis-server
+            fi
+            sudo systemctl enable redis-server
+            sudo systemctl start redis-server || true
+            grep -q 'REDIS_URL' /opt/flowtask/backend/.env \
+              || echo 'REDIS_URL=redis://127.0.0.1:6379' >> /opt/flowtask/backend/.env
+          "
+
       - name: Run migrations + restart
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}

--- a/backend/src/__tests__/tasks-edge-cases.test.ts
+++ b/backend/src/__tests__/tasks-edge-cases.test.ts
@@ -166,7 +166,7 @@ describe('Tasks — edge cases', () => {
 
     const res = await api.get('/api/my-tasks').set(auth(ownerToken));
     expect(res.status).toBe(200);
-    expect(res.body.every((t: { assigneeId: string }) => t.assigneeId === myId)).toBe(true);
+    expect(res.body.tasks.every((t: { assigneeId: string }) => t.assigneeId === myId)).toBe(true);
   });
 
   it('my-tasks duePreset=overdue returns only past-due tasks', async () => {
@@ -182,8 +182,8 @@ describe('Tasks — edge cases', () => {
 
     const res = await api.get('/api/my-tasks?duePreset=overdue').set(auth(ownerToken));
     expect(res.status).toBe(200);
-    expect(res.body.length).toBeGreaterThan(0);
-    res.body.forEach((t: { dueDate: string }) => {
+    expect(res.body.tasks.length).toBeGreaterThan(0);
+    res.body.tasks.forEach((t: { dueDate: string }) => {
       expect(new Date(t.dueDate).getTime()).toBeLessThan(Date.now());
     });
   });

--- a/backend/src/__tests__/tasks-filters-rbac.test.ts
+++ b/backend/src/__tests__/tasks-filters-rbac.test.ts
@@ -110,7 +110,7 @@ describe('Tasks — filters and RBAC', () => {
 
       const res = await api.get(`/api/boards/${boardId}/tasks?statusId=${s0}`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.every((t: { statusId: string }) => t.statusId === s0)).toBe(true);
+      expect(res.body.tasks.every((t: { statusId: string }) => t.statusId === s0)).toBe(true);
     });
   });
 
@@ -123,8 +123,8 @@ describe('Tasks — filters and RBAC', () => {
 
       const res = await api.get(`/api/boards/${boardId}/tasks?assigneeId=${ownerId}`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThan(0);
-      expect(res.body.every((t: { assignee: { id: string } | null }) => t.assignee?.id === ownerId)).toBe(true);
+      expect(res.body.tasks.length).toBeGreaterThan(0);
+      expect(res.body.tasks.every((t: { assignee: { id: string } | null }) => t.assignee?.id === ownerId)).toBe(true);
     });
   });
 
@@ -140,10 +140,10 @@ describe('Tasks — filters and RBAC', () => {
 
       const res = await api.get(`/api/boards/${boardId}/tasks?labelId=${labelId}`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThan(0);
+      expect(res.body.tasks.length).toBeGreaterThan(0);
       // Every returned task should have this label
       const allHaveLabel = await Promise.all(
-        res.body.map(async (t: { id: string }) => {
+        res.body.tasks.map(async (t: { id: string }) => {
           const detail = await api.get(`/api/tasks/${t.id}`).set(auth(ownerToken));
           return detail.body.labels.some((l: { labelId: string }) => l.labelId === labelId);
         })
@@ -161,8 +161,8 @@ describe('Tasks — filters and RBAC', () => {
 
       const res = await api.get(`/api/boards/${boardId}/tasks?duePreset=overdue`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThan(0);
-      res.body.forEach((t: { dueDate: string }) => {
+      expect(res.body.tasks.length).toBeGreaterThan(0);
+      res.body.tasks.forEach((t: { dueDate: string }) => {
         expect(new Date(t.dueDate).getTime()).toBeLessThan(Date.now());
       });
     });
@@ -172,8 +172,8 @@ describe('Tasks — filters and RBAC', () => {
 
       const res = await api.get(`/api/boards/${boardId}/tasks?duePreset=no_date`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThan(0);
-      res.body.forEach((t: { dueDate: string | null }) => {
+      expect(res.body.tasks.length).toBeGreaterThan(0);
+      res.body.tasks.forEach((t: { dueDate: string | null }) => {
         expect(t.dueDate).toBeNull();
       });
     });
@@ -188,7 +188,7 @@ describe('Tasks — filters and RBAC', () => {
       // All returned tasks should be due today (not tomorrow, not yesterday)
       const todayStart = new Date(today); todayStart.setHours(0, 0, 0, 0);
       const todayEnd   = new Date(today); todayEnd.setHours(23, 59, 59, 999);
-      res.body.forEach((t: { dueDate: string }) => {
+      res.body.tasks.forEach((t: { dueDate: string }) => {
         const due = new Date(t.dueDate).getTime();
         expect(due).toBeGreaterThanOrEqual(todayStart.getTime());
         expect(due).toBeLessThanOrEqual(todayEnd.getTime());
@@ -208,8 +208,8 @@ describe('Tasks — filters and RBAC', () => {
       const res = await api.get(`/api/boards/${boardId}/tasks?priority=HIGH&search=${uniqueTitle}`)
         .set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThanOrEqual(1);
-      expect(res.body.every((t: { priority: string; title: string }) =>
+      expect(res.body.tasks.length).toBeGreaterThanOrEqual(1);
+      expect(res.body.tasks.every((t: { priority: string; title: string }) =>
         t.priority === 'HIGH' && t.title.includes(uniqueTitle)
       )).toBe(true);
     });
@@ -221,7 +221,7 @@ describe('Tasks — filters and RBAC', () => {
       const res = await api.get(`/api/boards/${boardId}/tasks?assigneeId=${ownerId}&priority=HIGH`)
         .set(auth(ownerToken));
       expect(res.status).toBe(200);
-      res.body.forEach((t: { assignee: { id: string } | null; priority: string }) => {
+      res.body.tasks.forEach((t: { assignee: { id: string } | null; priority: string }) => {
         expect(t.assignee?.id).toBe(ownerId);
         expect(t.priority).toBe('HIGH');
       });
@@ -241,9 +241,9 @@ describe('Tasks — filters and RBAC', () => {
 
       const res = await api.get(`/api/boards/${boardId}/tasks?parentId=${parent.id}`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThanOrEqual(1);
-      expect(res.body.some((t: { id: string }) => t.id === child.id)).toBe(true);
-      expect(res.body.every((t: { parentId: string | null }) => t.parentId === parent.id)).toBe(true);
+      expect(res.body.tasks.length).toBeGreaterThanOrEqual(1);
+      expect(res.body.tasks.some((t: { id: string }) => t.id === child.id)).toBe(true);
+      expect(res.body.tasks.every((t: { parentId: string | null }) => t.parentId === parent.id)).toBe(true);
     });
   });
 
@@ -262,7 +262,7 @@ describe('Tasks — filters and RBAC', () => {
       expect(res.status).toBe(200);
       const now = Date.now();
       const weekEnd = now + 7 * 24 * 60 * 60 * 1000;
-      res.body.forEach((t: { dueDate: string }) => {
+      res.body.tasks.forEach((t: { dueDate: string }) => {
         const due = new Date(t.dueDate).getTime();
         expect(due).toBeGreaterThanOrEqual(now - 86400000); // allow 1-day tolerance
         expect(due).toBeLessThan(weekEnd);
@@ -279,7 +279,7 @@ describe('Tasks — filters and RBAC', () => {
 
       const res = await api.get('/api/my-tasks?duePreset=next_week').set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThan(0);
+      expect(res.body.tasks.length).toBeGreaterThan(0);
     });
 
     it('returns 401 without token', async () => {

--- a/backend/src/__tests__/tasks.test.ts
+++ b/backend/src/__tests__/tasks.test.ts
@@ -187,7 +187,8 @@ describe('Tasks', () => {
       await createTask(ownerToken, boardId, { assigneeId: userId });
       const res = await api.get('/api/my-tasks').set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body)).toBe(true);
+      expect(Array.isArray(res.body.tasks)).toBe(true);
+      expect(typeof res.body.total).toBe('number');
     });
   });
 

--- a/backend/src/__tests__/tasks.test.ts
+++ b/backend/src/__tests__/tasks.test.ts
@@ -83,21 +83,22 @@ describe('Tasks', () => {
     it('returns task list', async () => {
       const res = await api.get(`/api/boards/${boardId}/tasks`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body)).toBe(true);
+      expect(Array.isArray(res.body.tasks)).toBe(true);
+      expect(typeof res.body.total).toBe('number');
     });
 
     it('filters by priority', async () => {
       await createTask(ownerToken, boardId, { priority: 'LOW' });
       const res = await api.get(`/api/boards/${boardId}/tasks?priority=LOW`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.every((t: { priority: string }) => t.priority === 'LOW')).toBe(true);
+      expect(res.body.tasks.every((t: { priority: string }) => t.priority === 'LOW')).toBe(true);
     });
 
     it('filters by search', async () => {
       await createTask(ownerToken, boardId, { title: 'UniqueSearchTerm9999' });
       const res = await api.get(`/api/boards/${boardId}/tasks?search=UniqueSearchTerm9999`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(res.body.length).toBeGreaterThan(0);
+      expect(res.body.tasks.length).toBeGreaterThan(0);
     });
   });
 

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -73,6 +73,7 @@ export async function getBoard(boardId: string, userId: string) {
       tasks: {
         where: { parentId: null }, // root tasks only
         orderBy: [{ statusId: 'asc' }, { orderIndex: 'asc' }],
+        take: 100,
         include: {
           assignee: { select: { id: true, name: true, avatar: true } },
           _count: { select: { children: true } },

--- a/backend/src/modules/tasks/tasks.dto.ts
+++ b/backend/src/modules/tasks/tasks.dto.ts
@@ -40,8 +40,11 @@ export const taskFiltersDto = z.object({
   priority: z.enum(['HIGH', 'MEDIUM', 'LOW']).optional(),
   labelId: z.string().uuid().optional(),
   parentId: z.string().uuid().nullable().optional(),
+  rootOnly: z.enum(['true', 'false']).transform(v => v === 'true').optional(),
   search: z.string().max(200).optional(),
   duePreset: z.enum(['today', 'this_week', 'next_week', 'overdue', 'no_date']).optional(),
+  limit: z.coerce.number().int().min(1).max(500).default(100).optional(),
+  offset: z.coerce.number().int().min(0).default(0).optional(),
 });
 
 export const myTasksFiltersDto = z.object({
@@ -49,6 +52,8 @@ export const myTasksFiltersDto = z.object({
   duePreset: z.enum(['today', 'this_week', 'next_week', 'overdue', 'no_date']).optional(),
   search: z.string().max(200).optional(),
   workspaceId: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(500).default(100).optional(),
+  offset: z.coerce.number().int().min(0).default(0).optional(),
 });
 
 export type CreateTaskDto = z.infer<typeof createTaskDto>;

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -115,18 +115,23 @@ export async function listTasks(boardId: string, userId: string, filters: TaskFi
     where.parentId = filters.parentId;
   }
 
-  return prisma.task.findMany({
-    where,
-    orderBy: [{ statusId: 'asc' }, { orderIndex: 'asc' }],
-    take: filters.limit ?? 100,
-    skip: filters.offset ?? 0,
-    omit: { assigneeId: true },
-    include: {
-      assignee: { select: { id: true, name: true, avatar: true } },
-      status: { select: { id: true, name: true, color: true, category: true } },
-      _count: { select: { children: true } },
-    },
-  });
+  const [tasks, total] = await prisma.$transaction([
+    prisma.task.findMany({
+      where,
+      orderBy: [{ statusId: 'asc' }, { orderIndex: 'asc' }],
+      take: filters.limit ?? 100,
+      skip: filters.offset ?? 0,
+      omit: { assigneeId: true },
+      include: {
+        assignee: { select: { id: true, name: true, avatar: true } },
+        status: { select: { id: true, name: true, color: true, category: true } },
+        _count: { select: { children: true } },
+      },
+    }),
+    prisma.task.count({ where }),
+  ]);
+
+  return { tasks, total };
 }
 
 // ─── Create task ──────────────────────────────────────────────────────────────

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -107,7 +107,9 @@ export async function listTasks(boardId: string, userId: string, filters: TaskFi
   };
 
   // parentId filter: null = root tasks only, undefined = all, uuid = specific parent
-  if (filters.parentId === null) {
+  if (filters.rootOnly) {
+    where.parentId = null;
+  } else if (filters.parentId === null) {
     where.parentId = null;
   } else if (filters.parentId) {
     where.parentId = filters.parentId;
@@ -116,7 +118,8 @@ export async function listTasks(boardId: string, userId: string, filters: TaskFi
   return prisma.task.findMany({
     where,
     orderBy: [{ statusId: 'asc' }, { orderIndex: 'asc' }],
-    take: 500,
+    take: filters.limit ?? 100,
+    skip: filters.offset ?? 0,
     omit: { assigneeId: true },
     include: {
       assignee: { select: { id: true, name: true, avatar: true } },
@@ -384,7 +387,7 @@ export async function listMyTasks(userId: string, filters: MyTasksFiltersDto) {
   });
   const workspaceIds = memberships.map((m) => m.workspaceId);
 
-  if (workspaceIds.length === 0) return [];
+  if (workspaceIds.length === 0) return { tasks: [], total: 0 };
 
   // Filter by specific workspace if requested
   const filteredWorkspaceIds = filters.workspaceId
@@ -399,21 +402,27 @@ export async function listMyTasks(userId: string, filters: MyTasksFiltersDto) {
     ...buildDueDateFilter(filters.duePreset),
   };
 
-  return prisma.task.findMany({
-    where,
-    orderBy: [{ dueDate: 'asc' }, { createdAt: 'desc' }],
-    take: 500,
-    include: {
-      status: { select: { id: true, name: true, color: true, category: true } },
-      board: {
-        select: {
-          id: true, name: true, prefix: true,
-          workspace: { select: { id: true, name: true, slug: true } },
+  const [tasks, total] = await prisma.$transaction([
+    prisma.task.findMany({
+      where,
+      orderBy: [{ dueDate: 'asc' }, { createdAt: 'desc' }],
+      take: filters.limit ?? 100,
+      skip: filters.offset ?? 0,
+      include: {
+        status: { select: { id: true, name: true, color: true, category: true } },
+        board: {
+          select: {
+            id: true, name: true, prefix: true,
+            workspace: { select: { id: true, name: true, slug: true } },
+          },
         },
+        _count: { select: { children: true } },
       },
-      _count: { select: { children: true } },
-    },
-  });
+    }),
+    prisma.task.count({ where }),
+  ]);
+
+  return { tasks, total };
 }
 
 // ─── DnD reorder ──────────────────────────────────────────────────────────────

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -11,8 +11,8 @@ export interface CreateTaskPayload {
   parentId?: string;
 }
 
-export async function listTasks(boardId: string, params?: Record<string, string>): Promise<Task[]> {
-  const { data } = await api.get<Task[]>(`/boards/${boardId}/tasks`, { params });
+export async function listTasks(boardId: string, params?: Record<string, string>): Promise<{ tasks: Task[]; total: number }> {
+  const { data } = await api.get<{ tasks: Task[]; total: number }>(`/boards/${boardId}/tasks`, { params });
   return data;
 }
 

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -77,7 +77,9 @@ export async function listMyTasks(params?: {
   duePreset?: string;
   search?: string;
   workspaceId?: string;
-}): Promise<MyTask[]> {
-  const { data } = await api.get<MyTask[]>('/my-tasks', { params });
+  limit?: number;
+  offset?: number;
+}): Promise<{ tasks: MyTask[]; total: number }> {
+  const { data } = await api.get<{ tasks: MyTask[]; total: number }>('/my-tasks', { params });
   return data;
 }

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -120,6 +120,8 @@ export default function BoardPage() {
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [labels, setLabels] = useState<Label[]>([]);
   const [draggingFromStatusId, setDraggingFromStatusId] = useState<string | null>(null);
+  const [columnOffsets, setColumnOffsets] = useState<Record<string, number>>({});
+  const [loadingMoreCol, setLoadingMoreCol] = useState<string | null>(null);
   const addInputRef = useRef<HTMLInputElement | null>(null);
 
   const statuses = board?.workflow.statuses ?? [];
@@ -196,6 +198,19 @@ export default function BoardPage() {
       message.error('Не удалось сохранить порядок');
       loadBoard();
     }
+  };
+
+  // ── Load more (column pagination) ────────────────────────────────────────
+  const loadMoreColumn = async (statusId: string) => {
+    if (!boardId || loadingMoreCol) return;
+    const offset = columnOffsets[statusId] ?? 100;
+    setLoadingMoreCol(statusId);
+    try {
+      const more = await tasksApi.listTasks(boardId, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
+      setColumns(prev => ({ ...prev, [statusId]: [...(prev[statusId] ?? []), ...more] }));
+      setColumnOffsets(prev => ({ ...prev, [statusId]: offset + more.length }));
+    } catch { message.error('Не удалось загрузить задачи'); }
+    finally { setLoadingMoreCol(null); }
   };
 
   // ── Quick add ─────────────────────────────────────────────────────────────
@@ -461,6 +476,22 @@ export default function BoardPage() {
                           </div>
                         )}
                       </Droppable>
+                      {/* Load more button — shown when column loaded exactly 100/200/... tasks */}
+                      {(columns[status.id]?.length ?? 0) > 0 && (columns[status.id]?.length ?? 0) % 100 === 0 && (
+                        <button
+                          onClick={() => loadMoreColumn(status.id)}
+                          disabled={loadingMoreCol === status.id}
+                          style={{
+                            marginTop: 4, width: '100%', background: 'transparent',
+                            border: `1px dashed ${border}`, borderRadius: 8,
+                            padding: '6px 10px', cursor: 'pointer',
+                            fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
+                            color: addText, opacity: loadingMoreCol === status.id ? 0.5 : 1,
+                          }}
+                        >
+                          {loadingMoreCol === status.id ? 'Загрузка...' : 'Загрузить ещё'}
+                        </button>
+                      )}
                     </div>
                   );
                 })}

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -121,7 +121,8 @@ export default function BoardPage() {
   const [labels, setLabels] = useState<Label[]>([]);
   const [draggingFromStatusId, setDraggingFromStatusId] = useState<string | null>(null);
   const [columnOffsets, setColumnOffsets] = useState<Record<string, number>>({});
-  const [loadingMoreCol, setLoadingMoreCol] = useState<string | null>(null);
+  const [columnTotals, setColumnTotals] = useState<Record<string, number>>({});
+  const [loadingMoreCols, setLoadingMoreCols] = useState<Set<string>>(new Set());
   const addInputRef = useRef<HTMLInputElement | null>(null);
 
   const statuses = board?.workflow.statuses ?? [];
@@ -132,7 +133,23 @@ export default function BoardPage() {
     try {
       const b = await boardsApi.getBoard(boardId);
       setBoard(b);
-      setColumns(groupByStatus(b.tasks ?? [], b.workflow.statuses));
+      const cols = groupByStatus(b.tasks ?? [], b.workflow.statuses);
+      setColumns(cols);
+      setColumnOffsets(Object.fromEntries(
+        b.workflow.statuses.map(s => [s.id, cols[s.id]?.length ?? 0])
+      ));
+      // For columns that hit the 100-task cap, fetch real totals so the load-more button is shown
+      const fullCols = b.workflow.statuses.filter(s => (cols[s.id]?.length ?? 0) >= 100);
+      if (fullCols.length > 0) {
+        const totals = await Promise.all(
+          fullCols.map(s =>
+            tasksApi.listTasks(boardId, { statusId: s.id, rootOnly: 'true', limit: '1', offset: '0' })
+              .then(r => [s.id, r.total] as const)
+              .catch(() => [s.id, 100] as const)
+          )
+        );
+        setColumnTotals(Object.fromEntries(totals));
+      }
     } catch { message.error('Не удалось загрузить доску'); }
     finally { setLoading(false); }
   }, [boardId]);
@@ -202,15 +219,16 @@ export default function BoardPage() {
 
   // ── Load more (column pagination) ────────────────────────────────────────
   const loadMoreColumn = async (statusId: string) => {
-    if (!boardId || loadingMoreCol) return;
-    const offset = columnOffsets[statusId] ?? 100;
-    setLoadingMoreCol(statusId);
+    if (!boardId || loadingMoreCols.has(statusId)) return;
+    const offset = columnOffsets[statusId] ?? 0;
+    setLoadingMoreCols(prev => new Set(prev).add(statusId));
     try {
-      const more = await tasksApi.listTasks(boardId, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
+      const { tasks: more, total } = await tasksApi.listTasks(boardId, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
       setColumns(prev => ({ ...prev, [statusId]: [...(prev[statusId] ?? []), ...more] }));
       setColumnOffsets(prev => ({ ...prev, [statusId]: offset + more.length }));
+      setColumnTotals(prev => ({ ...prev, [statusId]: total }));
     } catch { message.error('Не удалось загрузить задачи'); }
-    finally { setLoadingMoreCol(null); }
+    finally { setLoadingMoreCols(prev => { const s = new Set(prev); s.delete(statusId); return s; }); }
   };
 
   // ── Quick add ─────────────────────────────────────────────────────────────
@@ -232,11 +250,12 @@ export default function BoardPage() {
         const idx = tasks.findIndex(t => t.id === updated.id);
         if (idx !== -1) {
           const arr = [...tasks];
-          arr[idx] = { ...arr[idx], ...updated };
+          const mergedTask = { ...arr[idx], ...updated };
+          arr[idx] = mergedTask;
           if (updated.statusId !== sid) {
             arr.splice(idx, 1);
             newCols[sid] = arr;
-            newCols[updated.statusId] = [...(newCols[updated.statusId] ?? []), arr[idx]];
+            newCols[updated.statusId] = [...(newCols[updated.statusId] ?? []), mergedTask];
           } else {
             newCols[sid] = arr;
           }
@@ -260,6 +279,10 @@ export default function BoardPage() {
   // ── Filtered data ─────────────────────────────────────────────────────────
   const allTasks = useMemo(() => columnsToList(columns), [columns]);
   const filteredTasks = useMemo(() => applyFilters(allTasks, filters), [allTasks, filters]);
+  const hasMoreTasks = useMemo(
+    () => Object.entries(columnTotals).some(([sid, total]) => (columns[sid]?.length ?? 0) < total),
+    [columnTotals, columns],
+  );
   const filteredColumns = useMemo(() => {
     const ids = new Set(filteredTasks.map(t => t.id));
     const result: Columns = {};
@@ -312,7 +335,7 @@ export default function BoardPage() {
           {board.name}
         </h1>
         <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: cntText, background: cntBg, borderRadius: 6, padding: '2px 8px', flexShrink: 0 }}>
-          {allTasks.length} задач
+          {allTasks.length}{hasMoreTasks ? '+' : ''} задач
         </span>
 
         <div style={{ flex: 1 }} />
@@ -476,20 +499,20 @@ export default function BoardPage() {
                           </div>
                         )}
                       </Droppable>
-                      {/* Load more button — shown when column loaded exactly 100/200/... tasks */}
-                      {(columns[status.id]?.length ?? 0) > 0 && (columns[status.id]?.length ?? 0) % 100 === 0 && (
+                      {/* Load more button — shown when server has more tasks than loaded */}
+                      {columnTotals[status.id] !== undefined && (columns[status.id]?.length ?? 0) < columnTotals[status.id] && (
                         <button
                           onClick={() => loadMoreColumn(status.id)}
-                          disabled={loadingMoreCol === status.id}
+                          disabled={loadingMoreCols.has(status.id)}
                           style={{
                             marginTop: 4, width: '100%', background: 'transparent',
                             border: `1px dashed ${border}`, borderRadius: 8,
                             padding: '6px 10px', cursor: 'pointer',
                             fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
-                            color: addText, opacity: loadingMoreCol === status.id ? 0.5 : 1,
+                            color: addText, opacity: loadingMoreCols.has(status.id) ? 0.5 : 1,
                           }}
                         >
-                          {loadingMoreCol === status.id ? 'Загрузка...' : 'Загрузить ещё'}
+                          {loadingMoreCols.has(status.id) ? 'Загрузка...' : `Загрузить ещё (${columnTotals[status.id] - (columns[status.id]?.length ?? 0)})`}
                         </button>
                       )}
                     </div>

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { message } from 'antd';
 import { useThemeStore } from '../store/theme.store';
@@ -36,25 +36,6 @@ const PRIO: Record<string, { bg: string; text: string }> = {
 // ── Due preset helpers ─────────────────────────────────────────────────────────
 type DuePreset = '' | 'today' | 'this_week' | 'overdue' | 'no_date';
 
-function duePresetMatch(task: MyTask, preset: DuePreset): boolean {
-  if (preset === '') return true;
-  const now = new Date();
-  const today = new Date(now); today.setHours(0, 0, 0, 0);
-  const tomorrow = new Date(today); tomorrow.setDate(today.getDate() + 1);
-  const weekEnd = new Date(today); weekEnd.setDate(today.getDate() + 7);
-  if (preset === 'no_date') return !task.dueDate;
-  if (!task.dueDate) return false;
-  const d = new Date(task.dueDate);
-  if (preset === 'overdue') return d < today;
-  if (preset === 'today') return d >= today && d < tomorrow;
-  if (preset === 'this_week') return d >= today && d < weekEnd;
-  return true;
-}
-
-function presetCount(tasks: MyTask[], preset: DuePreset): number {
-  return tasks.filter((t) => duePresetMatch(t, preset)).length;
-}
-
 // ── Workspace icon colors ──────────────────────────────────────────────────────
 const WS_COLORS = ['#22C55E', '#4F6EF7', '#8B5CF6', '#F59E0B', '#EC4899', '#0EA5E9'];
 function wsColor(name: string): string {
@@ -68,37 +49,39 @@ export default function MyTasksPage() {
   const c = mode === 'light' ? LIGHT : DARK;
 
   const [allTasks, setAllTasks] = useState<MyTask[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [duePreset, setDuePreset] = useState<DuePreset>('');
   const [search, setSearch] = useState('');
+  const offsetRef = useRef(0);
+
+  const fetchTasks = async (preset: DuePreset, q: string, replace: boolean) => {
+    const offset = replace ? 0 : offsetRef.current;
+    if (replace) setLoading(true); else setLoadingMore(true);
+    try {
+      const result = await tasksApi.listMyTasks({
+        duePreset: preset || undefined,
+        search: q.trim() || undefined,
+        limit: 100,
+        offset,
+      });
+      setTotal(result.total);
+      setAllTasks(prev => replace ? result.tasks : [...prev, ...result.tasks]);
+      offsetRef.current = replace ? result.tasks.length : offset + result.tasks.length;
+    } catch {
+      message.error('Не удалось загрузить задачи');
+    } finally {
+      if (replace) setLoading(false); else setLoadingMore(false);
+    }
+  };
 
   useEffect(() => {
-    (async () => {
-      setLoading(true);
-      try {
-        const data = await tasksApi.listMyTasks();
-        setAllTasks(data);
-      } catch {
-        message.error('Не удалось загрузить задачи');
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
-
-  // Filtered + searched tasks
-  const visibleTasks = useMemo(() => {
-    let result = allTasks.filter((t) => duePresetMatch(t, duePreset));
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      result = result.filter(
-        (t) =>
-          t.title.toLowerCase().includes(q) ||
-          (t.issueKey ?? '').toLowerCase().includes(q),
-      );
-    }
-    return result;
-  }, [allTasks, duePreset, search]);
+    offsetRef.current = 0;
+    const timer = setTimeout(() => { fetchTasks(duePreset, search, true); }, search ? 300 : 0);
+    return () => clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [duePreset, search]);
 
   // Group by workspace → board
   const grouped = useMemo(() => {
@@ -111,7 +94,7 @@ export default function MyTasksPage() {
         boards: Map<string, { boardId: string; boardName: string; tasks: MyTask[] }>;
       }
     >();
-    for (const t of visibleTasks) {
+    for (const t of allTasks) {
       const { workspace, id: boardId, name: boardName } = t.board;
       if (!wsMap.has(workspace.id)) {
         wsMap.set(workspace.id, {
@@ -131,7 +114,7 @@ export default function MyTasksPage() {
       ...ws,
       boards: Array.from(ws.boards.values()),
     }));
-  }, [visibleTasks]);
+  }, [allTasks]);
 
   const chips: { value: DuePreset; label: string }[] = [
     { value: '', label: 'Все' },
@@ -161,7 +144,7 @@ export default function MyTasksPage() {
             color: c.chipText, background: c.chipBg,
             borderRadius: 6, padding: '2px 8px',
           }}>
-            {allTasks.length} задач
+            {total} задач
           </span>
         )}
       </div>
@@ -173,7 +156,6 @@ export default function MyTasksPage() {
         {chips.map((chip) => {
           const active = duePreset === chip.value;
           const isOverdue = chip.value === 'overdue';
-          const count = chip.value === '' ? null : presetCount(allTasks, chip.value);
           return (
             <button
               key={chip.value}
@@ -181,10 +163,10 @@ export default function MyTasksPage() {
               style={{
                 fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
                 fontWeight: active ? 500 : 400,
-                color: isOverdue && (active || count! > 0)
+                color: isOverdue && active
                   ? c.chipOverdueText
                   : active ? c.chipActiveText : c.chipText,
-                background: isOverdue && (active || count! > 0)
+                background: isOverdue && active
                   ? c.chipOverdue
                   : active ? c.chipActive : c.chipBg,
                 border: active
@@ -195,8 +177,8 @@ export default function MyTasksPage() {
               }}
             >
               {chip.label}
-              {count !== null && count > 0 && (
-                <span style={{ marginLeft: 4, opacity: 0.8 }}>· {count}</span>
+              {active && total > 0 && (
+                <span style={{ marginLeft: 4, opacity: 0.8 }}>· {total}</span>
               )}
             </button>
           );
@@ -236,7 +218,7 @@ export default function MyTasksPage() {
           }} />
           <style>{`@keyframes spin{to{transform:rotate(360deg)}}`}</style>
         </div>
-      ) : visibleTasks.length === 0 ? (
+      ) : allTasks.length === 0 ? (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 60, gap: 8 }}>
           <svg width="40" height="40" viewBox="0 0 40 40" fill="none">
             <circle cx="20" cy="20" r="18" stroke={c.border} strokeWidth="1.5"/>
@@ -409,6 +391,25 @@ export default function MyTasksPage() {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Load more */}
+      {!loading && allTasks.length < total && (
+        <div style={{ display: 'flex', justifyContent: 'center', marginTop: 24 }}>
+          <button
+            onClick={() => fetchTasks(duePreset, search, false)}
+            disabled={loadingMore}
+            style={{
+              fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13,
+              color: '#4F6EF7', background: 'transparent',
+              border: '1px solid #4F6EF7', borderRadius: 8,
+              padding: '8px 24px', cursor: 'pointer',
+              opacity: loadingMore ? 0.5 : 1,
+            }}
+          >
+            {loadingMore ? 'Загрузка...' : `Загрузить ещё (${total - allTasks.length})`}
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- **Board columns**: initial load capped at 100 root tasks per column; "Загрузить ещё" button appears when a column hits a 100-task boundary and fetches the next page
- **My Tasks**: server-side filtering/search (duePreset + search sent to API, 300ms debounce); "Загрузить ещё N" button at bottom when more results exist; returns `{ tasks, total }` from backend
- **Redis**: deploy step installs `redis-server` if absent, enables systemd, appends `REDIS_URL=redis://127.0.0.1:6379` to `.env` on first deploy

## Backend changes
- `tasks.dto.ts`: added `limit`, `offset`, `rootOnly` to `taskFiltersDto`; `limit`, `offset` to `myTasksFiltersDto`
- `tasks.service.ts`: `listTasks` uses `take/skip`; `listMyTasks` returns `{ tasks, total }` via `$transaction([findMany, count])`
- `boards.service.ts`: `take: 100` on tasks include

## Test plan
- [ ] Board with 100+ tasks in one column shows "Загрузить ещё" button
- [ ] Clicking button appends tasks, button disappears when all loaded
- [ ] My Tasks: changing duePreset chip reloads from server
- [ ] My Tasks: typing in search debounces and filters server-side
- [ ] "Загрузить ещё N" button shown when total > loaded count
- [ ] Deploy workflow: Redis step runs without error on clean server