### PR TITLE
fix: stale workspace cache — refresh current + invalidate on member mutations

### DIFF
--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -228,13 +228,14 @@ export default function WorkspaceDashboardPage() {
 
   useEffect(() => { if (workspaces.length === 0) load(); }, [workspaces.length, load]);
 
+  // Derive the workspace ID outside the effect to avoid stale closure.
+  // Always refresh current on mount/slug change so memberCount, boardCount
+  // are never stale after settings mutations.
+  const foundId = workspaces.find(w => w.slug === slug)?.id;
   useEffect(() => {
-    if (!slug) return;
-    const found = workspaces.find(w => w.slug === slug);
-    if (found && found.id !== current?.id) {
-      workspacesApi.getWorkspace(found.id).then(setCurrent).catch(() => null);
-    }
-  }, [slug, workspaces, current?.id, setCurrent]);
+    if (!foundId) return;
+    workspacesApi.getWorkspace(foundId).then(setCurrent).catch(() => null);
+  }, [foundId, setCurrent]);
 
   useEffect(() => {
     if (!current) return;

--- a/frontend/src/pages/WorkspaceSettingsPage.tsx
+++ b/frontend/src/pages/WorkspaceSettingsPage.tsx
@@ -200,12 +200,17 @@ export default function WorkspaceSettingsPage() {
     try {
       await workspacesApi.updateMemberRole(workspace.id, userId, role);
       setMembers((prev) => prev.map((m) => m.userId === userId ? { ...m, role } : m));
+      load(); // refresh memberCount in workspace store
     } catch { message.error('Не удалось изменить роль'); }
   };
 
   const handleRemoveMember = async (userId: string) => {
     if (!confirm('Удалить участника?')) return;
-    try { await workspacesApi.removeMember(workspace.id, userId); setMembers((prev) => prev.filter((m) => m.userId !== userId)); }
+    try {
+      await workspacesApi.removeMember(workspace.id, userId);
+      setMembers((prev) => prev.filter((m) => m.userId !== userId));
+      load(); // refresh memberCount in workspace store
+    }
     catch { message.error('Не удалось удалить'); }
   };
 
@@ -217,6 +222,7 @@ export default function WorkspaceSettingsPage() {
       const updated = await workspacesApi.listMembers(workspace.id);
       setMembers(updated); setInviteEmail(''); setShowInviteForm(false);
       message.success('Участник добавлен');
+      load(); // refresh memberCount in workspace store
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
       message.error(msg ?? 'Не удалось пригласить');


### PR DESCRIPTION
## Проблема (найдено аудитом кэширования)

1. **WorkspaceDashboardPage** — после изменения участников в настройках и возврата на дашборд `memberCount` оставался старым. Причина: `getWorkspace` вызывался только при `found.id !== current?.id`, т.е. никогда при навигации на тот же воркспейс.

2. **WorkspaceSettingsPage** — после add/remove/role-change участника `workspace.store.load()` не вызывался → список воркспейсов в Zustand не обновлялся → `memberCount` на карточке в WorkspacesPage оставался стейл.

## Фикс

- `WorkspaceDashboardPage`: `foundId` вычисляется снаружи эффекта, эффект зависит от `foundId` — всегда рефетчит `current` при mount или смене воркспейса
- `WorkspaceSettingsPage`: `load()` после `updateMemberRole`, `removeMember`, `inviteByEmail`

## Test plan
- [ ] Добавить участника → вернуться на список воркспейсов → `memberCount` актуален
- [ ] Удалить участника → то же самое
- [ ] Открыть дашборд, зайти в настройки, изменить роль → вернуться на дашборд → `memberCount` обновлён

🤖 Generated with [Claude Code](https://claude.com/claude-code)