### PR TITLE
feat: человекочитаемые URL для досок (prefix вместо UUID)

### DIFF
--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -60,6 +60,15 @@ export async function createBoard(workspaceId: string, userId: string, dto: Crea
   });
 }
 
+export async function getBoardByPrefix(workspaceId: string, prefix: string, userId: string) {
+  await assertMember(workspaceId, userId);
+  const board = await prisma.board.findFirst({
+    where: { workspaceId, prefix: prefix.toUpperCase() },
+  });
+  if (!board) throw new AppError(404, 'Board not found');
+  return getBoard(board.id, userId);
+}
+
 export async function getBoard(boardId: string, userId: string) {
   const board = await prisma.board.findUnique({
     where: { id: boardId },

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -61,6 +61,7 @@ export async function createBoard(workspaceId: string, userId: string, dto: Crea
 }
 
 export async function getBoardByPrefix(workspaceId: string, prefix: string, userId: string) {
+  if (!/^[A-Z0-9_-]{1,20}$/i.test(prefix)) throw new AppError(400, 'Invalid board prefix');
   await assertMember(workspaceId, userId);
   const board = await prisma.board.findFirst({
     where: { workspaceId, prefix: prefix.toUpperCase() },

--- a/backend/src/modules/workspaces/workspaces.router.ts
+++ b/backend/src/modules/workspaces/workspaces.router.ts
@@ -9,6 +9,7 @@ import {
   inviteByEmailDto,
 } from './workspaces.dto.js';
 import * as ws from './workspaces.service.js';
+import * as boards from '../boards/boards.service.js';
 import { authHandler } from '../../shared/utils/async-handler.js';
 
 const router = Router();
@@ -60,6 +61,10 @@ router.post('/:id/invite', validate(inviteByEmailDto), authHandler(async (req, r
 router.delete('/:id/members/:userId', authHandler(async (req, res) => {
   await ws.removeMember(String(req.params.id), req.user!.userId, String(req.params.userId));
   res.json({ message: 'Member removed' });
+}));
+
+router.get('/:id/boards/by-prefix/:prefix', authHandler(async (req, res) => {
+  res.json(await boards.getBoardByPrefix(String(req.params.id), String(req.params.prefix), req.user!.userId));
 }));
 
 router.get('/:id/history', authHandler(async (req, res) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -79,8 +79,8 @@ export default function App() {
           <Route path="/" element={<Navigate to="/workspaces" replace />} />
           <Route path="/workspaces" element={<PrivateRoute><WorkspacesPage /></PrivateRoute>} />
           <Route path="/w/:slug" element={<PrivateRoute><WorkspaceDashboardPage /></PrivateRoute>} />
-          <Route path="/w/:slug/boards/:boardId" element={<PrivateRoute><BoardPage /></PrivateRoute>} />
-          <Route path="/w/:slug/boards/:boardId/settings" element={<PrivateRoute><BoardSettingsPage /></PrivateRoute>} />
+          <Route path="/w/:slug/boards/:boardSlug" element={<PrivateRoute><BoardPage /></PrivateRoute>} />
+          <Route path="/w/:slug/boards/:boardSlug/settings" element={<PrivateRoute><BoardSettingsPage /></PrivateRoute>} />
           <Route path="/w/:slug/settings" element={<PrivateRoute><WorkspaceSettingsPage /></PrivateRoute>} />
           <Route path="/my-tasks" element={<PrivateRoute><MyTasksPage /></PrivateRoute>} />
           <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -21,6 +21,11 @@ export async function getBoard(boardId: string): Promise<Board> {
   return data;
 }
 
+export async function getBoardByPrefix(workspaceId: string, prefix: string): Promise<Board> {
+  const { data } = await api.get<Board>(`/workspaces/${workspaceId}/boards/by-prefix/${prefix}`);
+  return data;
+}
+
 export async function updateBoard(boardId: string, payload: { name?: string; description?: string; workflowId?: string; isPrivate?: boolean }): Promise<Board> {
   const { data } = await api.patch<Board>(`/boards/${boardId}`, payload);
   return data;

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -6,6 +6,7 @@ import {
 import { message } from 'antd';
 import type { Board, Task, WorkflowStatus, WorkspaceMember, Label } from '../types';
 import { useThemeStore } from '../store/theme.store';
+import { useWorkspaceStore } from '../store/workspace.store';
 import * as boardsApi from '../api/boards';
 import * as tasksApi from '../api/tasks';
 import * as workspacesApi from '../api/workspaces';
@@ -123,9 +124,11 @@ function BoardSettingsBtn({ onClick, border, addText, isPrivate }: {
 
 // ── Page ───────────────────────────────────────────────────────────────────────
 export default function BoardPage() {
-  const { boardId } = useParams<{ boardId: string }>();
+  const { slug, boardSlug } = useParams<{ slug: string; boardSlug: string }>();
   const navigate = useNavigate();
   const mode = useThemeStore(s => s.mode);
+  const workspaces = useWorkspaceStore(s => s.workspaces);
+  const wsId = workspaces.find(w => w.slug === slug)?.id;
   const isDark = mode === 'dark';
 
   // ── Theme tokens ──────────────────────────────────────────────────────────
@@ -164,9 +167,9 @@ export default function BoardPage() {
 
   // ── Load ──────────────────────────────────────────────────────────────────
   const loadBoard = useCallback(async () => {
-    if (!boardId) return;
+    if (!wsId || !boardSlug) return;
     try {
-      const b = await boardsApi.getBoard(boardId);
+      const b = await boardsApi.getBoardByPrefix(wsId, boardSlug);
       setBoard(b);
       const cols = groupByStatus(b.tasks ?? [], b.workflow.statuses);
       setColumns(cols);
@@ -178,7 +181,7 @@ export default function BoardPage() {
       if (fullCols.length > 0) {
         const totals = await Promise.all(
           fullCols.map(s =>
-            tasksApi.listTasks(boardId, { statusId: s.id, rootOnly: 'true', limit: '1', offset: '0' })
+            tasksApi.listTasks(b.id, { statusId: s.id, rootOnly: 'true', limit: '1', offset: '0' })
               .then(r => [s.id, r.total] as const)
               .catch(() => [s.id, 100] as const)
           )
@@ -187,7 +190,7 @@ export default function BoardPage() {
       }
     } catch { message.error('Не удалось загрузить доску'); }
     finally { setLoading(false); }
-  }, [boardId]);
+  }, [wsId, boardSlug]);
 
   useEffect(() => { loadBoard(); }, [loadBoard]);
 
@@ -245,7 +248,7 @@ export default function BoardPage() {
       }
     }
     try {
-      await tasksApi.reorderTasks(boardId!, updates);
+      await tasksApi.reorderTasks(board!.id, updates);
     } catch {
       message.error('Не удалось сохранить порядок');
       loadBoard();
@@ -254,11 +257,11 @@ export default function BoardPage() {
 
   // ── Load more (column pagination) ────────────────────────────────────────
   const loadMoreColumn = async (statusId: string) => {
-    if (!boardId || loadingMoreCols.has(statusId)) return;
+    if (!board || loadingMoreCols.has(statusId)) return;
     const offset = columnOffsets[statusId] ?? 0;
     setLoadingMoreCols(prev => new Set(prev).add(statusId));
     try {
-      const { tasks: more, total } = await tasksApi.listTasks(boardId, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
+      const { tasks: more, total } = await tasksApi.listTasks(board.id, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
       setColumns(prev => ({ ...prev, [statusId]: [...(prev[statusId] ?? []), ...more] }));
       setColumnOffsets(prev => ({ ...prev, [statusId]: offset + more.length }));
       setColumnTotals(prev => ({ ...prev, [statusId]: total }));
@@ -270,7 +273,7 @@ export default function BoardPage() {
   const submitAdd = async (statusId: string) => {
     if (!addTitle.trim()) { setAddingTo(null); return; }
     try {
-      const task = await tasksApi.createTask(boardId!, { title: addTitle.trim(), statusId });
+      const task = await tasksApi.createTask(board!.id, { title: addTitle.trim(), statusId });
       setColumns(prev => ({ ...prev, [statusId]: [...(prev[statusId] ?? []), task] }));
       setAddTitle('');
       setAddingTo(null);
@@ -597,7 +600,7 @@ export default function BoardPage() {
         statuses={statuses}
         members={members}
         workspaceId={board.workspaceId}
-        boardId={boardId}
+        boardId={board?.id ?? ''}
         workspaceLabels={labels}
         onWorkspaceLabelCreated={label => setLabels(prev => [...prev, label])}
         onClose={() => setSelectedTaskId(null)}

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -128,6 +128,7 @@ export default function BoardPage() {
   const navigate = useNavigate();
   const mode = useThemeStore(s => s.mode);
   const workspaces = useWorkspaceStore(s => s.workspaces);
+  const wsLoading = useWorkspaceStore(s => s.loading);
   const wsId = workspaces.find(w => w.slug === slug)?.id;
   const isDark = mode === 'dark';
 
@@ -150,6 +151,7 @@ export default function BoardPage() {
   const [board, setBoard] = useState<Board | null>(null);
   const [columns, setColumns] = useState<Columns>({});
   const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [addingTo, setAddingTo] = useState<string | null>(null);
   const [addTitle, setAddTitle] = useState('');
@@ -167,7 +169,11 @@ export default function BoardPage() {
 
   // ── Load ──────────────────────────────────────────────────────────────────
   const loadBoard = useCallback(async () => {
-    if (!wsId || !boardSlug) return;
+    if (!boardSlug) { setLoading(false); return; }
+    if (!wsId) {
+      if (!wsLoading) setLoading(false); // store loaded but workspace not found
+      return;
+    }
     try {
       const b = await boardsApi.getBoardByPrefix(wsId, boardSlug);
       setBoard(b);
@@ -188,9 +194,13 @@ export default function BoardPage() {
         );
         setColumnTotals(Object.fromEntries(totals));
       }
-    } catch { message.error('Не удалось загрузить доску'); }
+    } catch (e: unknown) {
+      const status = (e as { response?: { status?: number } })?.response?.status;
+      if (status === 404 || status === 403) { setNotFound(true); }
+      else { message.error('Не удалось загрузить доску'); }
+    }
     finally { setLoading(false); }
-  }, [wsId, boardSlug]);
+  }, [wsId, wsLoading, boardSlug]);
 
   useEffect(() => { loadBoard(); }, [loadBoard]);
 
@@ -340,6 +350,14 @@ export default function BoardPage() {
     );
   }
 
+  if (notFound || (!loading && !board)) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 12, background: pageBg }}>
+        <div style={{ fontSize: 15, color: isDark ? '#8B949E' : '#9B96B8', fontFamily: '"Inter",system-ui,sans-serif' }}>Доска не найдена</div>
+        <button onClick={() => navigate(-1)} style={{ fontSize: 13, color: '#4F6EF7', background: 'none', border: 'none', cursor: 'pointer', fontFamily: '"Inter",system-ui,sans-serif' }}>← Назад</button>
+      </div>
+    );
+  }
   if (!board) return null;
 
   const viewBtns: { mode: ViewMode; icon: React.ReactNode }[] = [
@@ -600,7 +618,7 @@ export default function BoardPage() {
         statuses={statuses}
         members={members}
         workspaceId={board.workspaceId}
-        boardId={board?.id ?? ''}
+        boardId={board.id}
         workspaceLabels={labels}
         onWorkspaceLabelCreated={label => setLabels(prev => [...prev, label])}
         onClose={() => setSelectedTaskId(null)}

--- a/frontend/src/pages/BoardSettingsPage.tsx
+++ b/frontend/src/pages/BoardSettingsPage.tsx
@@ -25,7 +25,7 @@ const INTER = '"Inter",system-ui,sans-serif';
 const GROTESK = '"Space Grotesk",system-ui,sans-serif';
 
 export default function BoardSettingsPage() {
-  const { slug, boardId } = useParams<{ slug: string; boardId: string }>();
+  const { slug, boardSlug } = useParams<{ slug: string; boardSlug: string }>();
   const navigate = useNavigate();
   const mode = useThemeStore((s) => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
@@ -43,18 +43,19 @@ export default function BoardSettingsPage() {
   const [deleting, setDeleting] = useState(false);
 
   const workspace = workspaces.find((w) => w.slug === slug) ?? null;
+  const wsId = workspace?.id;
   const isOwner = workspace?.role === 'OWNER';
 
   useEffect(() => {
-    if (!boardId) return;
-    boardsApi.getBoard(boardId).then((b) => {
+    if (!wsId || !boardSlug) return;
+    boardsApi.getBoardByPrefix(wsId, boardSlug).then((b) => {
       setBoard(b);
       setName(b.name);
       setDescription(b.description ?? '');
       setWorkflowId(b.workflowId);
       setIsPrivate(b.isPrivate ?? false);
     }).catch(() => { message.error('Не удалось загрузить доску'); setLoadError(true); });
-  }, [boardId]);
+  }, [wsId, boardSlug]);
 
   useEffect(() => {
     if (!workspace?.id) return;
@@ -62,20 +63,20 @@ export default function BoardSettingsPage() {
   }, [workspace?.id]);
 
   const save = async () => {
-    if (!boardId) return;
+    if (!board) return;
     setSaving(true);
     try {
-      await boardsApi.updateBoard(boardId, { name, description, workflowId, isPrivate });
+      await boardsApi.updateBoard(board.id, { name, description, workflowId, isPrivate });
       message.success('Сохранено');
     } catch { message.error('Ошибка сохранения'); }
     finally { setSaving(false); }
   };
 
   const handleDelete = async () => {
-    if (!boardId || !confirm(`Удалить доску "${board?.name}"? Все задачи будут удалены.`)) return;
+    if (!board || !confirm(`Удалить доску "${board.name}"? Все задачи будут удалены.`)) return;
     setDeleting(true);
     try {
-      await boardsApi.deleteBoard(boardId);
+      await boardsApi.deleteBoard(board.id);
       navigate(`/w/${slug}`);
     } catch { message.error('Не удалось удалить доску'); setDeleting(false); }
   };
@@ -125,7 +126,7 @@ export default function BoardSettingsPage() {
           <div style={{ fontSize: 12, color: c.muted, marginTop: 2 }}>{board.name}</div>
         </div>
         <button
-          onClick={() => navigate(`/w/${slug}/boards/${boardId}`)}
+          onClick={() => navigate(`/w/${slug}/boards/${boardSlug}`)}
           style={{
             display: 'flex', alignItems: 'center', gap: 8,
             margin: '0 12px', padding: '8px 12px', borderRadius: 8,

--- a/frontend/src/pages/BoardSettingsPage.tsx
+++ b/frontend/src/pages/BoardSettingsPage.tsx
@@ -30,7 +30,7 @@ export default function BoardSettingsPage() {
   const mode = useThemeStore((s) => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
   const isDark = mode !== 'light';
-  const { workspaces } = useWorkspaceStore();
+  const { workspaces, loading: wsLoading } = useWorkspaceStore();
 
   const [board, setBoard] = useState<Board | null>(null);
   const [loadError, setLoadError] = useState(false);
@@ -47,7 +47,11 @@ export default function BoardSettingsPage() {
   const isOwner = workspace?.role === 'OWNER';
 
   useEffect(() => {
-    if (!wsId || !boardSlug) return;
+    if (!boardSlug) { setLoadError(true); return; }
+    if (!wsId) {
+      if (!wsLoading) setLoadError(true);
+      return;
+    }
     boardsApi.getBoardByPrefix(wsId, boardSlug).then((b) => {
       setBoard(b);
       setName(b.name);
@@ -55,7 +59,7 @@ export default function BoardSettingsPage() {
       setWorkflowId(b.workflowId);
       setIsPrivate(b.isPrivate ?? false);
     }).catch(() => { message.error('Не удалось загрузить доску'); setLoadError(true); });
-  }, [wsId, boardSlug]);
+  }, [wsId, wsLoading, boardSlug]);
 
   useEffect(() => {
     if (!workspace?.id) return;

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -91,11 +91,11 @@ export default function MyTasksPage() {
         wsId: string;
         wsName: string;
         wsSlug: string;
-        boards: Map<string, { boardId: string; boardName: string; tasks: MyTask[] }>;
+        boards: Map<string, { boardId: string; boardSlug: string; boardName: string; tasks: MyTask[] }>;
       }
     >();
     for (const t of allTasks) {
-      const { workspace, id: boardId, name: boardName } = t.board;
+      const { workspace, id: boardId, name: boardName, prefix } = t.board;
       if (!wsMap.has(workspace.id)) {
         wsMap.set(workspace.id, {
           wsId: workspace.id,
@@ -106,7 +106,7 @@ export default function MyTasksPage() {
       }
       const ws = wsMap.get(workspace.id)!;
       if (!ws.boards.has(boardId)) {
-        ws.boards.set(boardId, { boardId, boardName, tasks: [] });
+        ws.boards.set(boardId, { boardId, boardSlug: prefix.toLowerCase(), boardName, tasks: [] });
       }
       ws.boards.get(boardId)!.tasks.push(t);
     }
@@ -291,7 +291,7 @@ export default function MyTasksPage() {
                         return (
                           <div
                             key={task.id}
-                            onClick={() => navigate(`/w/${ws.wsSlug}/boards/${board.boardId}`)}
+                            onClick={() => navigate(`/w/${ws.wsSlug}/boards/${board.boardSlug}`)}
                             style={{
                               display: 'flex', alignItems: 'center', gap: 12,
                               padding: '11px 16px',

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -259,7 +259,7 @@ export default function WorkspaceDashboardPage() {
       incrementBoardCount(current.id);
       message.success(`Доска "${board.name}" создана`);
       closeModal();
-      navigate(`/w/${slug}/boards/${board.id}`);
+      navigate(`/w/${slug}/boards/${board.prefix.toLowerCase()}`);
     } catch (e: unknown) {
       const err = e as { response?: { data?: { error?: string } } };
       message.error(err?.response?.data?.error ?? 'Не удалось создать доску');
@@ -431,7 +431,7 @@ export default function WorkspaceDashboardPage() {
             {boards.map(board => (
               <BoardCard
                 key={board.id} board={board} c={c} isDark={isDark}
-                onClick={() => navigate(`/w/${slug}/boards/${board.id}`)}
+                onClick={() => navigate(`/w/${slug}/boards/${board.prefix.toLowerCase()}`)}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- URL досок теперь используют `prefix` вместо UUID: `/w/workspace/boards/dev` вместо `/w/workspace/boards/a3f2c1d8-...`
- Новый backend endpoint: `GET /workspaces/:wsId/boards/by-prefix/:prefix`
- Все точки навигации обновлены: WorkspaceDashboard, MyTasks, BoardSettings

## Changes
- `backend/modules/boards/boards.service.ts` — добавлен `getBoardByPrefix()`
- `backend/modules/workspaces/workspaces.router.ts` — новый route `GET /:id/boards/by-prefix/:prefix`
- `frontend/src/api/boards.ts` — добавлен `getBoardByPrefix()`
- `frontend/src/App.tsx` — route param `:boardId` → `:boardSlug`
- `frontend/src/pages/BoardPage.tsx` — резолвит slug → UUID через `getBoardByPrefix`
- `frontend/src/pages/BoardSettingsPage.tsx` — аналогично
- `frontend/src/pages/WorkspaceDashboardPage.tsx` — навигация через `board.prefix.toLowerCase()`
- `frontend/src/pages/MyTasksPage.tsx` — `boardSlug` в группировке

## Test plan
- [ ] Открыть доску — URL содержит prefix доски (например `/w/my-ws/boards/dev`)
- [ ] Обновить страницу — доска загружается корректно
- [ ] Перейти в настройки доски и обратно — URL корректный
- [ ] MyTasks → клик по доске → переход с правильным URL
- [ ] Создать новую доску → переход на неё с human-readable URL