### PR TITLE
feat: автоопределение устройства в форме обратной связи

### DIFF
--- a/backend/src/modules/feedback/feedback.dto.ts
+++ b/backend/src/modules/feedback/feedback.dto.ts
@@ -5,11 +5,12 @@ export const feedbackDto = z.object({
   title: stripHtml(z.string().min(3, 'Заголовок слишком короткий').max(200, 'Заголовок слишком длинный')),
   body: stripHtml(z.string().min(10, 'Описание слишком короткое').max(5000, 'Описание слишком длинное')),
   type: z.enum(['bug', 'idea'], { message: 'Тип должен быть bug или idea' }),
-  device: z.object({
-    tier: z.enum(['mobile', 'tablet', 'desktop']),
-    screenWidth: z.number().int().positive(),
-    screenHeight: z.number().int().positive(),
-    userAgent: z.string().max(500),
+  meta: z.object({
+    ua: z.string().max(500),
+    screen: z.string().max(50),
+    viewport: z.string().max(50),
+    url: z.string().max(500),
+    language: z.string().max(20),
   }).optional(),
 });
 

--- a/backend/src/modules/feedback/feedback.service.ts
+++ b/backend/src/modules/feedback/feedback.service.ts
@@ -15,12 +15,15 @@ export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
   }
 
   const label = dto.type === 'bug' ? 'bug' : 'enhancement';
-
-  const deviceBlock = dto.device
-    ? `**Устройство:** ${dto.device.tier} (${dto.device.screenWidth}×${dto.device.screenHeight})\n**User-Agent:** \`${dto.device.userAgent}\``
-    : '**Устройство:** неизвестно';
-
-  const bodyWithMeta = `${dto.body}\n\n---\n**Отправитель:** ${user.name} (${user.email})\n**Окружение:** ${config.NODE_ENV}\n${deviceBlock}`;
+  const deviceSection = dto.meta
+    ? [
+        `**UA:** \`${dto.meta.ua}\``,
+        `**Экран:** ${dto.meta.screen} / вьюпорт: ${dto.meta.viewport}`,
+        `**Язык:** ${dto.meta.language}`,
+        `**URL:** ${dto.meta.url}`,
+      ].join('\n')
+    : '*нет данных об устройстве*';
+  const bodyWithMeta = `${dto.body}\n\n---\n**Отправитель:** ${user.name} (${user.email})\n**Окружение:** ${config.NODE_ENV}\n\n### Устройство\n${deviceSection}`;
 
   const response = await fetch(
     `https://api.github.com/repos/${config.GITHUB_REPO_OWNER}/${config.GITHUB_REPO_NAME}/issues`,

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Modal, Form, Input, Radio, Button, message } from 'antd';
 import api from '../api/client';
 import { formatApiError } from '../utils/apiError';
-import { useBreakpoint } from '../utils/useBreakpoint';
 
 interface FeedbackModalProps {
   open: boolean;
@@ -12,18 +11,24 @@ interface FeedbackModalProps {
 export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   const [loading, setLoading] = useState(false);
   const [form] = Form.useForm();
-  const tier = useBreakpoint();
+
+  function collectDeviceMeta() {
+    return {
+      ua: navigator.userAgent,
+      screen: `${screen.width}x${screen.height}`,
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+      url: window.location.href,
+      language: navigator.language,
+    };
+  }
 
   const onFinish = async (values: { title: string; body: string; type: 'bug' | 'idea' }) => {
     setLoading(true);
     try {
-      const device = {
-        tier,
-        screenWidth: window.screen.width,
-        screenHeight: window.screen.height,
-        userAgent: navigator.userAgent.slice(0, 500),
-      };
-      const res = await api.post<{ url: string; number: number }>('/feedback', { ...values, device });
+      const res = await api.post<{ url: string; number: number }>('/feedback', {
+        ...values,
+        meta: collectDeviceMeta(),
+      });
       message.success(
         <span>
           Обращение #{res.data.number} создано.{' '}


### PR DESCRIPTION
## Summary
- Фронт: `FeedbackModal` собирает UA, экран, вьюпорт, URL, язык браузера через `collectDeviceMeta()` и отправляет как скрытое поле `meta`
- Бэк: DTO принимает опциональный объект `meta` (Zod schema); сервис форматирует его в секцию **Устройство** в теле GitHub Issue
- Пользователь ничего не видит и не заполняет — данные собираются автоматически

## Test plan
- [ ] Отправить обратную связь через форму
- [ ] Открыть созданный GitHub Issue — в теле должна быть секция "Устройство" с UA, экраном, вьюпортом, языком и URL
- [ ] Проверить что старые поля (Отправитель, Окружение) не сломались
- [ ] Отправить с мобильного — убедиться что вьюпорт корректный (не 1920x1080)