### PR TITLE
fix: hello-блок показывает имя, а не фамилию

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -10,6 +10,12 @@ import type { RegisterDto, LoginDto, UpdateProfileDto } from './auth.dto.js';
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_SECONDS = 15 * 60;
 
+// Convention: name field stores "FirstName LastName". Takes first word.
+function extractFirstName(name: string): string {
+  const trimmed = name.trim();
+  return trimmed.split(/\s+/)[0] || trimmed;
+}
+
 async function checkBruteForce(email: string): Promise<void> {
   if (!await isRedisAvailable()) return; // brute-force protection degraded gracefully
   const key = `auth:fail:${email.toLowerCase()}`;
@@ -191,7 +197,8 @@ export async function updateProfile(userId: string, dto: UpdateProfileDto) {
     data,
     select: { id: true, email: true, name: true, avatar: true, loginCount: true, createdAt: true },
   });
-  return user;
+  const firstName = extractFirstName(user.name);
+  return { ...user, firstName };
 }
 
 export async function getMe(userId: string) {
@@ -200,7 +207,7 @@ export async function getMe(userId: string) {
     select: { id: true, email: true, name: true, avatar: true, loginCount: true, createdAt: true, isSuperadmin: true },
   });
   if (!user) throw new AppError(404, 'Пользователь не найден');
-  const firstName = user.name.split(' ')[0] ?? user.name;
+  const firstName = extractFirstName(user.name);
   // SUPERADMIN_EMAIL always has superadmin access even if DB flag not set
   const isSuperadmin = user.isSuperadmin || user.email === config.SUPERADMIN_EMAIL;
   return { ...user, isSuperadmin, firstName };

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -393,7 +393,7 @@ export default function WorkspacesPage() {
   const gap         = useResponsiveValue(20, 28, 32);
   const paddingBlock  = useResponsiveValue('24px', '32px', '48px');
   const paddingInline = useResponsiveValue('16px', '40px', '80px');
-  const firstName = ((user as { firstName?: string; name?: string })?.firstName ?? user?.name?.split(' ')[0] ?? 'ПОЛЬЗОВАТЕЛЬ').toUpperCase();
+  const firstName = (user?.firstName ?? user?.name?.trim().split(/\s+/)[0] ?? 'ПОЛЬЗОВАТЕЛЬ').toUpperCase();
 
   const handleCreate = async (name: string, slug: string, description?: string) => {
     try {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,7 @@ export interface User {
   id: string;
   email: string;
   name: string;
+  firstName?: string;
   avatar?: string;
   loginCount?: number;
   createdAt?: string;


### PR DESCRIPTION
## Проблема

В hello-блоке на странице воркспейсов отображалась фамилия вместо имени.

## Root cause

1. `updateProfile` (PATCH `/auth/me`) не вычислял и не возвращал `firstName` — после сохранения профиля `user.firstName` в Zustand становился `undefined`, фолбэк `split(' ')[0]` срабатывал на сырое поле `name`
2. `User` тип не содержал `firstName` → фронт использовал небезопасный cast `(user as { firstName?: string })?.firstName`

## Изменения

**`auth.service.ts`**
- Выделена `extractFirstName(name)`: trim → split(/\s+/) → первое слово, с guard на пустую строку (`|| trimmed`)
- `updateProfile` теперь тоже возвращает `{ ...user, firstName }` (как `getMe`)

**`types/index.ts`**
- `firstName?: string` добавлен в интерфейс `User`

**`WorkspacesPage.tsx`**
- Убран cast, используем типизированный `user.firstName`
- Фолбэк split использует `/\s+/` (множественные пробелы)

## Test plan
- [ ] Зайти под любым пользователем — hello-блок показывает первое слово имени
- [ ] Сохранить профиль (изменить имя) — hello-блок обновляется корректно
- [ ] Пустое имя не ломает UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)