### PR TITLE
fix: nginx no-cache для index.html — стейдж показывает старую версию после деплоя

### DIFF
--- a/deploy/nginx/flowtask.conf
+++ b/deploy/nginx/flowtask.conf
@@ -45,11 +45,20 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    # index.html — never cache so browsers always get the latest entry point
+    location = /index.html {
+        try_files $uri /index.html;
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+    }
+
     # SPA fallback — all routes → index.html
     location / {
         try_files $uri $uri/ /index.html;
-        expires 1h;
-        add_header Cache-Control "public, max-age=3600";
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
     }
 
     # Static assets — long cache


### PR DESCRIPTION
## Проблема
После деплоя браузеры продолжали загружать старый `index.html` из кэша (TTL 1h), который ссылался на старые хэшированные бандлы → пользователи не видели новые фичи до истечения кэша.

## Причина
`location /` в nginx выставлял `Cache-Control: public, max-age=3600` на все маршруты, включая `index.html`.

## Решение
- `index.html` и SPA-фолбэк: `no-cache, no-store, must-revalidate`
- JS/CSS/шрифты остаются `immutable` (Vite хэширует имена при каждом билде, поэтому длинный кэш безопасен)

🤖 Generated with [Claude Code](https://claude.com/claude-code)