### PR TITLE
feat: workspace home quick nav + roadmaps hub page + Roadmaps tab

### DIFF
--- a/backend/src/modules/boards/boards.router.ts
+++ b/backend/src/modules/boards/boards.router.ts
@@ -34,8 +34,11 @@ router.delete('/:id', authHandler(async (req, res) => {
   res.json({ message: 'Board deleted' });
 }));
 
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 router.get('/:id/roadmap', authHandler(async (req, res) => {
-  const { from, to } = req.query as { from?: string; to?: string };
+  const from = typeof req.query.from === 'string' && DATE_RE.test(req.query.from) ? req.query.from : undefined;
+  const to   = typeof req.query.to   === 'string' && DATE_RE.test(req.query.to)   ? req.query.to   : undefined;
   res.json(await boards.getRoadmapTasks(String(req.params.id), req.user!.userId, from, to));
 }));
 

--- a/backend/src/modules/boards/boards.router.ts
+++ b/backend/src/modules/boards/boards.router.ts
@@ -34,4 +34,9 @@ router.delete('/:id', authHandler(async (req, res) => {
   res.json({ message: 'Board deleted' });
 }));
 
+router.get('/:id/roadmap', authHandler(async (req, res) => {
+  const { from, to } = req.query as { from?: string; to?: string };
+  res.json(await boards.getRoadmapTasks(String(req.params.id), req.user!.userId, from, to));
+}));
+
 export default router;

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -60,6 +60,15 @@ export async function createBoard(workspaceId: string, userId: string, dto: Crea
   });
 }
 
