### PR TITLE
fix: человекочитаемая история — глаголы по роду, имена вместо UUID, детали изменений

### DIFF
--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -364,11 +364,34 @@ export async function moveTask(taskId: string, userId: string, toStatusId: strin
 export async function getTaskHistory(taskId: string, userId: string) {
   await getTaskWithAccess(taskId, userId);
 
-  return prisma.taskHistory.findMany({
+  const entries = await prisma.taskHistory.findMany({
     where: { taskId },
     orderBy: { createdAt: 'asc' },
     include: { user: { select: { id: true, name: true, avatar: true } } },
   });
+
+  // Resolve assigneeId UUIDs → user names so the frontend can display them.
+  const assigneeIds = new Set<string>();
+  for (const e of entries) {
+    if (e.field === 'assigneeId') {
+      if (e.oldValue) assigneeIds.add(e.oldValue);
+      if (e.newValue) assigneeIds.add(e.newValue);
+    }
+  }
+  const userMap = new Map<string, string>();
+  if (assigneeIds.size > 0) {
+    const users = await prisma.user.findMany({
+      where: { id: { in: [...assigneeIds] } },
+      select: { id: true, name: true },
+    });
+    for (const u of users) userMap.set(u.id, u.name);
+  }
+
+  return entries.map((e) => ({
+    ...e,
+    oldValue: e.field === 'assigneeId' && e.oldValue ? (userMap.get(e.oldValue) ?? e.oldValue) : e.oldValue,
+    newValue: e.field === 'assigneeId' && e.newValue ? (userMap.get(e.newValue) ?? e.newValue) : e.newValue,
+  }));
 }
 
 // ─── Delete task ──────────────────────────────────────────────────────────────

--- a/frontend/src/components/TaskHistoryTimeline.tsx
+++ b/frontend/src/components/TaskHistoryTimeline.tsx
@@ -4,7 +4,6 @@ import { useThemeStore } from '../store/theme.store';
 import type { TaskHistory, WorkflowStatus } from '../types';
 import * as tasksApi from '../api/tasks';
 
-// ── Design tokens ──────────────────────────────────────────────────────────────
 type C = Record<string, string>;
 const DARK: C = {
   text: '#E2E8F8', muted: '#8B95B0', dim: '#4A5578',
@@ -15,36 +14,54 @@ const LIGHT: C = {
   line: '#E8E5F0', removed: '#EF4444', added: '#10B981',
 };
 
-// ── Avatar helpers ─────────────────────────────────────────────────────────────
 const AVATAR_PALETTE = ['#4F6EF7','#8B5CF6','#22C55E','#F59E0B','#EC4899','#EF4444','#0EA5E9'];
 function avatarColor(name: string): string { return AVATAR_PALETTE[(name?.charCodeAt(0) ?? 0) % AVATAR_PALETTE.length]; }
 
-// ── Field / value labels ───────────────────────────────────────────────────────
 const FIELD_LABELS: Record<string, string> = {
-  title: 'заголовок', description: 'описание', priority: 'приоритет',
-  statusId: 'статус', assigneeId: 'исполнитель', dueDate: 'срок', startDate: 'дата начала',
+  title:       'заголовок',
+  description: 'описание',
+  priority:    'приоритет',
+  statusId:    'статус',
+  assigneeId:  'исполнитель',
+  dueDate:     'срок',
+  startDate:   'дата начала',
 };
-const PRIORITY_LABELS: Record<string, string> = { HIGH: 'Высокий', MEDIUM: 'Средний', LOW: 'Низкий' };
+
+const PRIORITY_LABELS: Record<string, string> = {
+  HIGH: 'Высокий', MEDIUM: 'Средний', LOW: 'Низкий',
+};
+
+// Russian verb form heuristic: names ending in а/я are typically feminine.
+// Checks the last word (usually given name in "Фамилия Имя" format).
+function verbForm(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const firstName = parts[parts.length - 1] ?? name;
+  return /[аяАЯ]$/u.test(firstName) ? 'изменила' : 'изменил';
+}
 
 function formatValue(field: string, value: string | null, statuses: WorkflowStatus[]): string {
-  if (value === null) return '—';
+  if (value === null || value === '') return '—';
   if (field === 'statusId') return statuses.find(s => s.id === value)?.name ?? value;
   if (field === 'priority') return PRIORITY_LABELS[value] ?? value;
   if (field === 'dueDate' || field === 'startDate') {
-    try { return new Date(value).toLocaleDateString('ru-RU'); } catch { return value; }
+    try {
+      return new Date(value).toLocaleDateString('ru-RU', { day: 'numeric', month: 'long', year: 'numeric' });
+    } catch { return value; }
   }
-  if (value.length > 60) return value.slice(0, 60) + '…';
-  return value;
+  return value.length > 80 ? value.slice(0, 80) + '…' : value;
 }
 
-// ── Props ──────────────────────────────────────────────────────────────────────
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('ru-RU', {
+    day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
+  });
+}
+
 interface Props { taskId: string; statuses: WorkflowStatus[]; }
 
-// ── Component ─────────────────────────────────────────────────────────────────
 export default function TaskHistoryTimeline({ taskId, statuses }: Props) {
   const mode = useThemeStore(s => s.mode);
-  const isDark = mode === 'dark';
-  const c = isDark ? DARK : LIGHT;
+  const c = mode === 'dark' ? DARK : LIGHT;
 
   const [history, setHistory] = useState<TaskHistory[]>([]);
   const [loading, setLoading] = useState(true);
@@ -59,80 +76,64 @@ export default function TaskHistoryTimeline({ taskId, statuses }: Props) {
     return () => controller.abort();
   }, [taskId]);
 
-  if (loading) {
-    return (
-      <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.dim }}>
-        Загрузка...
-      </span>
-    );
-  }
-  if (history.length === 0) {
-    return (
-      <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.dim }}>
-        История изменений пуста
-      </span>
-    );
-  }
+  if (loading) return <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.dim }}>Загрузка…</span>;
+  if (history.length === 0) return <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.dim }}>История изменений пуста</span>;
 
   return (
-    <div style={{ marginTop: 8, paddingLeft: 0 }}>
+    <div style={{ marginTop: 8 }}>
       {history.map((entry, i) => {
         const dotColor = avatarColor(entry.user.name);
         const isLast = i === history.length - 1;
+        const fieldLabel = FIELD_LABELS[entry.field] ?? entry.field;
+        const verb = verbForm(entry.user.name);
+
         return (
           <div key={entry.id} style={{ display: 'flex', gap: 12, position: 'relative', paddingBottom: isLast ? 0 : 16 }}>
-            {/* Vertical line */}
             {!isLast && (
-              <div style={{
-                position: 'absolute', left: 9, top: 20, bottom: 0, width: 1,
-                background: c.line,
-              }} />
+              <div style={{ position: 'absolute', left: 9, top: 20, bottom: 0, width: 1, background: c.line }} />
             )}
             {/* Avatar dot */}
             <div style={{
               width: 20, height: 20, borderRadius: '50%', flexShrink: 0,
-              background: dotColor,
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-              marginTop: 1,
+              background: dotColor, display: 'flex', alignItems: 'center', justifyContent: 'center', marginTop: 1,
             }}>
               <span style={{ fontFamily: '"Space Grotesk",system-ui,sans-serif', fontSize: 8, fontWeight: 700, color: '#fff' }}>
                 {entry.user.name?.[0]?.toUpperCase() ?? '?'}
               </span>
             </div>
             {/* Content */}
-            <div style={{ flex: 1, paddingBottom: 4 }}>
+            <div style={{ flex: 1, paddingBottom: 2 }}>
               <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, flexWrap: 'wrap' }}>
-                <span style={{
-                  fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 600, color: c.muted,
-                }}>
+                <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 600, color: c.muted }}>
                   {entry.user.name}
                 </span>
-                <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.dim }}>
-                  изменил(-а) {FIELD_LABELS[entry.field] ?? entry.field}
+                <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.dim }}>
+                  {verb} {fieldLabel}
                 </span>
