### PR TITLE
fix: searchMembers router/service arg mismatch

### DIFF
--- a/backend/src/modules/workspaces/workspaces.router.ts
+++ b/backend/src/modules/workspaces/workspaces.router.ts
@@ -37,7 +37,7 @@ router.delete('/:id', authHandler(async (req, res) => {
 
 router.get('/:id/members/search', authHandler(async (req, res) => {
   const q = (req.query.q as string) ?? '';
-  const users = await ws.searchMembers(String(req.params.id), req.user!.userId, q);
+  const users = await ws.searchMembers(String(req.params.id), q);
   res.json(users);
 }));
 


### PR DESCRIPTION
Router передавал 3 аргумента (workspaceId, callerId, q), сервис принимает 2 (workspaceId, q). TS build падал.