+export async function getBoardByPrefix(workspaceId: string, prefix: string, userId: string) {
+  await assertMember(workspaceId, userId);
+  const board = await prisma.board.findFirst({
+    where: { workspaceId, prefix: prefix.toUpperCase() },
+  });
+  if (!board) throw new AppError(404, 'Board not found');
+  return getBoard(board.id, userId);
+}
+
 export async function getBoard(boardId: string, userId: string) {
   const board = await prisma.board.findUnique({
     where: { id: boardId },

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -118,3 +118,46 @@ export async function deleteBoard(boardId: string, userId: string) {
   await assertOwner(board.workspaceId, userId);
   await prisma.board.delete({ where: { id: boardId } });
 }
+
+// ─── Roadmap ──────────────────────────────────────────────────────────────────
+export async function getRoadmapTasks(boardId: string, userId: string, from?: string, to?: string) {
+  const board = await prisma.board.findUnique({ where: { id: boardId } });
+  if (!board) throw new AppError(404, 'Board not found');
+  await assertMember(board.workspaceId, userId);
+
+  const fromDate = from ? new Date(from) : new Date(new Date().getFullYear(), 0, 1);
+  const toDate   = to   ? new Date(to)   : new Date(new Date().getFullYear() + 1, 0, 1);
+
+  const taskInclude = {
+    status:   { select: { id: true, name: true, color: true, category: true } },
+    assignee: { select: { id: true, name: true, avatar: true } },
+    _count:   { select: { children: true } },
+  } as const;
+
+  const dateInRange = {
+    OR: [
+      { startDate: { gte: fromDate, lte: toDate } },
+      { dueDate:   { gte: fromDate, lte: toDate } },
+      { startDate: { lte: fromDate }, dueDate: { gte: toDate } },
+    ],
+  };
+
+  return prisma.task.findMany({
+    where: {
+      boardId,
+      parentId: null,
+      OR: [
+        dateInRange,
+        { children: { some: dateInRange } },
+      ],
+    },
+    include: {
+      ...taskInclude,
+      children: {
+        include: taskInclude,
+        orderBy: { orderIndex: 'asc' },
+      },
+    },
+    orderBy: { orderIndex: 'asc' },
+  });
+}

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -123,7 +123,8 @@ export async function deleteBoard(boardId: string, userId: string) {
 export async function getRoadmapTasks(boardId: string, userId: string, from?: string, to?: string) {
   const board = await prisma.board.findUnique({ where: { id: boardId } });
   if (!board) throw new AppError(404, 'Board not found');
-  await assertMember(board.workspaceId, userId);
+  const member = await assertMember(board.workspaceId, userId);
+  if (board.isPrivate && member.role === 'VIEWER') throw new AppError(403, 'This board is private');
 
   const fromDate = from ? new Date(from) : new Date(new Date().getFullYear(), 0, 1);
   const toDate   = to   ? new Date(to)   : new Date(new Date().getFullYear() + 1, 0, 1);

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -61,6 +61,7 @@ export async function createBoard(workspaceId: string, userId: string, dto: Crea
 }
 
 export async function getBoardByPrefix(workspaceId: string, prefix: string, userId: string) {
+  if (!/^[A-Z0-9_-]{1,20}$/i.test(prefix)) throw new AppError(400, 'Invalid board prefix');
   await assertMember(workspaceId, userId);
   const board = await prisma.board.findFirst({
     where: { workspaceId, prefix: prefix.toUpperCase() },

--- a/backend/src/modules/feedback/feedback.dto.ts
+++ b/backend/src/modules/feedback/feedback.dto.ts
@@ -6,11 +6,14 @@ export const feedbackDto = z.object({
   body: stripHtml(z.string().min(10, 'Описание слишком короткое').max(5000, 'Описание слишком длинное')),
   type: z.enum(['bug', 'idea'], { message: 'Тип должен быть bug или idea' }),
   meta: z.object({
-    ua: z.string().max(500),
-    screen: z.string().max(50),
-    viewport: z.string().max(50),
-    url: z.string().max(500),
-    language: z.string().max(20),
+    ua:         z.string().max(500),
+    screen:     z.string().max(50),
+    viewport:   z.string().max(50),
+    url:        z.string().max(500),
+    language:   z.string().max(20),
+    deviceType: z.enum(['mobile', 'tablet', 'desktop']).optional(),
+    os:         z.string().max(50).optional(),
+    browser:    z.string().max(50).optional(),
   }).optional(),
 });
 

--- a/backend/src/modules/feedback/feedback.service.ts
+++ b/backend/src/modules/feedback/feedback.service.ts
@@ -17,10 +17,11 @@ export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
   const label = dto.type === 'bug' ? 'bug' : 'enhancement';
   const deviceSection = dto.meta
     ? [
-        `**UA:** \`${dto.meta.ua}\``,
+        `**Устройство:** ${dto.meta.deviceType ?? '—'} | **ОС:** ${dto.meta.os ?? '—'} | **Браузер:** ${dto.meta.browser ?? '—'}`,
         `**Экран:** ${dto.meta.screen} / вьюпорт: ${dto.meta.viewport}`,
         `**Язык:** ${dto.meta.language}`,
         `**URL:** ${dto.meta.url}`,
+        `**UA:** \`${dto.meta.ua}\``,
       ].join('\n')
     : '*нет данных об устройстве*';
   const bodyWithMeta = `${dto.body}\n\n---\n**Отправитель:** ${user.name} (${user.email})\n**Окружение:** ${config.NODE_ENV}\n\n### Устройство\n${deviceSection}`;

--- a/backend/src/modules/workspaces/workspaces.router.ts
+++ b/backend/src/modules/workspaces/workspaces.router.ts
@@ -9,6 +9,7 @@ import {
   inviteByEmailDto,
 } from './workspaces.dto.js';
 import * as ws from './workspaces.service.js';
+import * as boards from '../boards/boards.service.js';
 import { authHandler } from '../../shared/utils/async-handler.js';
 
 const router = Router();
@@ -60,6 +61,10 @@ router.post('/:id/invite', validate(inviteByEmailDto), authHandler(async (req, r
 router.delete('/:id/members/:userId', authHandler(async (req, res) => {
   await ws.removeMember(String(req.params.id), req.user!.userId, String(req.params.userId));
   res.json({ message: 'Member removed' });
+}));
+
+router.get('/:id/boards/by-prefix/:prefix', authHandler(async (req, res) => {
+  res.json(await boards.getBoardByPrefix(String(req.params.id), String(req.params.prefix), req.user!.userId));
 }));
 
 router.get('/:id/history', authHandler(async (req, res) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -79,8 +79,8 @@ export default function App() {
           <Route path="/" element={<Navigate to="/workspaces" replace />} />
           <Route path="/workspaces" element={<PrivateRoute><WorkspacesPage /></PrivateRoute>} />
           <Route path="/w/:slug" element={<PrivateRoute><WorkspaceDashboardPage /></PrivateRoute>} />
-          <Route path="/w/:slug/boards/:boardId" element={<PrivateRoute><BoardPage /></PrivateRoute>} />
-          <Route path="/w/:slug/boards/:boardId/settings" element={<PrivateRoute><BoardSettingsPage /></PrivateRoute>} />
+          <Route path="/w/:slug/boards/:boardSlug" element={<PrivateRoute><BoardPage /></PrivateRoute>} />
+          <Route path="/w/:slug/boards/:boardSlug/settings" element={<PrivateRoute><BoardSettingsPage /></PrivateRoute>} />
           <Route path="/w/:slug/settings" element={<PrivateRoute><WorkspaceSettingsPage /></PrivateRoute>} />
           <Route path="/my-tasks" element={<PrivateRoute><MyTasksPage /></PrivateRoute>} />
           <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import BoardSettingsPage from './pages/BoardSettingsPage';
 import ProfilePage from './pages/ProfilePage';
 import AdminUsersPage from './pages/AdminUsersPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
+import RoadmapsPage from './pages/RoadmapsPage';
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const user = useAuthStore((s) => s.user);
@@ -81,6 +82,7 @@ export default function App() {
           <Route path="/w/:slug" element={<PrivateRoute><WorkspaceDashboardPage /></PrivateRoute>} />
           <Route path="/w/:slug/boards/:boardSlug" element={<PrivateRoute><BoardPage /></PrivateRoute>} />
           <Route path="/w/:slug/boards/:boardSlug/settings" element={<PrivateRoute><BoardSettingsPage /></PrivateRoute>} />
+          <Route path="/w/:slug/roadmaps" element={<PrivateRoute><RoadmapsPage /></PrivateRoute>} />
           <Route path="/w/:slug/settings" element={<PrivateRoute><WorkspaceSettingsPage /></PrivateRoute>} />
           <Route path="/my-tasks" element={<PrivateRoute><MyTasksPage /></PrivateRoute>} />
           <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -21,6 +21,11 @@ export async function getBoard(boardId: string): Promise<Board> {
   return data;
 }
 
+export async function getBoardByPrefix(workspaceId: string, prefix: string): Promise<Board> {
+  const { data } = await api.get<Board>(`/workspaces/${workspaceId}/boards/by-prefix/${prefix}`);
+  return data;
+}
+
 export async function updateBoard(boardId: string, payload: { name?: string; description?: string; workflowId?: string; isPrivate?: boolean }): Promise<Board> {
   const { data } = await api.patch<Board>(`/boards/${boardId}`, payload);
   return data;

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -1,5 +1,5 @@
 import api from './client';
-import type { Board } from '../types';
+import type { Board, Task } from '../types';
 
 export async function listBoards(workspaceId: string): Promise<Board[]> {
   const { data } = await api.get<Board[]>(`/workspaces/${workspaceId}/boards`);
@@ -33,4 +33,13 @@ export async function updateBoard(boardId: string, payload: { name?: string; des
 
 export async function deleteBoard(boardId: string): Promise<void> {
   await api.delete(`/boards/${boardId}`);
+}
+
+export async function getRoadmapTasks(boardId: string, from?: string, to?: string): Promise<Task[]> {
+  const params = new URLSearchParams();
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  const query = params.toString();
+  const { data } = await api.get<Task[]>(`/boards/${boardId}/roadmap${query ? `?${query}` : ''}`);
+  return data;
 }

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -192,7 +192,9 @@ export default function AppLayout({ children }: Props) {
 
   const isWorkspace = !!urlSlug;
   const isRoadmaps = isWorkspace && location.pathname.endsWith('/roadmaps');
-  const isBoards   = isWorkspace && !location.pathname.includes('/settings') && !isRoadmaps;
+  const isBoards   = isWorkspace
+    && (location.pathname === `/w/${urlSlug}`
+        || location.pathname.startsWith(`/w/${urlSlug}/boards`));
   const isMyTasks  = location.pathname === '/my-tasks';
 
   const userInitials = user ? initials(user.name) : '?';

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -191,8 +191,9 @@ export default function AppLayout({ children }: Props) {
   };
 
   const isWorkspace = !!urlSlug;
-  const isBoards = isWorkspace && !location.pathname.includes('/settings');
-  const isMyTasks = location.pathname === '/my-tasks';
+  const isRoadmaps = isWorkspace && location.pathname.endsWith('/roadmaps');
+  const isBoards   = isWorkspace && !location.pathname.includes('/settings') && !isRoadmaps;
+  const isMyTasks  = location.pathname === '/my-tasks';
 
   const userInitials = user ? initials(user.name) : '?';
 
@@ -277,6 +278,20 @@ export default function AppLayout({ children }: Props) {
             >
               <span style={{ color: isMyTasks ? tabActiveText : tabIdleText, fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13, lineHeight: '16px' }}>
                 My Tasks
+              </span>
+            </div>
+
+            {/* Roadmaps tab */}
+            <div
+              onClick={() => navigate(`/w/${current.slug}/roadmaps`)}
+              style={{
+                alignItems: 'center', backgroundColor: isRoadmaps ? tabActiveBg : 'transparent',
+                borderRadius: 8, cursor: 'pointer', display: 'flex', gap: 4,
+                paddingBlock: 5, paddingInline: 12,
+              }}
+            >
+              <span style={{ color: isRoadmaps ? tabActiveText : tabIdleText, fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13, fontWeight: isRoadmaps ? 500 : 400, lineHeight: '16px' }}>
+                Roadmaps
               </span>
             </div>
           </>

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -13,12 +13,37 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   const [form] = Form.useForm();
 
   function collectDeviceMeta() {
+    const ua = navigator.userAgent;
+
+    const deviceType =
+      /Mobi|Android|iPhone|iPod/i.test(ua) ? 'mobile' :
+      /iPad|Tablet/i.test(ua) ? 'tablet' : 'desktop';
+
+    let os = 'Unknown';
+    if      (/Windows/i.test(ua))                          os = 'Windows';
+    else if (/Mac OS X/i.test(ua) && !/iPhone|iPad/i.test(ua)) os = 'macOS';
+    else if (/iPhone/i.test(ua))                           os = 'iOS';
+    else if (/iPad/i.test(ua))                             os = 'iPadOS';
+    else if (/Android/i.test(ua))                          os = 'Android';
+    else if (/Linux/i.test(ua))                            os = 'Linux';
+
+    let browser = 'Unknown';
+    if      (/Edg\//i.test(ua))     browser = 'Edge';
+    else if (/OPR\//i.test(ua))     browser = 'Opera';
+    else if (/YaBrowser/i.test(ua)) browser = 'Yandex';
+    else if (/Chrome\//i.test(ua))  browser = 'Chrome';
+    else if (/Firefox\//i.test(ua)) browser = 'Firefox';
+    else if (/Safari\//i.test(ua))  browser = 'Safari';
+
     return {
-      ua: navigator.userAgent,
-      screen: `${screen.width}x${screen.height}`,
-      viewport: `${window.innerWidth}x${window.innerHeight}`,
+      ua,
+      screen: `${screen.width}×${screen.height}`,
+      viewport: `${window.innerWidth}×${window.innerHeight}`,
       url: window.location.href,
       language: navigator.language,
+      deviceType,
+      os,
+      browser,
     };
   }
 

--- a/frontend/src/components/RoadmapView.tsx
+++ b/frontend/src/components/RoadmapView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { message } from 'antd';
 import { useThemeStore } from '../store/theme.store';
-import type { Task, WorkflowStatus, WorkspaceMember } from '../types';
+import type { Task, WorkflowStatus } from '../types';
 import * as boardsApi from '../api/boards';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -33,21 +34,22 @@ function fmtShort(d: Date) {
 }
 
 // ── Zoom config ────────────────────────────────────────────────────────────────
-const TODAY = d0(new Date());
+function getToday() { return d0(new Date()); }
 
 function zoomRange(z: Zoom): { start: Date; end: Date } {
+  const t = getToday();
   switch (z) {
     case 'week':
-      return { start: addDays(TODAY, -21), end: addDays(TODAY, 42) };
+      return { start: addDays(t, -21), end: addDays(t, 42) };
     case 'month':
       return {
-        start: new Date(TODAY.getFullYear(), TODAY.getMonth() - 1, 1),
-        end:   new Date(TODAY.getFullYear(), TODAY.getMonth() + 6, 1),
+        start: new Date(t.getFullYear(), t.getMonth() - 1, 1),
+        end:   new Date(t.getFullYear(), t.getMonth() + 6, 1),
       };
     case 'quarter':
       return {
-        start: new Date(TODAY.getFullYear(), 0, 1),
-        end:   new Date(TODAY.getFullYear() + 1, 0, 1),
+        start: new Date(t.getFullYear(), 0, 1),
+        end:   new Date(t.getFullYear() + 1, 0, 1),
       };
   }
 }
@@ -76,7 +78,6 @@ const LIGHT: C = {
 interface Props {
   boardId: string;
   statuses: WorkflowStatus[];
-  members?: WorkspaceMember[];
 }
 
 // ── Row height constants ───────────────────────────────────────────────────────
@@ -112,7 +113,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
         const ids = new Set(data.filter(t => (t._count?.children ?? 0) > 0).map(t => t.id));
         setExpanded(ids);
       })
-      .catch(() => {})
+      .catch(() => { message.error('Не удалось загрузить дорожную карту'); })
       .finally(() => setLoading(false));
   }, [boardId, zoom]);
 
@@ -149,7 +150,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
     const r = zoomRange(zoom);
     const total = diffDays(r.start, r.end);
     const dayPx = TL_W / total;
-    const todayX = diffDays(r.start, TODAY) * dayPx;
+    const todayX = diffDays(r.start, getToday()) * dayPx;
     right.scrollLeft = Math.max(0, todayX - right.clientWidth * 0.35);
   }, [zoom]);
 
@@ -204,13 +205,13 @@ export default function RoadmapView({ boardId, statuses }: Props) {
         const wEnd = addDays(cur, 7);
         const we   = wEnd < range.end ? wEnd : range.end;
         const w    = xOf(we) - xOf(cur);
-        const isCW = cur <= TODAY && TODAY < we;
+        const isCW = cur <= getToday() && getToday() < we;
         weeks.push({ label: `${fmtShort(cur)} – ${fmtShort(addDays(we, -1))}`, x: xOf(cur), w, isCurrent: isCW });
         cur = wEnd;
       }
       cur = new Date(range.start);
       while (cur < range.end) {
-        const isToday   = isSameDay(cur, TODAY);
+        const isToday   = isSameDay(cur, getToday());
         const isWeekend = cur.getDay() === 0 || cur.getDay() === 6;
         const isMon     = cur.getDay() === 1;
         days.push({
@@ -239,7 +240,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
       while (cur < range.end) {
         const wEnd = addDays(cur, 7);
         const we   = wEnd < range.end ? wEnd : range.end;
-        const isCW = cur <= TODAY && TODAY < wEnd;
+        const isCW = cur <= getToday() && getToday() < wEnd;
         weeks.push({ label: fmtShort(cur), x: xOf(cur), w: xOf(we) - xOf(cur), isCurrent: isCW });
         cur = wEnd;
       }
@@ -250,21 +251,21 @@ export default function RoadmapView({ boardId, statuses }: Props) {
     const quarters: { label: string; x: number; w: number }[] = [];
     const months:   { label: string; x: number; w: number; isCurrent: boolean }[] = [];
     const QS = [
-      { label: 'Q1', start: new Date(TODAY.getFullYear(), 0, 1), end: new Date(TODAY.getFullYear(), 3, 1) },
-      { label: 'Q2', start: new Date(TODAY.getFullYear(), 3, 1), end: new Date(TODAY.getFullYear(), 6, 1) },
-      { label: 'Q3', start: new Date(TODAY.getFullYear(), 6, 1), end: new Date(TODAY.getFullYear(), 9, 1) },
-      { label: 'Q4', start: new Date(TODAY.getFullYear(), 9, 1), end: new Date(TODAY.getFullYear() + 1, 0, 1) },
+      { label: 'Q1', start: new Date(getToday().getFullYear(), 0, 1), end: new Date(getToday().getFullYear(), 3, 1) },
+      { label: 'Q2', start: new Date(getToday().getFullYear(), 3, 1), end: new Date(getToday().getFullYear(), 6, 1) },
+      { label: 'Q3', start: new Date(getToday().getFullYear(), 6, 1), end: new Date(getToday().getFullYear(), 9, 1) },
+      { label: 'Q4', start: new Date(getToday().getFullYear(), 9, 1), end: new Date(getToday().getFullYear() + 1, 0, 1) },
     ].filter(q => q.end > range.start && q.start < range.end);
     for (const q of QS) {
       const qs = q.start < range.start ? range.start : q.start;
       const qe = q.end   > range.end   ? range.end   : q.end;
-      quarters.push({ label: `${q.label} ${TODAY.getFullYear()}`, x: xOf(qs), w: xOf(qe) - xOf(qs) });
+      quarters.push({ label: `${q.label} ${getToday().getFullYear()}`, x: xOf(qs), w: xOf(qe) - xOf(qs) });
     }
     let cur = new Date(range.start);
     while (cur < range.end) {
       const next  = new Date(cur.getFullYear(), cur.getMonth() + 1, 1);
       const me    = next < range.end ? next : range.end;
-      const isCM  = cur.getMonth() === TODAY.getMonth() && cur.getFullYear() === TODAY.getFullYear();
+      const isCM  = cur.getMonth() === getToday().getMonth() && cur.getFullYear() === getToday().getFullYear();
       const lbl   = cur.toLocaleString('ru', { month: 'short' });
       months.push({ label: lbl[0].toUpperCase() + lbl.slice(1), x: xOf(cur), w: xOf(me) - xOf(cur), isCurrent: isCM });
       cur = next;
@@ -277,7 +278,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
   const totalH = rows.reduce((acc, t) => acc + (t.parentId ? CROW_H : ROW_H), 0);
 
   // ── Today X ───────────────────────────────────────────────────────────────
-  const todayX = xOf(TODAY);
+  const todayX = xOf(getToday());
 
   // ── Status color for tooltip ───────────────────────────────────────────────
   function statusLabel(task: Task) {
@@ -288,7 +289,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
   // ── Overdue ────────────────────────────────────────────────────────────────
   function isOverdue(task: Task) {
     const due = parseDate(task.dueDate);
-    return due && due < TODAY && task.status?.category !== 'DONE';
+    return due && due < getToday() && task.status?.category !== 'DONE';
   }
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -408,7 +409,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
               const isExp    = expanded.has(task.id);
               const due      = parseDate(task.dueDate);
               const overdue  = isOverdue(task);
-              const dueColor = overdue ? '#EF4444' : due && diffDays(due, TODAY) < 7 && due >= TODAY ? '#F59E0B' : task.status?.category === 'DONE' ? '#10B981' : c.dimmed;
+              const dueColor = overdue ? '#EF4444' : due && diffDays(due, getToday()) < 7 && due >= getToday() ? '#F59E0B' : task.status?.category === 'DONE' ? '#10B981' : c.dimmed;
 
               return (
                 <div
@@ -521,7 +522,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
 
               {/* Current-week highlight */}
               {(() => {
-                const ws = d0(new Date(TODAY));
+                const ws = d0(new Date(getToday()));
                 const dayOfWeek = ws.getDay();
                 const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
                 const monday = addDays(ws, mondayOffset);
@@ -620,9 +621,9 @@ export default function RoadmapView({ boardId, statuses }: Props) {
 
                 const overdue = isOverdue(task);
                 const ovLeft  = Math.min(TL_W, Math.max(0, xOf(end)));
-                const ovRight = Math.min(TL_W, xOf(TODAY));
+                const ovRight = Math.min(TL_W, xOf(getToday()));
                 const ovW     = overdue ? ovRight - ovLeft : 0;
-                const overdueDays = overdue ? diffDays(end, TODAY) : 0;
+                const overdueDays = overdue ? diffDays(end, getToday()) : 0;
 
                 return (
                   <div key={task.id} style={rowStyle}>

--- a/frontend/src/components/RoadmapView.tsx
+++ b/frontend/src/components/RoadmapView.tsx
@@ -1,0 +1,695 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useThemeStore } from '../store/theme.store';
+import type { Task, WorkflowStatus, WorkspaceMember } from '../types';
+import * as boardsApi from '../api/boards';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+type Zoom = 'week' | 'month' | 'quarter';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+const DAY_MS = 86_400_000;
+
+function d0(d: Date) {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+function addDays(d: Date, n: number) {
+  return new Date(+d0(d) + n * DAY_MS);
+}
+function diffDays(a: Date, b: Date) {
+  return Math.round((+d0(b) - +d0(a)) / DAY_MS);
+}
+function isSameDay(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate();
+}
+function parseDate(s?: string | null): Date | null {
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d0(d);
+}
+function fmtShort(d: Date) {
+  return d.toLocaleString('ru', { day: 'numeric', month: 'short' });
+}
+
+// ── Zoom config ────────────────────────────────────────────────────────────────
+const TODAY = d0(new Date());
+
+function zoomRange(z: Zoom): { start: Date; end: Date } {
+  switch (z) {
+    case 'week':
+      return { start: addDays(TODAY, -21), end: addDays(TODAY, 42) };
+    case 'month':
+      return {
+        start: new Date(TODAY.getFullYear(), TODAY.getMonth() - 1, 1),
+        end:   new Date(TODAY.getFullYear(), TODAY.getMonth() + 6, 1),
+      };
+    case 'quarter':
+      return {
+        start: new Date(TODAY.getFullYear(), 0, 1),
+        end:   new Date(TODAY.getFullYear() + 1, 0, 1),
+      };
+  }
+}
+
+const TL_W = 1400;
+
+// ── Design tokens ──────────────────────────────────────────────────────────────
+type C = Record<string, string>;
+
+const DARK: C = {
+  bg: '#03050F', leftBg: '#0F1320', border: '#1C2236',
+  text: '#E2E8F8', muted: '#8B95B0', dimmed: '#484F58',
+  hdrBg: '#0F1320', rowEven: 'rgba(255,255,255,.012)',
+  curWeek: 'rgba(79,110,247,.05)', today: '#EF4444',
+  toolbarBg: '#03050F', chip: '#1C2236', chipText: '#8B95B0', accent: '#4F6EF7',
+};
+const LIGHT: C = {
+  bg: '#F5F3FF', leftBg: '#FDFCFF', border: '#E8E5F0',
+  text: '#1A1A2E', muted: '#6B7194', dimmed: '#9B96B8',
+  hdrBg: '#FDFCFF', rowEven: 'rgba(79,110,247,.025)',
+  curWeek: 'rgba(79,110,247,.07)', today: '#EF4444',
+  toolbarBg: '#F5F3FF', chip: '#EDE9FE', chipText: '#7C6FA8', accent: '#4F6EF7',
+};
+
+// ── Props ──────────────────────────────────────────────────────────────────────
+interface Props {
+  boardId: string;
+  statuses: WorkflowStatus[];
+  members?: WorkspaceMember[];
+}
+
+// ── Row height constants ───────────────────────────────────────────────────────
+const ROW_H  = 40;
+const CROW_H = 36;
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export default function RoadmapView({ boardId, statuses }: Props) {
+  const mode = useThemeStore(s => s.mode);
+  const isDark = mode === 'dark';
+  const c = isDark ? DARK : LIGHT;
+
+  const [zoom, setZoom]           = useState<Zoom>('month');
+  const [tasks, setTasks]         = useState<Task[]>([]);
+  const [loading, setLoading]     = useState(true);
+  const [expanded, setExpanded]   = useState<Set<string>>(new Set());
+  const [hideOpen, setHideOpen]   = useState(false);
+
+  const leftRef  = useRef<HTMLDivElement>(null);
+  const rightRef = useRef<HTMLDivElement>(null);
+  const lockRef  = useRef(false);
+
+  // ── Fetch ──────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    setLoading(true);
+    const r = zoomRange(zoom);
+    const from = r.start.toISOString().slice(0, 10);
+    const to   = r.end.toISOString().slice(0, 10);
+    boardsApi.getRoadmapTasks(boardId, from, to)
+      .then(data => {
+        setTasks(data);
+        // expand all parents by default
+        const ids = new Set(data.filter(t => (t._count?.children ?? 0) > 0).map(t => t.id));
+        setExpanded(ids);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [boardId, zoom]);
+
+  // ── Scroll sync ────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const left  = leftRef.current;
+    const right = rightRef.current;
+    if (!left || !right) return;
+
+    const onRight = () => {
+      if (lockRef.current) return;
+      lockRef.current = true;
+      left.scrollTop = right.scrollTop;
+      lockRef.current = false;
+    };
+    const onLeft = () => {
+      if (lockRef.current) return;
+      lockRef.current = true;
+      right.scrollTop = left.scrollTop;
+      lockRef.current = false;
+    };
+    right.addEventListener('scroll', onRight);
+    left.addEventListener('scroll',  onLeft);
+    return () => {
+      right.removeEventListener('scroll', onRight);
+      left.removeEventListener('scroll',  onLeft);
+    };
+  }, []);
+
+  // ── Scroll to today ────────────────────────────────────────────────────────
+  const scrollToToday = useCallback(() => {
+    const right = rightRef.current;
+    if (!right) return;
+    const r = zoomRange(zoom);
+    const total = diffDays(r.start, r.end);
+    const dayPx = TL_W / total;
+    const todayX = diffDays(r.start, TODAY) * dayPx;
+    right.scrollLeft = Math.max(0, todayX - right.clientWidth * 0.35);
+  }, [zoom]);
+
+  useEffect(() => { setTimeout(scrollToToday, 50); }, [scrollToToday]);
+
+  // ── Timeline math ──────────────────────────────────────────────────────────
+  const range  = zoomRange(zoom);
+  const total  = diffDays(range.start, range.end);
+  const dayPx  = TL_W / total;
+  const xOf    = (d: Date) => diffDays(range.start, d) * dayPx;
+  const wOf    = (s: Date, e: Date) => Math.max(6, diffDays(s, e) * dayPx);
+
+  // ── Visible rows ───────────────────────────────────────────────────────────
+  const visibleRows = (): Task[] => {
+    const out: Task[] = [];
+    for (const t of tasks) {
+      if (hideOpen && t.status?.category === 'OPEN') {
+        const hasVisibleChild = (t.children ?? []).some(
+          ch => ch.status?.category !== 'OPEN',
+        );
+        if (!hasVisibleChild) continue;
+      }
+      out.push(t);
+      if (expanded.has(t.id) && t.children && t.children.length > 0) {
+        for (const ch of t.children) {
+          if (hideOpen && ch.status?.category === 'OPEN') continue;
+          out.push(ch);
+        }
+      }
+    }
+    return out;
+  };
+
+  // ── Status bar color ───────────────────────────────────────────────────────
+  function barColor(task: Task): { bg: string; border: string } {
+    const color = task.status?.color ?? '#4F6EF7';
+    const cat   = task.status?.category ?? 'OPEN';
+    const alpha = cat === 'DONE' ? '.62' : cat === 'IN_PROGRESS' ? '.68' : '.55';
+    return {
+      bg:     `${color}${Math.round(parseFloat(alpha) * 255).toString(16).padStart(2,'0')}`,
+      border: `${color}E0`,
+    };
+  }
+
+  // ── Timeline header ────────────────────────────────────────────────────────
+  function renderHeader() {
+    if (zoom === 'week') {
+      const weeks: { label: string; x: number; w: number; isCurrent: boolean }[] = [];
+      const days:  { label: string; x: number; w: number; isToday: boolean; isWeekend: boolean }[] = [];
+      let cur = new Date(range.start);
+      while (cur < range.end) {
+        const wEnd = addDays(cur, 7);
+        const we   = wEnd < range.end ? wEnd : range.end;
+        const w    = xOf(we) - xOf(cur);
+        const isCW = cur <= TODAY && TODAY < we;
+        weeks.push({ label: `${fmtShort(cur)} – ${fmtShort(addDays(we, -1))}`, x: xOf(cur), w, isCurrent: isCW });
+        cur = wEnd;
+      }
+      cur = new Date(range.start);
+      while (cur < range.end) {
+        const isToday   = isSameDay(cur, TODAY);
+        const isWeekend = cur.getDay() === 0 || cur.getDay() === 6;
+        const isMon     = cur.getDay() === 1;
+        days.push({
+          label: isMon
+            ? `${cur.getDate()} ${cur.toLocaleString('ru', { month: 'short' })}`
+            : `${cur.getDate()}`,
+          x: xOf(cur), w: dayPx, isToday, isWeekend,
+        });
+        cur = addDays(cur, 1);
+      }
+      return { row1: weeks, row2: days, type: 'week' as const };
+    }
+
+    if (zoom === 'month') {
+      const months: { label: string; x: number; w: number }[] = [];
+      const weeks:  { label: string; x: number; w: number; isCurrent: boolean }[] = [];
+      let cur = new Date(range.start);
+      while (cur < range.end) {
+        const next = new Date(cur.getFullYear(), cur.getMonth() + 1, 1);
+        const me   = next < range.end ? next : range.end;
+        const lbl  = cur.toLocaleString('ru', { month: 'long', year: 'numeric' });
+        months.push({ label: lbl[0].toUpperCase() + lbl.slice(1), x: xOf(cur), w: xOf(me) - xOf(cur) });
+        cur = next;
+      }
+      cur = new Date(range.start);
+      while (cur < range.end) {
+        const wEnd = addDays(cur, 7);
+        const we   = wEnd < range.end ? wEnd : range.end;
+        const isCW = cur <= TODAY && TODAY < wEnd;
+        weeks.push({ label: fmtShort(cur), x: xOf(cur), w: xOf(we) - xOf(cur), isCurrent: isCW });
+        cur = wEnd;
+      }
+      return { row1: months, row2: weeks, type: 'month' as const };
+    }
+
+    // quarter
+    const quarters: { label: string; x: number; w: number }[] = [];
+    const months:   { label: string; x: number; w: number; isCurrent: boolean }[] = [];
+    const QS = [
+      { label: 'Q1', start: new Date(TODAY.getFullYear(), 0, 1), end: new Date(TODAY.getFullYear(), 3, 1) },
+      { label: 'Q2', start: new Date(TODAY.getFullYear(), 3, 1), end: new Date(TODAY.getFullYear(), 6, 1) },
+      { label: 'Q3', start: new Date(TODAY.getFullYear(), 6, 1), end: new Date(TODAY.getFullYear(), 9, 1) },
+      { label: 'Q4', start: new Date(TODAY.getFullYear(), 9, 1), end: new Date(TODAY.getFullYear() + 1, 0, 1) },
+    ].filter(q => q.end > range.start && q.start < range.end);
+    for (const q of QS) {
+      const qs = q.start < range.start ? range.start : q.start;
+      const qe = q.end   > range.end   ? range.end   : q.end;
+      quarters.push({ label: `${q.label} ${TODAY.getFullYear()}`, x: xOf(qs), w: xOf(qe) - xOf(qs) });
+    }
+    let cur = new Date(range.start);
+    while (cur < range.end) {
+      const next  = new Date(cur.getFullYear(), cur.getMonth() + 1, 1);
+      const me    = next < range.end ? next : range.end;
+      const isCM  = cur.getMonth() === TODAY.getMonth() && cur.getFullYear() === TODAY.getFullYear();
+      const lbl   = cur.toLocaleString('ru', { month: 'short' });
+      months.push({ label: lbl[0].toUpperCase() + lbl.slice(1), x: xOf(cur), w: xOf(me) - xOf(cur), isCurrent: isCM });
+      cur = next;
+    }
+    return { row1: quarters, row2: months, type: 'quarter' as const };
+  }
+
+  const hdr = renderHeader();
+  const rows = visibleRows();
+  const totalH = rows.reduce((acc, t) => acc + (t.parentId ? CROW_H : ROW_H), 0);
+
+  // ── Today X ───────────────────────────────────────────────────────────────
+  const todayX = xOf(TODAY);
+
+  // ── Status color for tooltip ───────────────────────────────────────────────
+  function statusLabel(task: Task) {
+    const s = statuses.find(st => st.id === task.statusId);
+    return s?.name ?? task.status?.name ?? '–';
+  }
+
+  // ── Overdue ────────────────────────────────────────────────────────────────
+  function isOverdue(task: Task) {
+    const due = parseDate(task.dueDate);
+    return due && due < TODAY && task.status?.category !== 'DONE';
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden', background: c.bg, fontFamily: '"Inter",system-ui,sans-serif' }}>
+
+      {/* ── Toolbar ── */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8, padding: '8px 24px',
+        background: c.toolbarBg, borderBottom: `1px solid ${c.border}`, flexShrink: 0,
+      }}>
+        {/* Zoom */}
+        <span style={{ fontSize: 12, color: c.muted, marginRight: 2 }}>Масштаб</span>
+        <div style={{ display: 'flex', gap: 2, background: c.chip, borderRadius: 8, padding: 2 }}>
+          {(['week', 'month', 'quarter'] as Zoom[]).map(z => (
+            <button
+              key={z}
+              onClick={() => setZoom(z)}
+              style={{
+                padding: '4px 11px', border: 'none', borderRadius: 6, cursor: 'pointer',
+                fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 500,
+                background: zoom === z ? c.accent : 'transparent',
+                color: zoom === z ? '#fff' : c.chipText,
+                transition: 'all .12s',
+              }}
+            >
+              {{ week: 'Неделя', month: 'Месяц', quarter: 'Квартал' }[z]}
+            </button>
+          ))}
+        </div>
+
+        {/* Today button */}
+        <button
+          onClick={scrollToToday}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 4,
+            padding: '5px 10px', border: `1px solid ${c.border}`,
+            borderRadius: 7, background: 'transparent', cursor: 'pointer',
+            fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.muted,
+          }}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2"/>
+            <line x1="6" y1="3.5" x2="6" y2="6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+            <line x1="6" y1="6" x2="7.5" y2="7.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+          </svg>
+          Сегодня
+        </button>
+
+        {/* Hide open toggle */}
+        <button
+          onClick={() => setHideOpen(v => !v)}
+          title={hideOpen ? 'Показать открытые задачи' : 'Скрыть открытые задачи'}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 5,
+            padding: '5px 10px', border: `1px solid ${c.border}`,
+            borderRadius: 7, background: 'transparent', cursor: 'pointer',
+            fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
+            color: c.muted,
+            opacity: hideOpen ? .5 : 1,
+            textDecoration: hideOpen ? 'line-through' : 'none',
+          }}
+        >
+          <div style={{ width: 8, height: 8, borderRadius: '50%', background: c.accent, flexShrink: 0 }} />
+          Открыто
+          {hideOpen ? (
+            <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+              <path d="M2 2l10 10M4.5 4.8A5.4 5.4 0 0 0 1.5 7c1 2 3 3.5 5.5 3.5a5.5 5.5 0 0 0 2.5-.6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+              <path d="M7.5 3.6A5.4 5.4 0 0 1 12.5 7a5.5 5.5 0 0 1-.8 1.4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+            </svg>
+          ) : (
+            <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+              <ellipse cx="7" cy="7" rx="5.5" ry="3.5" stroke="currentColor" strokeWidth="1.2"/>
+              <circle cx="7" cy="7" r="1.5" fill="currentColor"/>
+            </svg>
+          )}
+        </button>
+
+        <div style={{ flex: 1 }} />
+
+        <span style={{ fontSize: 12, color: c.muted }}>{rows.length} задач</span>
+      </div>
+
+      {/* ── Main area ── */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
+
+        {/* ── Left panel ── */}
+        <div style={{
+          width: 280, flexShrink: 0, display: 'flex', flexDirection: 'column',
+          borderRight: `1px solid ${c.border}`, overflow: 'hidden',
+        }}>
+          {/* Header */}
+          <div style={{
+            height: 52, display: 'flex', alignItems: 'center',
+            padding: '0 12px 0 16px', background: c.hdrBg,
+            borderBottom: `1px solid ${c.border}`, flexShrink: 0, gap: 8,
+          }}>
+            <span style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.06em', color: c.dimmed, flex: 1 }}>
+              Задача
+            </span>
+            <span style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '.06em', color: c.dimmed, width: 72, textAlign: 'right', flexShrink: 0 }}>
+              Дедлайн
+            </span>
+          </div>
+          {/* Rows */}
+          <div ref={leftRef} style={{ overflowY: 'auto', flex: 1 }}>
+            {loading ? (
+              <div style={{ padding: 24, textAlign: 'center', color: c.muted, fontSize: 13 }}>Загрузка…</div>
+            ) : rows.length === 0 ? (
+              <div style={{ padding: 24, textAlign: 'center', color: c.dimmed, fontSize: 13 }}>
+                Нет задач с датами в этом периоде
+              </div>
+            ) : rows.map((task, idx) => {
+              const isChild  = !!task.parentId;
+              const rh       = isChild ? CROW_H : ROW_H;
+              const hasKids  = (task._count?.children ?? (task.children?.length ?? 0)) > 0;
+              const isExp    = expanded.has(task.id);
+              const due      = parseDate(task.dueDate);
+              const overdue  = isOverdue(task);
+              const dueColor = overdue ? '#EF4444' : due && diffDays(due, TODAY) < 7 && due >= TODAY ? '#F59E0B' : task.status?.category === 'DONE' ? '#10B981' : c.dimmed;
+
+              return (
+                <div
+                  key={task.id}
+                  style={{
+                    display: 'flex', alignItems: 'center', height: rh,
+                    borderBottom: `1px solid ${c.border}`,
+                    background: idx % 2 === 0 ? 'transparent' : c.rowEven,
+                    paddingRight: 8, overflow: 'hidden', cursor: 'pointer',
+                    transition: 'background .1s',
+                  }}
+                  onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.background = `rgba(79,110,247,.05)`; }}
+                  onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = idx % 2 === 0 ? 'transparent' : c.rowEven; }}
+                >
+                  {isChild ? (
+                    <>
+                      <div style={{ width: 26, flexShrink: 0, display: 'flex', alignItems: 'center', height: '100%', paddingLeft: 16 }}>
+                        <div style={{ width: 1, height: '100%', background: c.border, opacity: .6, marginRight: 8 }} />
+                        <svg width="8" height="8" viewBox="0 0 8 8" fill="none" style={{ flexShrink: 0, opacity: .5 }}>
+                          <circle cx="4" cy="4" r="2.5" stroke={c.muted} strokeWidth="1.3"/>
+                        </svg>
+                      </div>
+                      <span style={{ fontSize: 10.5, color: c.dimmed, flexShrink: 0, marginRight: 5, fontWeight: 500 }}>{task.issueKey}</span>
+                      <span style={{ fontSize: 12.5, color: c.text, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{task.title}</span>
+                    </>
+                  ) : (
+                    <>
+                      {/* Expand button */}
+                      <button
+                        onClick={() => {
+                          if (!hasKids) return;
+                          setExpanded(prev => {
+                            const next = new Set(prev);
+                            if (next.has(task.id)) next.delete(task.id);
+                            else next.add(task.id);
+                            return next;
+                          });
+                        }}
+                        style={{
+                          width: 20, height: 20, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          background: 'none', border: 'none', cursor: hasKids ? 'pointer' : 'default',
+                          color: c.muted, flexShrink: 0, marginLeft: 10,
+                          transform: isExp ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform .18s',
+                        }}
+                      >
+                        {hasKids && (
+                          <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+                            <path d="M2 1.5L5.5 4L2 6.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+                          </svg>
+                        )}
+                      </button>
+                      <span style={{ fontSize: 10.5, color: c.dimmed, flexShrink: 0, margin: '0 5px 0 4px', fontWeight: 500 }}>{task.issueKey}</span>
+                      <span style={{ fontSize: 12.5, color: c.text, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 500 }}>{task.title}</span>
+                    </>
+                  )}
+                  <span style={{ fontSize: 11, color: dueColor, flexShrink: 0, width: 72, textAlign: 'right', fontWeight: 500 }}>
+                    {due ? fmtShort(due) : '—'}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── Right panel (timeline) ── */}
+        <div
+          ref={rightRef}
+          style={{ flex: 1, overflow: 'auto', position: 'relative', minWidth: 0 }}
+        >
+          <div style={{ position: 'relative', width: TL_W, minWidth: '100%' }}>
+
+            {/* Timeline header */}
+            <div style={{
+              height: 52, background: c.hdrBg, borderBottom: `1px solid ${c.border}`,
+              position: 'sticky', top: 0, zIndex: 20, display: 'flex', flexDirection: 'column',
+            }}>
+              {/* Row 1 */}
+              <div style={{ display: 'flex', height: 26, borderBottom: `1px solid ${c.border}` }}>
+                {hdr.row1.map((cell, i) => (
+                  <div key={i} style={{
+                    position: 'absolute', left: cell.x, width: cell.w, height: 26,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    borderRight: `1px solid ${c.border}`,
+                    fontSize: 11, fontWeight: 600, color: c.muted,
+                    overflow: 'hidden', whiteSpace: 'nowrap', paddingInline: 8,
+                    background: 'isCurrent' in cell && (cell as { isCurrent?: boolean }).isCurrent ? c.curWeek : 'transparent',
+                  }}>
+                    {cell.label}
+                  </div>
+                ))}
+              </div>
+              {/* Row 2 */}
+              <div style={{ display: 'flex', height: 26, position: 'relative' }}>
+                {hdr.row2.map((cell, i) => (
+                  <div key={i} style={{
+                    position: 'absolute', left: cell.x, width: cell.w, height: 26,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    borderRight: `1px solid rgba(255,255,255,.04)`,
+                    fontSize: 10, color: c.dimmed, overflow: 'hidden', whiteSpace: 'nowrap',
+                    background: 'isCurrent' in cell && (cell as { isCurrent?: boolean }).isCurrent ? c.curWeek : 'transparent',
+                  }}>
+                    {(cell as { label: string }).label}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Bars area */}
+            <div style={{ position: 'relative', height: totalH }}>
+
+              {/* Current-week highlight */}
+              {(() => {
+                const ws = d0(new Date(TODAY));
+                const dayOfWeek = ws.getDay();
+                const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+                const monday = addDays(ws, mondayOffset);
+                const sunday = addDays(monday, 7);
+                const lx = Math.max(0, xOf(monday));
+                const rx = Math.min(TL_W, xOf(sunday));
+                return rx > lx ? (
+                  <div style={{
+                    position: 'absolute', top: 0, bottom: 0,
+                    left: lx, width: rx - lx,
+                    background: c.curWeek, pointerEvents: 'none',
+                  }} />
+                ) : null;
+              })()}
+
+              {/* Grid lines (month separators) */}
+              {(() => {
+                const lines: number[] = [];
+                let cur = new Date(range.start);
+                while (cur <= range.end) {
+                  const x = xOf(cur);
+                  if (x >= 0 && x <= TL_W) lines.push(x);
+                  cur = new Date(cur.getFullYear(), cur.getMonth() + 1, 1);
+                }
+                return lines.map((x, i) => (
+                  <div key={i} style={{
+                    position: 'absolute', top: 0, bottom: 0, left: x, width: 1,
+                    background: c.border, opacity: .9, pointerEvents: 'none',
+                  }} />
+                ));
+              })()}
+
+              {/* Week grid lines */}
+              {zoom !== 'week' && (() => {
+                const lines: number[] = [];
+                let cur = new Date(range.start);
+                while (cur < range.end) {
+                  const x = xOf(cur);
+                  if (x > 0 && x < TL_W) lines.push(x);
+                  cur = addDays(cur, 7);
+                }
+                return lines.map((x, i) => (
+                  <div key={i} style={{
+                    position: 'absolute', top: 0, bottom: 0, left: x, width: 1,
+                    background: c.border, opacity: .35, pointerEvents: 'none',
+                  }} />
+                ));
+              })()}
+
+              {/* Today line */}
+              {todayX >= 0 && todayX <= TL_W && (
+                <div style={{
+                  position: 'absolute', top: 0, bottom: 0, left: todayX, width: 2,
+                  background: c.today, zIndex: 15, pointerEvents: 'none',
+                }}>
+                  <div style={{
+                    position: 'absolute', top: 0, left: -3,
+                    width: 8, height: 8, borderRadius: '50%', background: c.today,
+                  }} />
+                </div>
+              )}
+
+              {/* Task bars */}
+              {rows.map((task, idx) => {
+                const isChild = !!task.parentId;
+                const rh      = isChild ? CROW_H : ROW_H;
+                const yOffset = rows.slice(0, idx).reduce((acc, t) => acc + (t.parentId ? CROW_H : ROW_H), 0);
+                const start   = parseDate(task.startDate) ?? parseDate(task.dueDate);
+                const end     = parseDate(task.dueDate)   ?? parseDate(task.startDate);
+                const { bg, border } = barColor(task);
+                const barH    = isChild ? 22 : 30;
+                const barR    = isChild ? 5  : 7;
+
+                const rowStyle: React.CSSProperties = {
+                  position: 'absolute', left: 0, right: 0,
+                  top: yOffset, height: rh,
+                  background: idx % 2 === 0 ? 'transparent' : c.rowEven,
+                  borderBottom: `1px solid ${c.border}`,
+                };
+
+                if (!start || !end) {
+                  return (
+                    <div key={task.id} style={rowStyle}>
+                      <span style={{
+                        position: 'absolute', right: 10, top: '50%',
+                        transform: 'translateY(-50%)', fontSize: 11, color: c.dimmed, fontStyle: 'italic',
+                      }}>нет дат</span>
+                    </div>
+                  );
+                }
+
+                const bx = xOf(start);
+                const bw = Math.max(6, wOf(start, end));
+                const cx = Math.max(0, bx);
+                const cw = Math.min(TL_W - cx, bw - (cx - bx));
+
+                const overdue = isOverdue(task);
+                const ovLeft  = Math.min(TL_W, Math.max(0, xOf(end)));
+                const ovRight = Math.min(TL_W, xOf(TODAY));
+                const ovW     = overdue ? ovRight - ovLeft : 0;
+                const overdueDays = overdue ? diffDays(end, TODAY) : 0;
+
+                return (
+                  <div key={task.id} style={rowStyle}>
+                    {cw > 0 && (
+                      <div
+                        title={`${task.issueKey} · ${task.title} · ${statusLabel(task)}`}
+                        style={{
+                          position: 'absolute',
+                          top: '50%', transform: 'translateY(-50%)',
+                          left: cx, width: cw, height: barH,
+                          borderRadius: barR, overflow: 'hidden',
+                          background: bg, border: `1px solid ${border}`,
+                          display: 'flex', alignItems: 'center',
+                          padding: '0 8px 0 10px', cursor: 'default',
+                          color: '#fff', textShadow: '0 1px 3px rgba(0,0,0,.35)',
+                          fontSize: isChild ? 11 : 12, fontWeight: 500,
+                          whiteSpace: 'nowrap',
+                          transition: 'filter .12s',
+                          zIndex: 2,
+                        }}
+                        onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.filter = 'brightness(1.12)'; }}
+                        onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.filter = ''; }}
+                      >
+                        {/* Left accent stripe */}
+                        <div style={{
+                          position: 'absolute', left: 0, top: 0, bottom: 0, width: isChild ? 3 : 4,
+                          background: 'rgba(0,0,0,.25)',
+                        }} />
+                        {cw > 38 && <span style={{ color: 'rgba(255,255,255,.7)', fontSize: 10, fontWeight: 600, marginRight: 5, flexShrink: 0 }}>{task.issueKey}</span>}
+                        {cw > 60 && <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>{task.title}</span>}
+                        {cw > 90 && <span style={{ fontSize: 10, color: 'rgba(255,255,255,.82)', marginLeft: 6, flexShrink: 0, fontWeight: 600 }}>{fmtShort(end)}</span>}
+                      </div>
+                    )}
+
+                    {/* Overdue tail */}
+                    {ovW > 4 && (
+                      <div
+                        title={`Просрочено на ${overdueDays} дн.`}
+                        style={{
+                          position: 'absolute',
+                          top: '50%', transform: 'translateY(-50%)',
+                          left: ovLeft, width: ovW, height: barH,
+                          borderRadius: `0 ${barR}px ${barR}px 0`,
+                          background: 'rgba(239,68,68,.28)',
+                          border: '1.5px dashed rgba(239,68,68,.72)',
+                          borderLeft: 'none',
+                          display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
+                          paddingRight: 6, zIndex: 3, cursor: 'default',
+                          animation: task.priority === 'HIGH' ? 'ov-pulse 2s ease-in-out infinite' : 'none',
+                        }}
+                      >
+                        {ovW > 36 && (
+                          <span style={{ fontSize: 10, fontWeight: 700, color: 'rgba(239,68,68,.95)', whiteSpace: 'nowrap' }}>
+                            +{overdueDays}д
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style>{`@keyframes ov-pulse{0%,100%{opacity:1}50%{opacity:.55}}`}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/SubtaskTree.tsx
+++ b/frontend/src/components/SubtaskTree.tsx
@@ -44,11 +44,12 @@ interface Props {
   statuses: WorkflowStatus[];
   depth?: number;
   onRefresh: () => void;
+  onOpenTask?: (taskId: string) => void;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 export default function SubtaskTree({
-  tasks, parentId, boardId, statuses, depth = 0, onRefresh,
+  tasks, parentId, boardId, statuses, depth = 0, onRefresh, onOpenTask,
 }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
@@ -179,14 +180,24 @@ export default function SubtaskTree({
                 )}
               </span>
 
-              {/* Title */}
-              <span style={{
-                flex: 1, fontSize: 13,
-                fontFamily: '"Inter",system-ui,sans-serif',
-                color: done ? c.doneTitleText : c.titleText,
-                textDecoration: done ? 'line-through' : 'none',
-                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-              }}>
+              {/* Title — кликабельный переход в карточку */}
+              <span
+                onClick={() => onOpenTask?.(task.id)}
+                style={{
+                  flex: 1, fontSize: 13,
+                  fontFamily: '"Inter",system-ui,sans-serif',
+                  color: done ? c.doneTitleText : c.titleText,
+                  textDecoration: done ? 'line-through' : 'none',
+                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                  cursor: onOpenTask ? 'pointer' : 'default',
+                }}
+                onMouseEnter={e => {
+                  if (onOpenTask) (e.currentTarget as HTMLSpanElement).style.color = isDark ? '#A8B4D0' : '#4F6EF7';
+                }}
+                onMouseLeave={e => {
+                  (e.currentTarget as HTMLSpanElement).style.color = done ? c.doneTitleText : c.titleText;
+                }}
+              >
                 {task.title}
               </span>
 
@@ -256,6 +267,7 @@ export default function SubtaskTree({
                   statuses={statuses}
                   depth={depth + 1}
                   onRefresh={() => { fetchSubtree(task.id); onRefresh(); }}
+                  onOpenTask={onOpenTask}
                 />
               </div>
             )}

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -110,6 +110,7 @@ export default function TaskDrawer({
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>('details');
+  const [subtaskId, setSubtaskId] = useState<string | null>(null);
 
   // Edit states
   const [editTitle, setEditTitle] = useState(false);
@@ -603,6 +604,7 @@ export default function TaskDrawer({
                       boardId={boardId}
                       statuses={statuses}
                       onRefresh={refreshTask}
+                      onOpenTask={setSubtaskId}
                     />
                   ) : (task._count?.children ?? 0) > 0 ? (
                     <span style={{ fontSize: 12, color: c.label }}>{task._count?.children} подзадач</span>
@@ -649,6 +651,22 @@ export default function TaskDrawer({
           )}
         </div>
       </div>
+
+      {/* Nested TaskDrawer — drill-down в подзадачу */}
+      {subtaskId && (
+        <TaskDrawer
+          taskId={subtaskId}
+          statuses={statuses}
+          members={members}
+          workspaceId={workspaceId}
+          boardId={boardId}
+          workspaceLabels={workspaceLabels}
+          onWorkspaceLabelCreated={onWorkspaceLabelCreated}
+          onClose={() => setSubtaskId(null)}
+          onUpdated={() => { refreshTask(); }}
+          onDeleted={() => { setSubtaskId(null); refreshTask(); }}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -663,8 +663,8 @@ export default function TaskDrawer({
           workspaceLabels={workspaceLabels}
           onWorkspaceLabelCreated={onWorkspaceLabelCreated}
           onClose={() => setSubtaskId(null)}
-          onUpdated={() => { refreshTask(); }}
-          onDeleted={() => { setSubtaskId(null); refreshTask(); }}
+          onUpdated={(updated) => { onUpdated(updated); refreshTask(); }}
+          onDeleted={(id) => { setSubtaskId(null); onDeleted(id); refreshTask(); }}
         />
       )}
     </>

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -16,9 +16,10 @@ import TaskCard from '../components/TaskCard';
 import TaskDrawer from '../components/TaskDrawer';
 import BoardListView from '../components/BoardListView';
 import BoardCalendarView from '../components/BoardCalendarView';
+import RoadmapView from '../components/RoadmapView';
 import FilterBar, { type FilterState, EMPTY_FILTERS } from '../components/FilterBar';
 
-type ViewMode = 'board' | 'list' | 'calendar';
+type ViewMode = 'board' | 'list' | 'calendar' | 'roadmap';
 type Columns = Record<string, Task[]>;
 
 function groupByStatus(tasks: Task[], statuses: WorkflowStatus[]): Columns {
@@ -364,10 +365,17 @@ export default function BoardPage() {
   }
   if (!board) return null;
 
-  const viewBtns: { mode: ViewMode; icon: React.ReactNode }[] = [
-    { mode: 'board',    icon: <KanbanIcon active={viewMode === 'board'} color={viewActive} /> },
-    { mode: 'list',     icon: <ListIcon /> },
-    { mode: 'calendar', icon: <CalIcon /> },
+  const viewBtns: { mode: ViewMode; icon: React.ReactNode; title: string }[] = [
+    { mode: 'board',    title: 'Канбан',        icon: <KanbanIcon active={viewMode === 'board'} color={viewActive} /> },
+    { mode: 'list',     title: 'Список',         icon: <ListIcon /> },
+    { mode: 'calendar', title: 'Календарь',      icon: <CalIcon /> },
+    { mode: 'roadmap',  title: 'Дорожная карта', icon: (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <line x1="1" y1="4"   x2="9"  y2="4"   stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="5" y1="7.5" x2="13" y2="7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="2" y1="11"  x2="10" y2="11"  stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    )},
   ];
 
   return (
@@ -415,6 +423,7 @@ export default function BoardPage() {
             <button
               key={btn.mode}
               onClick={() => setViewMode(btn.mode)}
+              title={btn.title}
               style={{
                 display: 'flex', alignItems: 'center', justifyContent: 'center',
                 width: 32, height: 28, border: 'none', cursor: 'pointer', borderRadius: 7,
@@ -460,7 +469,7 @@ export default function BoardPage() {
       />
 
       {/* ── View content ─────────────────────────────────────────────────── */}
-      <div style={{ flex: 1, overflow: viewMode === 'board' ? 'hidden' : 'auto' }}>
+      <div style={{ flex: 1, overflow: viewMode === 'board' || viewMode === 'roadmap' ? 'hidden' : 'auto', display: 'flex', flexDirection: 'column' }}>
 
         {/* Kanban */}
         {viewMode === 'board' && (
@@ -621,6 +630,15 @@ export default function BoardPage() {
             statuses={statuses}
             tasks={filteredTasks}
             onTaskClick={setSelectedTaskId}
+          />
+        )}
+
+        {/* Roadmap */}
+        {viewMode === 'roadmap' && (
+          <RoadmapView
+            boardId={board.id}
+            statuses={statuses}
+            members={members}
           />
         )}
       </div>

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -6,6 +6,7 @@ import {
 import { message } from 'antd';
 import type { Board, Task, WorkflowStatus, WorkspaceMember, Label } from '../types';
 import { useThemeStore } from '../store/theme.store';
+import { useWorkspaceStore } from '../store/workspace.store';
 import * as boardsApi from '../api/boards';
 import * as tasksApi from '../api/tasks';
 import * as workspacesApi from '../api/workspaces';
@@ -123,9 +124,11 @@ function BoardSettingsBtn({ onClick, border, addText, isPrivate }: {
 
 // ── Page ───────────────────────────────────────────────────────────────────────
 export default function BoardPage() {
-  const { boardId } = useParams<{ boardId: string }>();
+  const { slug, boardSlug } = useParams<{ slug: string; boardSlug: string }>();
   const navigate = useNavigate();
   const mode = useThemeStore(s => s.mode);
+  const workspaces = useWorkspaceStore(s => s.workspaces);
+  const wsId = workspaces.find(w => w.slug === slug)?.id;
   const isDark = mode === 'dark';
 
   // ── Theme tokens ──────────────────────────────────────────────────────────
@@ -164,9 +167,9 @@ export default function BoardPage() {
 
   // ── Load ──────────────────────────────────────────────────────────────────
   const loadBoard = useCallback(async () => {
-    if (!boardId) return;
+    if (!wsId || !boardSlug) return;
     try {
-      const b = await boardsApi.getBoard(boardId);
+      const b = await boardsApi.getBoardByPrefix(wsId, boardSlug);
       setBoard(b);
       const cols = groupByStatus(b.tasks ?? [], b.workflow.statuses);
       setColumns(cols);
@@ -178,7 +181,7 @@ export default function BoardPage() {
       if (fullCols.length > 0) {
         const totals = await Promise.all(
           fullCols.map(s =>
-            tasksApi.listTasks(boardId, { statusId: s.id, rootOnly: 'true', limit: '1', offset: '0' })
+            tasksApi.listTasks(b.id, { statusId: s.id, rootOnly: 'true', limit: '1', offset: '0' })
               .then(r => [s.id, r.total] as const)
               .catch(() => [s.id, 100] as const)
           )
@@ -187,7 +190,7 @@ export default function BoardPage() {
       }
     } catch { message.error('Не удалось загрузить доску'); }
     finally { setLoading(false); }
-  }, [boardId]);
+  }, [wsId, boardSlug]);
 
   useEffect(() => { loadBoard(); }, [loadBoard]);
 
@@ -245,7 +248,7 @@ export default function BoardPage() {
       }
     }
     try {
-      await tasksApi.reorderTasks(boardId!, updates);
+      await tasksApi.reorderTasks(board!.id, updates);
     } catch {
       message.error('Не удалось сохранить порядок');
       loadBoard();
@@ -254,11 +257,11 @@ export default function BoardPage() {
 
   // ── Load more (column pagination) ────────────────────────────────────────
   const loadMoreColumn = async (statusId: string) => {
-    if (!boardId || loadingMoreCols.has(statusId)) return;
+    if (!board || loadingMoreCols.has(statusId)) return;
     const offset = columnOffsets[statusId] ?? 0;
     setLoadingMoreCols(prev => new Set(prev).add(statusId));
     try {
-      const { tasks: more, total } = await tasksApi.listTasks(boardId, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
+      const { tasks: more, total } = await tasksApi.listTasks(board.id, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
       setColumns(prev => ({ ...prev, [statusId]: [...(prev[statusId] ?? []), ...more] }));
       setColumnOffsets(prev => ({ ...prev, [statusId]: offset + more.length }));
       setColumnTotals(prev => ({ ...prev, [statusId]: total }));
@@ -270,7 +273,7 @@ export default function BoardPage() {
   const submitAdd = async (statusId: string) => {
     if (!addTitle.trim()) { setAddingTo(null); return; }
     try {
-      const task = await tasksApi.createTask(boardId!, { title: addTitle.trim(), statusId });
+      const task = await tasksApi.createTask(board!.id, { title: addTitle.trim(), statusId });
       setColumns(prev => ({ ...prev, [statusId]: [...(prev[statusId] ?? []), task] }));
       setAddTitle('');
       setAddingTo(null);
@@ -597,7 +600,7 @@ export default function BoardPage() {
         statuses={statuses}
         members={members}
         workspaceId={board.workspaceId}
-        boardId={boardId}
+        boardId={board?.id ?? ''}
         workspaceLabels={labels}
         onWorkspaceLabelCreated={label => setLabels(prev => [...prev, label])}
         onClose={() => setSelectedTaskId(null)}

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
   DragDropContext, Droppable, Draggable, type DropResult, type DragStart,
 } from '@hello-pangea/dnd';
@@ -160,7 +160,11 @@ export default function BoardPage() {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [addingTo, setAddingTo] = useState<string | null>(null);
   const [addTitle, setAddTitle] = useState('');
-  const [viewMode, setViewMode] = useState<ViewMode>('board');
+  const [searchParams] = useSearchParams();
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    const v = searchParams.get('view');
+    return (v === 'roadmap' || v === 'list' || v === 'calendar') ? v : 'board';
+  });
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [labels, setLabels] = useState<Label[]>([]);

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -11,6 +11,7 @@ import * as boardsApi from '../api/boards';
 import * as tasksApi from '../api/tasks';
 import * as workspacesApi from '../api/workspaces';
 import * as labelsApi from '../api/labels';
+import { useBreakpoint } from '../utils/useBreakpoint';
 import TaskCard from '../components/TaskCard';
 import TaskDrawer from '../components/TaskDrawer';
 import BoardListView from '../components/BoardListView';
@@ -126,6 +127,9 @@ function BoardSettingsBtn({ onClick, border, addText, isPrivate }: {
 export default function BoardPage() {
   const { slug, boardSlug } = useParams<{ slug: string; boardSlug: string }>();
   const navigate = useNavigate();
+  const bp      = useBreakpoint();
+  const isMobile = bp === 'mobile';
+
   const mode = useThemeStore(s => s.mode);
   const workspaces = useWorkspaceStore(s => s.workspaces);
   const wsLoading = useWorkspaceStore(s => s.loading);
@@ -372,14 +376,15 @@ export default function BoardPage() {
 
       {/* ── Board header ─────────────────────────────────────────────────── */}
       <div style={{
-        display: 'flex', alignItems: 'center', gap: 12,
-        padding: '16px 24px', background: headerBg,
-        borderBottom: `1px solid ${border}`, flexShrink: 0,
+        display: 'flex', alignItems: 'center', gap: isMobile ? 8 : 12,
+        padding: isMobile ? '12px 16px' : '16px 24px',
+        background: headerBg, borderBottom: `1px solid ${border}`,
+        flexShrink: 0, minWidth: 0, overflow: 'hidden',
       }}>
         {/* Back */}
         <button
           onClick={() => navigate(-1)}
-          style={{ background: 'transparent', border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', color: addText }}
+          style={{ background: 'transparent', border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', color: addText, flexShrink: 0 }}
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             <path d="M10 3L5 8L10 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
@@ -387,14 +392,22 @@ export default function BoardPage() {
         </button>
 
         {/* Board name + task count */}
-        <h1 style={{ fontFamily: '"Space Grotesk",system-ui,sans-serif', fontSize: 18, fontWeight: 700, color: nameColor, margin: 0, letterSpacing: '-0.3px' }}>
+        <h1 style={{
+          fontFamily: '"Space Grotesk",system-ui,sans-serif',
+          fontSize: isMobile ? 16 : 18, fontWeight: 700, color: nameColor,
+          margin: 0, letterSpacing: '-0.3px',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          minWidth: 0, flex: isMobile ? '1 1 0' : undefined,
+        }}>
           {board.name}
         </h1>
-        <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: cntText, background: cntBg, borderRadius: 6, padding: '2px 8px', flexShrink: 0 }}>
-          {allTasks.length}{hasMoreTasks ? '+' : ''} задач
-        </span>
+        {!isMobile && (
+          <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: cntText, background: cntBg, borderRadius: 6, padding: '2px 8px', flexShrink: 0 }}>
+            {allTasks.length}{hasMoreTasks ? '+' : ''} задач
+          </span>
+        )}
 
-        <div style={{ flex: 1 }} />
+        <div style={{ flex: isMobile ? undefined : 1 }} />
 
         {/* View switcher */}
         <div style={{ display: 'flex', gap: 2, background: isDark ? '#0F1320' : '#EDE9FE', borderRadius: 10, padding: 3 }}>
@@ -428,12 +441,12 @@ export default function BoardPage() {
         <button
           data-onboarding="create-task"
           onClick={() => { if (statuses.length > 0) { setAddingTo(statuses[0].id); setAddTitle(''); } }}
-          style={{ display: 'flex', alignItems: 'center', gap: 6, background: '#4F6EF7', border: 'none', borderRadius: 8, padding: '7px 14px', cursor: 'pointer' }}
+          style={{ display: 'flex', alignItems: 'center', gap: 6, background: '#4F6EF7', border: 'none', borderRadius: 8, padding: isMobile ? '7px 10px' : '7px 14px', cursor: 'pointer', flexShrink: 0 }}
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <path d="M6 1v10M1 6h10" stroke="white" strokeWidth="1.6" strokeLinecap="round"/>
           </svg>
-          <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13, fontWeight: 600, color: '#fff' }}>Создать</span>
+          {!isMobile && <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13, fontWeight: 600, color: '#fff' }}>Создать</span>}
         </button>
       </div>
 
@@ -451,7 +464,7 @@ export default function BoardPage() {
 
         {/* Kanban */}
         {viewMode === 'board' && (
-          <div style={{ overflowX: 'auto', padding: '24px', height: '100%' }}>
+          <div style={{ overflowX: 'auto', padding: isMobile ? '12px 16px' : '24px', height: '100%', WebkitOverflowScrolling: 'touch' }}>
             <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
               <div style={{ display: 'flex', gap: 16, height: '100%', minHeight: 0 }}>
                 {statuses.map(status => {

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -642,7 +642,6 @@ export default function BoardPage() {
           <RoadmapView
             boardId={board.id}
             statuses={statuses}
-            members={members}
           />
         )}
       </div>

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -128,6 +128,7 @@ export default function BoardPage() {
   const navigate = useNavigate();
   const mode = useThemeStore(s => s.mode);
   const workspaces = useWorkspaceStore(s => s.workspaces);
+  const wsLoading = useWorkspaceStore(s => s.loading);
   const wsId = workspaces.find(w => w.slug === slug)?.id;
   const isDark = mode === 'dark';
 
@@ -150,6 +151,7 @@ export default function BoardPage() {
   const [board, setBoard] = useState<Board | null>(null);
   const [columns, setColumns] = useState<Columns>({});
   const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [addingTo, setAddingTo] = useState<string | null>(null);
   const [addTitle, setAddTitle] = useState('');
@@ -167,7 +169,11 @@ export default function BoardPage() {
 
   // ── Load ──────────────────────────────────────────────────────────────────
   const loadBoard = useCallback(async () => {
-    if (!wsId || !boardSlug) return;
+    if (!boardSlug) { setLoading(false); return; }
+    if (!wsId) {
+      if (!wsLoading) setLoading(false); // store loaded but workspace not found
+      return;
+    }
     try {
       const b = await boardsApi.getBoardByPrefix(wsId, boardSlug);
       setBoard(b);
@@ -188,9 +194,13 @@ export default function BoardPage() {
         );
         setColumnTotals(Object.fromEntries(totals));
       }
-    } catch { message.error('Не удалось загрузить доску'); }
+    } catch (e: unknown) {
+      const status = (e as { response?: { status?: number } })?.response?.status;
+      if (status === 404 || status === 403) { setNotFound(true); }
+      else { message.error('Не удалось загрузить доску'); }
+    }
     finally { setLoading(false); }
-  }, [wsId, boardSlug]);
+  }, [wsId, wsLoading, boardSlug]);
 
   useEffect(() => { loadBoard(); }, [loadBoard]);
 
@@ -340,6 +350,14 @@ export default function BoardPage() {
     );
   }
 
+  if (notFound || (!loading && !board)) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 12, background: pageBg }}>
+        <div style={{ fontSize: 15, color: isDark ? '#8B949E' : '#9B96B8', fontFamily: '"Inter",system-ui,sans-serif' }}>Доска не найдена</div>
+        <button onClick={() => navigate(-1)} style={{ fontSize: 13, color: '#4F6EF7', background: 'none', border: 'none', cursor: 'pointer', fontFamily: '"Inter",system-ui,sans-serif' }}>← Назад</button>
+      </div>
+    );
+  }
   if (!board) return null;
 
   const viewBtns: { mode: ViewMode; icon: React.ReactNode }[] = [
@@ -600,7 +618,7 @@ export default function BoardPage() {
         statuses={statuses}
         members={members}
         workspaceId={board.workspaceId}
-        boardId={board?.id ?? ''}
+        boardId={board.id}
         workspaceLabels={labels}
         onWorkspaceLabelCreated={label => setLabels(prev => [...prev, label])}
         onClose={() => setSelectedTaskId(null)}

--- a/frontend/src/pages/BoardSettingsPage.tsx
+++ b/frontend/src/pages/BoardSettingsPage.tsx
@@ -25,7 +25,7 @@ const INTER = '"Inter",system-ui,sans-serif';
 const GROTESK = '"Space Grotesk",system-ui,sans-serif';
 
 export default function BoardSettingsPage() {
-  const { slug, boardId } = useParams<{ slug: string; boardId: string }>();
+  const { slug, boardSlug } = useParams<{ slug: string; boardSlug: string }>();
   const navigate = useNavigate();
   const mode = useThemeStore((s) => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
@@ -43,18 +43,19 @@ export default function BoardSettingsPage() {
   const [deleting, setDeleting] = useState(false);
 
   const workspace = workspaces.find((w) => w.slug === slug) ?? null;
+  const wsId = workspace?.id;
   const isOwner = workspace?.role === 'OWNER';
 
   useEffect(() => {
-    if (!boardId) return;
-    boardsApi.getBoard(boardId).then((b) => {
+    if (!wsId || !boardSlug) return;
+    boardsApi.getBoardByPrefix(wsId, boardSlug).then((b) => {
       setBoard(b);
       setName(b.name);
       setDescription(b.description ?? '');
       setWorkflowId(b.workflowId);
       setIsPrivate(b.isPrivate ?? false);
     }).catch(() => { message.error('Не удалось загрузить доску'); setLoadError(true); });
-  }, [boardId]);
+  }, [wsId, boardSlug]);
 
   useEffect(() => {
     if (!workspace?.id) return;
@@ -62,20 +63,20 @@ export default function BoardSettingsPage() {
   }, [workspace?.id]);
 
   const save = async () => {
-    if (!boardId) return;
+    if (!board) return;
     setSaving(true);
     try {
-      await boardsApi.updateBoard(boardId, { name, description, workflowId, isPrivate });
+      await boardsApi.updateBoard(board.id, { name, description, workflowId, isPrivate });
       message.success('Сохранено');
     } catch { message.error('Ошибка сохранения'); }
     finally { setSaving(false); }
   };
 
   const handleDelete = async () => {
-    if (!boardId || !confirm(`Удалить доску "${board?.name}"? Все задачи будут удалены.`)) return;
+    if (!board || !confirm(`Удалить доску "${board.name}"? Все задачи будут удалены.`)) return;
     setDeleting(true);
     try {
-      await boardsApi.deleteBoard(boardId);
+      await boardsApi.deleteBoard(board.id);
       navigate(`/w/${slug}`);
     } catch { message.error('Не удалось удалить доску'); setDeleting(false); }
   };
@@ -125,7 +126,7 @@ export default function BoardSettingsPage() {
           <div style={{ fontSize: 12, color: c.muted, marginTop: 2 }}>{board.name}</div>
         </div>
         <button
-          onClick={() => navigate(`/w/${slug}/boards/${boardId}`)}
+          onClick={() => navigate(`/w/${slug}/boards/${boardSlug}`)}
           style={{
             display: 'flex', alignItems: 'center', gap: 8,
             margin: '0 12px', padding: '8px 12px', borderRadius: 8,

--- a/frontend/src/pages/BoardSettingsPage.tsx
+++ b/frontend/src/pages/BoardSettingsPage.tsx
@@ -30,7 +30,7 @@ export default function BoardSettingsPage() {
   const mode = useThemeStore((s) => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
   const isDark = mode !== 'light';
-  const { workspaces } = useWorkspaceStore();
+  const { workspaces, loading: wsLoading } = useWorkspaceStore();
 
   const [board, setBoard] = useState<Board | null>(null);
   const [loadError, setLoadError] = useState(false);
@@ -47,7 +47,11 @@ export default function BoardSettingsPage() {
   const isOwner = workspace?.role === 'OWNER';
 
   useEffect(() => {
-    if (!wsId || !boardSlug) return;
+    if (!boardSlug) { setLoadError(true); return; }
+    if (!wsId) {
+      if (!wsLoading) setLoadError(true);
+      return;
+    }
     boardsApi.getBoardByPrefix(wsId, boardSlug).then((b) => {
       setBoard(b);
       setName(b.name);
@@ -55,7 +59,7 @@ export default function BoardSettingsPage() {
       setWorkflowId(b.workflowId);
       setIsPrivate(b.isPrivate ?? false);
     }).catch(() => { message.error('Не удалось загрузить доску'); setLoadError(true); });
-  }, [wsId, boardSlug]);
+  }, [wsId, wsLoading, boardSlug]);
 
   useEffect(() => {
     if (!workspace?.id) return;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -23,7 +23,7 @@ export default function HomePage() {
         fontFamily: '"Inter",system-ui,sans-serif', fontSize: 14,
         color: c.sub, display: 'block', marginBottom: 24,
       }}>
-        Добро пожаловать, {user?.name ?? 'пользователь'}!
+        Добро пожаловать, {user?.name?.trim().split(/\s+/)[0] ?? 'пользователь'}!
       </span>
       <button
         onClick={logout}

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -91,11 +91,11 @@ export default function MyTasksPage() {
         wsId: string;
         wsName: string;
         wsSlug: string;
-        boards: Map<string, { boardId: string; boardName: string; tasks: MyTask[] }>;
+        boards: Map<string, { boardId: string; boardSlug: string; boardName: string; tasks: MyTask[] }>;
       }
     >();
     for (const t of allTasks) {
-      const { workspace, id: boardId, name: boardName } = t.board;
+      const { workspace, id: boardId, name: boardName, prefix } = t.board;
       if (!wsMap.has(workspace.id)) {
         wsMap.set(workspace.id, {
           wsId: workspace.id,
@@ -106,7 +106,7 @@ export default function MyTasksPage() {
       }
       const ws = wsMap.get(workspace.id)!;
       if (!ws.boards.has(boardId)) {
-        ws.boards.set(boardId, { boardId, boardName, tasks: [] });
+        ws.boards.set(boardId, { boardId, boardSlug: prefix.toLowerCase(), boardName, tasks: [] });
       }
       ws.boards.get(boardId)!.tasks.push(t);
     }
@@ -291,7 +291,7 @@ export default function MyTasksPage() {
                         return (
                           <div
                             key={task.id}
-                            onClick={() => navigate(`/w/${ws.wsSlug}/boards/${board.boardId}`)}
+                            onClick={() => navigate(`/w/${ws.wsSlug}/boards/${board.boardSlug}`)}
                             style={{
                               display: 'flex', alignItems: 'center', gap: 12,
                               padding: '11px 16px',

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useWorkspaceStore } from '../store/workspace.store';
+import { useThemeStore } from '../store/theme.store';
+import { useBreakpoint } from '../utils/useBreakpoint';
+import type { Board } from '../types';
+import * as boardsApi from '../api/boards';
+
+// ── Design tokens ──────────────────────────────────────────────────────────────
+type C = Record<string, string>;
+
+const DARK: C = {
+  bg: '#03050F', border: '#1C2236',
+  title: '#E2E8F8', sub: '#8B949E', muted: '#484F58',
+  cardBg: '#0F1320', cardBorder: '#1C2236', cardTitle: '#E2E8F8', cardSub: '#484F58',
+  pillBg: '#1C2236', pillText: '#8B949E', backText: '#484F58',
+};
+const LIGHT: C = {
+  bg: '#F5F3FF', border: '#E8E5F0',
+  title: '#1A1A2E', sub: '#9B96B8', muted: '#9B96B8',
+  cardBg: '#FDFCFF', cardBorder: '#E8E5F0', cardTitle: '#1A1A2E', cardSub: '#9B96B8',
+  pillBg: '#F0ECF8', pillText: '#7C6FA8', backText: '#9B96B8',
+};
+
+const BD_COLORS = ['#4F6EF7','#8B5CF6','#22C55E','#F59E0B','#EC4899','#EF4444','#0EA5E9'];
+function boardColor(name: string) {
+  return BD_COLORS[(name.charCodeAt(0) ?? 0) % BD_COLORS.length];
+}
+
+function pluralTasks(n: number) {
+  const m10 = n % 10, m100 = n % 100;
+  if (m100 >= 11 && m100 <= 19) return `${n} задач`;
+  if (m10 === 1) return `${n} задача`;
+  if (m10 >= 2 && m10 <= 4) return `${n} задачи`;
+  return `${n} задач`;
+}
+
+// ── Mini roadmap bar preview ───────────────────────────────────────────────────
+function MiniPreview({ color }: { color: string }) {
+  const bars = [
+    { left: '2%',  width: '55%', opacity: .7 },
+    { left: '20%', width: '35%', opacity: .55 },
+    { left: '45%', width: '40%', opacity: .45 },
+  ];
+  return (
+    <div style={{ position: 'relative', height: 48, display: 'flex', flexDirection: 'column', justifyContent: 'space-around', padding: '4px 0' }}>
+      {bars.map((b, i) => (
+        <div key={i} style={{ position: 'absolute', top: `${20 + i * 26}%`, height: 8, borderRadius: 4, background: color, opacity: b.opacity, left: b.left, width: b.width }} />
+      ))}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+export default function RoadmapsPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate  = useNavigate();
+  const mode      = useThemeStore(s => s.mode);
+  const c         = mode === 'light' ? LIGHT : DARK;
+  const isDark    = mode === 'dark';
+  const bp        = useBreakpoint();
+  const isMobile  = bp === 'mobile';
+
+  const { workspaces, current, setCurrent, load } = useWorkspaceStore();
+  const [boards, setBoards]   = useState<Board[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => { if (workspaces.length === 0) load(); }, [workspaces.length, load]);
+
+  useEffect(() => {
+    if (!slug || workspaces.length === 0) return;
+    const ws = workspaces.find(w => w.slug === slug);
+    if (ws && ws.id !== current?.id) setCurrent(ws);
+  }, [slug, workspaces, current?.id, setCurrent]);
+
+  useEffect(() => {
+    if (!current) return;
+    setLoading(true);
+    boardsApi.listBoards(current.id)
+      .then(setBoards)
+      .catch(() => setBoards([]))
+      .finally(() => setLoading(false));
+  }, [current?.id]);
+
+  const padding = isMobile ? '20px 16px' : bp === 'tablet' ? '24px 32px' : '36px 48px';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100%', background: c.bg }}>
+
+      {/* ── Header ── */}
+      <div style={{ padding, borderBottom: `1px solid ${c.border}`, flexShrink: 0 }}>
+        {/* Back */}
+        <div
+          onClick={() => navigate(`/w/${slug}`)}
+          style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 16, cursor: 'pointer', width: 'fit-content' }}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M9 2.5L4.5 7L9 11.5" stroke={c.backText} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.backText, letterSpacing: '0.02em' }}>
+            {current?.name ?? 'Пространство'}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+          <div>
+            <h1 style={{ fontFamily: '"Space Grotesk",system-ui,sans-serif', fontSize: isMobile ? 20 : 24, fontWeight: 700, color: c.title, letterSpacing: '-0.5px', margin: '0 0 4px' }}>
+              Дорожные карты
+            </h1>
+            <p style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13, color: c.sub, margin: 0 }}>
+              Откройте любую доску в виде временно́й шкалы
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Boards grid ── */}
+      <div style={{ flex: 1, padding, overflowY: 'auto' }}>
+        {loading ? (
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 60 }}>
+            <div style={{ width: 28, height: 28, border: `2px solid ${c.border}`, borderTopColor: '#4F6EF7', borderRadius: '50%', animation: 'rm-spin .8s linear infinite' }} />
+            <style>{`@keyframes rm-spin{to{transform:rotate(360deg)}}`}</style>
+          </div>
+        ) : boards.length === 0 ? (
+          <div style={{ padding: '60px 24px', textAlign: 'center', color: c.sub, fontFamily: '"Inter",system-ui,sans-serif', fontSize: 14 }}>
+            Нет досок. Создайте первую в разделе <span style={{ color: '#4F6EF7', cursor: 'pointer' }} onClick={() => navigate(`/w/${slug}`)}>Доски</span>.
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: 16 }}>
+            {boards.map(board => {
+              const color     = boardColor(board.name);
+              const taskCount = board._count?.tasks ?? 0;
+              const statuses  = board.workflow?.statuses ?? [];
+
+              return (
+                <div
+                  key={board.id}
+                  style={{
+                    background: c.cardBg, border: `1px solid ${c.cardBorder}`,
+                    borderRadius: 14, padding: '20px 22px', cursor: 'default',
+                    display: 'flex', flexDirection: 'column', gap: 0,
+                    boxShadow: isDark ? 'none' : '0 2px 8px rgba(79,110,247,.05)',
+                    transition: 'border-color .14s, box-shadow .12s',
+                  }}
+                >
+                  {/* Card header */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+                    <div style={{ width: 34, height: 34, background: color, borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                      <span style={{ fontFamily: '"Space Grotesk",system-ui,sans-serif', fontSize: 13, fontWeight: 700, color: '#fff' }}>
+                        {board.name[0]?.toUpperCase()}
+                      </span>
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontFamily: '"Space Grotesk",system-ui,sans-serif', fontSize: 15, fontWeight: 600, color: c.cardTitle, letterSpacing: '-.2px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                        {board.name}
+                      </div>
+                      <div style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.cardSub, marginTop: 2 }}>
+                        {board.prefix}{board.description ? ` · ${board.description}` : ''}
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Status pills */}
+                  {statuses.length > 0 && (
+                    <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginBottom: 12 }}>
+                      {statuses.slice(0, 4).map(s => (
+                        <div key={s.id} style={{ display: 'flex', alignItems: 'center', gap: 4, background: c.pillBg, borderRadius: 5, padding: '3px 8px' }}>
+                          <div style={{ width: 6, height: 6, borderRadius: '50%', background: s.color, flexShrink: 0 }} />
+                          <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.pillText }}>{s.name}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Mini preview */}
+                  <div style={{
+                    background: isDark ? 'rgba(255,255,255,.025)' : 'rgba(79,110,247,.04)',
+                    borderRadius: 8, padding: '8px 12px', marginBottom: 16, position: 'relative', overflow: 'hidden',
+                  }}>
+                    <MiniPreview color={color} />
+                  </div>
+
+                  {/* Footer */}
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.cardSub }}>
+                      {pluralTasks(taskCount)}
+                    </span>
+                    <button
+                      onClick={() => navigate(`/w/${slug}/boards/${board.prefix.toLowerCase()}?view=roadmap`)}
+                      style={{
+                        display: 'flex', alignItems: 'center', gap: 5,
+                        padding: '7px 14px', background: 'rgba(79,110,247,.1)',
+                        border: '1px solid rgba(79,110,247,.25)', borderRadius: 8,
+                        cursor: 'pointer', fontFamily: '"Inter",system-ui,sans-serif',
+                        fontSize: 12, fontWeight: 600, color: '#4F6EF7',
+                        transition: 'background .14s, border-color .14s',
+                      }}
+                      onMouseEnter={e => {
+                        (e.currentTarget as HTMLButtonElement).style.background = '#4F6EF7';
+                        (e.currentTarget as HTMLButtonElement).style.color = '#fff';
+                        (e.currentTarget as HTMLButtonElement).style.borderColor = '#4F6EF7';
+                      }}
+                      onMouseLeave={e => {
+                        (e.currentTarget as HTMLButtonElement).style.background = 'rgba(79,110,247,.1)';
+                        (e.currentTarget as HTMLButtonElement).style.color = '#4F6EF7';
+                        (e.currentTarget as HTMLButtonElement).style.borderColor = 'rgba(79,110,247,.25)';
+                      }}
+                    >
+                      <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+                        <line x1="1" y1="4"   x2="9"  y2="4"   stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                        <line x1="5" y1="7.5" x2="13" y2="7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                        <line x1="2" y1="11"  x2="10" y2="11"  stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                      </svg>
+                      Открыть дорожную карту
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -259,7 +259,7 @@ export default function WorkspaceDashboardPage() {
       incrementBoardCount(current.id);
       message.success(`Доска "${board.name}" создана`);
       closeModal();
-      navigate(`/w/${slug}/boards/${board.id}`);
+      navigate(`/w/${slug}/boards/${board.prefix.toLowerCase()}`);
     } catch (e: unknown) {
       const err = e as { response?: { data?: { error?: string } } };
       message.error(err?.response?.data?.error ?? 'Не удалось создать доску');
@@ -431,7 +431,7 @@ export default function WorkspaceDashboardPage() {
             {boards.map(board => (
               <BoardCard
                 key={board.id} board={board} c={c} isDark={isDark}
-                onClick={() => navigate(`/w/${slug}/boards/${board.id}`)}
+                onClick={() => navigate(`/w/${slug}/boards/${board.prefix.toLowerCase()}`)}
               />
             ))}
           </div>

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -4,7 +4,7 @@ import { message } from 'antd';
 import { useWorkspaceStore } from '../store/workspace.store';
 import { useThemeStore } from '../store/theme.store';
 import { useBreakpoint } from '../utils/useBreakpoint';
-import type { Board } from '../types';
+import type { Board, WorkspaceEvent } from '../types';
 import * as workspacesApi from '../api/workspaces';
 import * as boardsApi from '../api/boards';
 
@@ -218,6 +218,7 @@ export default function WorkspaceDashboardPage() {
 
   const { workspaces, current, setCurrent, loading: wsLoading, load, incrementBoardCount } = useWorkspaceStore();
   const [boards, setBoards] = useState<Board[]>([]);
+  const [activity, setActivity] = useState<WorkspaceEvent[]>([]);
   const [boardsLoading, setBoardsLoading] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -244,6 +245,9 @@ export default function WorkspaceDashboardPage() {
       .then(setBoards)
       .catch(() => setBoards([]))
       .finally(() => setBoardsLoading(false));
+    workspacesApi.getWorkspaceHistory(current.id)
+      .then(evs => setActivity(evs.slice(0, 6)))
+      .catch(() => {});
   }, [current?.id]);
 
   const onCreateBoard = async () => {
@@ -399,7 +403,70 @@ export default function WorkspaceDashboardPage() {
       </div>
 
       {/* ── Content ──────────────────────────────────────────────────────── */}
-      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, padding: '28px 48px' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, padding: isMobile ? '20px 16px' : '28px 48px', overflowY: 'auto' }}>
+
+        {/* Quick nav */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 12, marginBottom: 32 }}>
+          {[
+            {
+              title: 'Мои задачи',
+              desc: 'Назначенные вам задачи',
+              color: '#4F6EF7',
+              icon: (
+                <svg width="17" height="17" viewBox="0 0 18 18" fill="none">
+                  <path d="M3 5.5h7M3 9h5M3 12.5h4" stroke="#4F6EF7" strokeWidth="1.5" strokeLinecap="round"/>
+                  <circle cx="13" cy="11" r="3.5" stroke="#4F6EF7" strokeWidth="1.4"/>
+                  <path d="M11.8 11l.8.8 1.7-1.7" stroke="#4F6EF7" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              ),
+              onClick: () => navigate('/my-tasks'),
+            },
+            {
+              title: 'Дорожные карты',
+              desc: `${boards.length} ${boards.length === 1 ? 'доска' : boards.length < 5 ? 'доски' : 'досок'} · сроки и прогресс`,
+              color: '#F59E0B',
+              icon: (
+                <svg width="17" height="17" viewBox="0 0 18 18" fill="none">
+                  <line x1="2" y1="5"  x2="12" y2="5"  stroke="#F59E0B" strokeWidth="1.6" strokeLinecap="round"/>
+                  <line x1="6" y1="9"  x2="16" y2="9"  stroke="#F59E0B" strokeWidth="1.6" strokeLinecap="round"/>
+                  <line x1="3" y1="13" x2="13" y2="13" stroke="#F59E0B" strokeWidth="1.6" strokeLinecap="round"/>
+                </svg>
+              ),
+              onClick: () => navigate(`/w/${slug}/roadmaps`),
+            },
+          ].map(item => (
+            <div
+              key={item.title}
+              onClick={item.onClick}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 12,
+                background: c.cardBg, border: `1px solid ${c.cardBorder}`,
+                borderRadius: 12, padding: '14px 16px', cursor: 'pointer',
+                transition: 'border-color .14s, box-shadow .12s',
+              }}
+              onMouseEnter={e => {
+                (e.currentTarget as HTMLDivElement).style.borderColor = 'rgba(79,110,247,.35)';
+                (e.currentTarget as HTMLDivElement).style.boxShadow = '0 2px 12px rgba(79,110,247,.06)';
+              }}
+              onMouseLeave={e => {
+                (e.currentTarget as HTMLDivElement).style.borderColor = c.cardBorder;
+                (e.currentTarget as HTMLDivElement).style.boxShadow = 'none';
+              }}
+            >
+              <div style={{ width: 34, height: 34, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, background: `${item.color}18` }}>
+                {item.icon}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13, fontWeight: 600, color: c.cardTitle }}>{item.title}</div>
+                <div style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.cardSub, marginTop: 2 }}>{item.desc}</div>
+              </div>
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ flexShrink: 0, color: c.cardSub }}>
+                <path d="M5 3l4 4-4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </div>
+          ))}
+        </div>
+
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 18 }}>
           <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, fontWeight: 600, color: c.secLbl, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
             Доски · {boards.length}
@@ -434,6 +501,48 @@ export default function WorkspaceDashboardPage() {
                 onClick={() => navigate(`/w/${slug}/boards/${board.prefix.toLowerCase()}`)}
               />
             ))}
+          </div>
+        )}
+
+        {/* ── Activity ──────────────────────────────────────────────────── */}
+        {activity.length > 0 && (
+          <div style={{ marginTop: 36 }}>
+            <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, fontWeight: 600, color: c.secLbl, letterSpacing: '0.08em', textTransform: 'uppercase', display: 'block', marginBottom: 14 }}>
+              Последняя активность
+            </span>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+              {activity.map(ev => {
+                const name = ev.user?.name ?? 'Кто-то';
+                const nameParts = name.trim().split(/\s+/);
+                const isFem = /[аяАЯ]$/u.test(nameParts[nameParts.length - 1] ?? '');
+                const ACTION_LABELS: Record<string, string> = {
+                  workspace_created: isFem ? 'создала пространство' : 'создал пространство',
+                  workspace_updated: isFem ? 'обновила настройки' : 'обновил настройки',
+                  member_added:      isFem ? 'добавила участника' : 'добавил участника',
+                  member_removed:    isFem ? 'удалила участника' : 'удалил участника',
+                  board_created:     isFem ? 'создала доску' : 'создал доску',
+                  board_deleted:     isFem ? 'удалила доску' : 'удалил доску',
+                  member_role_changed: isFem ? 'изменила роль' : 'изменил роль',
+                };
+                const label = ACTION_LABELS[ev.action] ?? ev.action;
+                const time  = new Date(ev.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+                const AVATAR_COLORS = ['#4F6EF7','#8B5CF6','#F59E0B','#34D399','#F87171','#38BDF8'];
+                const avColor = AVATAR_COLORS[(name.charCodeAt(0) ?? 0) % AVATAR_COLORS.length];
+                const initials = name.split(/\s+/).map((p: string) => p[0]).slice(0,2).join('').toUpperCase();
+
+                return (
+                  <div key={ev.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: `1px solid ${c.cardBorder}` }}>
+                    <div style={{ width: 26, height: 26, borderRadius: '50%', background: avColor, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 9, fontWeight: 700, color: '#fff' }}>{initials}</span>
+                    </div>
+                    <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13, color: c.cardSub, flex: 1 }}>
+                      <span style={{ color: c.cardTitle, fontWeight: 500 }}>{name}</span> {label}
+                    </span>
+                    <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.cardSub, flexShrink: 0 }}>{time}</span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- **WorkspaceDashboardPage** — quick nav карточки (Мои задачи / Дорожные карты) + лента активности из workspace history
- **RoadmapsPage** — хаб `/w/:slug/roadmaps` со списком досок, кнопка «Открыть дорожную карту» → deep link `?view=roadmap`
- **AppLayout** — вкладка Roadmaps в топбаре, точная проверка `isBoards`
- **BoardPage** — читает `?view=roadmap` из URL для deep link из хаба
- **Code review fixes** — private board guard (CRITICAL), валидация дат, getToday() вместо стейл TODAY, onUpdated propagation, error handling

## Test plan
- [ ] `/w/:slug` — видны карточки «Мои задачи» и «Дорожные карты» + активность внизу
- [ ] Клик «Дорожные карты» → `/w/:slug/roadmaps` со списком досок
- [ ] Клик «Открыть дорожную карту» → BoardPage с активным roadmap view
- [ ] Топбар: вкладка Roadmaps подсвечивается на `/roadmaps` маршруте
- [ ] VIEWER не может получить данные приватной доски через `/api/boards/:id/roadmap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)