-                <span style={{
-                  fontFamily: '"Inter",system-ui,sans-serif', fontSize: 10, color: c.dim, marginLeft: 'auto',
-                }}>
-                  {new Date(entry.createdAt).toLocaleString('ru-RU', {
-                    day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
-                  })}
+                <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 10, color: c.dim, marginLeft: 'auto' }}>
+                  {formatDate(entry.createdAt)}
                 </span>
               </div>
-              <div style={{ fontSize: 12, marginTop: 2, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                {entry.oldValue !== null && (
-                  <span style={{
-                    fontFamily: '"Inter",system-ui,sans-serif',
-                    color: c.removed, textDecoration: 'line-through',
-                  }}>
-                    {formatValue(entry.field, entry.oldValue, statuses)}
-                  </span>
-                )}
-                {entry.newValue !== null && (
-                  <span style={{ fontFamily: '"Inter",system-ui,sans-serif', color: c.added }}>
-                    {formatValue(entry.field, entry.newValue, statuses)}
-                  </span>
-                )}
-              </div>
+              {/* Old → New values */}
+              {(entry.oldValue !== null || entry.newValue !== null) && (
+                <div style={{ fontSize: 12, marginTop: 3, display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                  {entry.oldValue !== null && (
+                    <span style={{ fontFamily: '"Inter",system-ui,sans-serif', color: c.removed, textDecoration: 'line-through' }}>
+                      {formatValue(entry.field, entry.oldValue, statuses)}
+                    </span>
+                  )}
+                  {entry.oldValue !== null && entry.newValue !== null && (
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                      <path d="M1 5h8M6 2l3 3-3 3" stroke={c.dim} strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  )}
+                  {entry.newValue !== null && (
+                    <span style={{ fontFamily: '"Inter",system-ui,sans-serif', color: c.added }}>
+                      {formatValue(entry.field, entry.newValue, statuses)}
+                    </span>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         );

--- a/frontend/src/components/WorkspaceHistoryTimeline.tsx
+++ b/frontend/src/components/WorkspaceHistoryTimeline.tsx
@@ -50,7 +50,15 @@ function formatMessage(event: WorkspaceEvent): string {
     case 'workflow_created':     return `${event.user.name} создал workflow «${meta?.name ?? ''}»`;
     case 'workflow_deleted':     return `${event.user.name} удалил workflow «${meta?.name ?? ''}»`;
     case 'workspace_created':    return `${event.user.name} создал рабочее пространство «${meta?.name ?? ''}»`;
-    case 'workspace_updated':    return `${event.user.name} обновил настройки workspace`;
+    case 'workspace_updated': {
+      const changes: string[] = [];
+      if (meta?.name)        changes.push(`название → «${meta.name}»`);
+      if (meta?.description !== undefined) changes.push(`описание обновлено`);
+      if (meta?.isPrivate !== undefined)   changes.push(meta.isPrivate === 'true' ? 'сделал приватным' : 'сделал публичным');
+      return changes.length > 0
+        ? `${event.user.name} изменил настройки: ${changes.join(', ')}`
+        : `${event.user.name} обновил настройки пространства`;
+    }
     case 'board_created':        return `${event.user.name} создал доску «${meta?.name ?? ''}»`;
     case 'board_deleted':        return `${event.user.name} удалил доску «${meta?.name ?? ''}»`;
     default: return `${event.user.name}: ${event.action}`;

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -463,11 +463,17 @@ export default function WorkspacesPage() {
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {recentEvents.map(ev => {
+              const name = ev.user?.name ?? 'Кто-то';
+              const nameParts = name.trim().split(/\s+/);
+              const isFem = /[аяАЯ]$/u.test(nameParts[nameParts.length - 1] ?? name);
               const ACTION_LABELS: Record<string, string> = {
-                workspace_created: 'создал(а) пространство',
-                workspace_updated: 'обновил(а) пространство',
-                member_added: 'добавил(а) участника',
-                member_removed: 'удалил(а) участника',
+                workspace_created: isFem ? 'создала пространство' : 'создал пространство',
+                workspace_updated: isFem ? 'обновила настройки' : 'обновил настройки',
+                member_added:      isFem ? 'добавила участника' : 'добавил участника',
+                member_removed:    isFem ? 'удалила участника' : 'удалил участника',
+                board_created:     isFem ? 'создала доску' : 'создал доску',
+                board_deleted:     isFem ? 'удалила доску' : 'удалил доску',
+                member_role_changed: isFem ? 'изменила роль участника' : 'изменил роль участника',
               };
               const label = ACTION_LABELS[ev.action] ?? ev.action;
               const ws = workspaces.find(w => w.id === ev.workspaceId);
@@ -476,7 +482,7 @@ export default function WorkspacesPage() {
                 <div key={ev.id} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                   <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#4F6EF7', flexShrink: 0 }} />
                   <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13, color: C.actText }}>
-                    <span style={{ fontWeight: 600 }}>{ev.user?.name ?? 'Кто-то'}</span>
+                    <span style={{ fontWeight: 600 }}>{name}</span>
                     {' '}{label}{ws ? ` «${ws.name}»` : ''}
                   </span>
                   <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 11, color: C.actTime, marginLeft: 'auto', flexShrink: 0 }}>{time}</span>


### PR DESCRIPTION
## Что было не так

- «изменил(-а)» — некрасивый gender-neutral костыль
- `assigneeId` в истории задачи показывал UUID вместо имени: «caf517c6-a438-451e-...»
- `workspace_updated` — просто «обновил настройки» без деталей что именно

## Что стало

**История задачи (TaskHistoryTimeline)**
- Глагол определяется по роду: последнее слово имени оканчивается на а/я → «изменила», иначе → «изменил»
- Между старым и новым значением стрелка →
- Даты форматируются: «30 апреля 2026» вместо ISO
- Backend `getTaskHistory`: резолвит UUID исполнителей → имена пользователей

**История воркспейса (WorkspaceHistoryTimeline)**
- `workspace_updated` теперь показывает что изменилось: «изменил настройки: название → «Новое»» / «сделал приватным»

**Лента активности (WorkspacesPage)**
- Все глаголы с учётом рода: «создала пространство», «добавил участника»
- Добавлены события board_created/deleted, member_role_changed

## Примеры до/после

| Было | Стало |
|------|-------|
| «Новак Павел изменил(-а) исполнитель» | «Новак Павел изменил исполнитель» |
| «caf517c6-...» | «Иван Иванов» |
| «обновил(а) пространство» | «Мария обновила настройки» |
| «Петров обновил настройки workspace» | «Петров изменил настройки: название → «Новое»» |

🤖 Generated with [Claude Code](https://claude.com/claude-code)