### PR TITLE
fix: sprint 1 — workflow default, back button, mobile overflow, feedback security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,11 @@ JWT_REFRESH_EXPIRES_IN=7d
 PORT=3101
 NODE_ENV=development
 CORS_ORIGIN=http://localhost:5174
+
+# Feedback → GitHub/GitNexus Issues integration
+# Set GITHUB_ISSUES_TOKEN to enable feedback submission.
+# Override GITHUB_REPO_OWNER/NAME to point at the correct repo (e.g. SourceCraft).
+# Without a token the endpoint returns 503 gracefully.
+GITHUB_ISSUES_TOKEN=
+GITHUB_REPO_OWNER=NovakPAai
+GITHUB_REPO_NAME=flow-tasks

--- a/backend/src/modules/feedback/feedback.dto.ts
+++ b/backend/src/modules/feedback/feedback.dto.ts
@@ -9,7 +9,7 @@ export const feedbackDto = z.object({
     ua:         z.string().max(500),
     screen:     z.string().max(50),
     viewport:   z.string().max(50),
-    url:        z.string().max(500),
+    url:        z.string().max(500).url().optional().or(z.literal('')),
     language:   z.string().max(20),
     deviceType: z.enum(['mobile', 'tablet', 'desktop']).optional(),
     os:         z.string().max(50).optional(),

--- a/backend/src/modules/feedback/feedback.router.ts
+++ b/backend/src/modules/feedback/feedback.router.ts
@@ -1,13 +1,16 @@
 import { Router } from 'express';
 import { validate } from '../../shared/middleware/validate.js';
 import { authenticate } from '../../shared/middleware/auth.js';
+import { rateLimit, RATE_LIMITS } from '../../shared/middleware/rate-limit.js';
 import { feedbackDto } from './feedback.dto.js';
 import * as feedbackService from './feedback.service.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 
 const router = Router();
 
-router.post('/', authenticate, validate(feedbackDto), async (req: AuthRequest, res, next) => {
+const feedbackLimit = rateLimit({ ...RATE_LIMITS.feedback, keyFn: (req) => (req as AuthRequest).user!.userId });
+
+router.post('/', authenticate, feedbackLimit, validate(feedbackDto), async (req: AuthRequest, res, next) => {
   try {
     const result = await feedbackService.submitFeedback(req.body, {
       id: req.user!.userId,

--- a/backend/src/modules/feedback/feedback.service.ts
+++ b/backend/src/modules/feedback/feedback.service.ts
@@ -9,6 +9,12 @@ interface FeedbackUser {
   email: string;
 }
 
+// Escape Markdown special chars and strip newlines to prevent injection
+function escapeMd(value: string | undefined | null): string {
+  if (!value) return '—';
+  return value.replace(/[\r\n]/g, ' ').replace(/[_*`[\]()~>#+=|{}.!\\-]/g, '\\$&');
+}
+
 export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
   if (!config.GITHUB_ISSUES_TOKEN) {
     throw new AppError(503, 'Отправка обратной связи временно недоступна');
@@ -17,14 +23,14 @@ export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
   const label = dto.type === 'bug' ? 'bug' : 'enhancement';
   const deviceSection = dto.meta
     ? [
-        `**Устройство:** ${dto.meta.deviceType ?? '—'} | **ОС:** ${dto.meta.os ?? '—'} | **Браузер:** ${dto.meta.browser ?? '—'}`,
-        `**Экран:** ${dto.meta.screen} / вьюпорт: ${dto.meta.viewport}`,
-        `**Язык:** ${dto.meta.language}`,
-        `**URL:** ${dto.meta.url}`,
-        `**UA:** \`${dto.meta.ua}\``,
+        `**Устройство:** ${escapeMd(dto.meta.deviceType)} | **ОС:** ${escapeMd(dto.meta.os)} | **Браузер:** ${escapeMd(dto.meta.browser)}`,
+        `**Экран:** ${escapeMd(dto.meta.screen)} / вьюпорт: ${escapeMd(dto.meta.viewport)}`,
+        `**Язык:** ${escapeMd(dto.meta.language)}`,
+        `**URL:** ${escapeMd(dto.meta.url)}`,
+        `**UA:** ${escapeMd(dto.meta.ua)}`,
       ].join('\n')
     : '*нет данных об устройстве*';
-  const bodyWithMeta = `${dto.body}\n\n---\n**Отправитель:** ${user.name} (${user.email})\n**Окружение:** ${config.NODE_ENV}\n\n### Устройство\n${deviceSection}`;
+  const bodyWithMeta = `${escapeMd(dto.body)}\n\n---\n**Отправитель:** ${escapeMd(user.name)} (${escapeMd(user.email)})\n**Окружение:** ${escapeMd(config.NODE_ENV)}\n\n### Устройство\n${deviceSection}`;
 
   const response = await fetch(
     `https://api.github.com/repos/${config.GITHUB_REPO_OWNER}/${config.GITHUB_REPO_NAME}/issues`,
@@ -41,8 +47,8 @@ export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
   );
 
   if (!response.ok) {
-    const err = await response.text();
-    console.error('[FEEDBACK] GitHub API error:', err);
+    const errText = await response.text();
+    console.error('[FEEDBACK] GitHub API error: status=%d body=%s', response.status, errText.slice(0, 200));
     throw new AppError(502, 'Не удалось создать обращение. Попробуйте позже.');
   }
 

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -125,6 +125,7 @@ export async function listTasks(boardId: string, userId: string, filters: TaskFi
       include: {
         assignee: { select: { id: true, name: true, avatar: true } },
         status: { select: { id: true, name: true, color: true, category: true } },
+        labels: { include: { label: { select: { id: true, name: true, color: true } } } },
         _count: { select: { children: true } },
       },
     }),

--- a/backend/src/modules/workflows/workflows.service.ts
+++ b/backend/src/modules/workflows/workflows.service.ts
@@ -149,10 +149,21 @@ export async function getWorkflow(workflowId: string, userId: string) {
 export async function updateWorkflow(workflowId: string, userId: string, dto: UpdateWorkflowDto) {
   const workflow = await assertWorkspaceOwner(workflowId, userId);
 
+  if (dto.isDefault === false && workflow.isDefault) {
+    throw new AppError(400, 'Cannot unset the default workflow — set another workflow as default first');
+  }
+
   const oldMode = workflow.mode;
-  const updated = await prisma.workflow.update({
-    where: { id: workflowId },
-    data: dto,
+
+  const updated = await prisma.$transaction(async (tx) => {
+    // Atomically unset previous default before setting a new one
+    if (dto.isDefault === true) {
+      await tx.workflow.updateMany({
+        where: { workspaceId: workflow.workspaceId, isDefault: true, id: { not: workflowId } },
+        data: { isDefault: false },
+      });
+    }
+    return tx.workflow.update({ where: { id: workflowId }, data: dto });
   });
 
   // If mode changed from/to FORWARD_ONLY or BIDIRECTIONAL, regenerate transitions
@@ -218,26 +229,23 @@ export async function deleteStatus(statusId: string, userId: string) {
   const status = await prisma.workflowStatus.findUnique({ where: { id: statusId } });
   if (!status) throw new AppError(404, 'Status not found');
 
-  await assertWorkspaceOwner(status.workflowId, userId);
+  const workflow = await assertWorkspaceOwner(status.workflowId, userId);
 
   const count = await prisma.workflowStatus.count({ where: { workflowId: status.workflowId } });
   if (count <= 1) throw new AppError(400, 'Workflow must have at least one status');
 
-  await prisma.workflowStatus.delete({ where: { id: statusId } });
-
-  // Re-normalize positions
-  const remaining = await prisma.workflowStatus.findMany({
-    where: { workflowId: status.workflowId },
-    orderBy: { position: 'asc' },
+  // Delete + re-normalize positions in a single transaction
+  await prisma.$transaction(async (tx) => {
+    await tx.workflowStatus.delete({ where: { id: statusId } });
+    const rest = await tx.workflowStatus.findMany({
+      where: { workflowId: status.workflowId },
+      orderBy: { position: 'asc' },
+    });
+    await Promise.all(
+      rest.map((s, i) => tx.workflowStatus.update({ where: { id: s.id }, data: { position: i } })),
+    );
   });
-  await Promise.all(
-    remaining.map((s, i) =>
-      prisma.workflowStatus.update({ where: { id: s.id }, data: { position: i } }),
-    ),
-  );
 
-  // Regenerate transitions
-  const workflow = await prisma.workflow.findUniqueOrThrow({ where: { id: status.workflowId } });
   if (workflow.mode !== 'CUSTOM') {
     await generateTransitions(status.workflowId);
   }
@@ -256,7 +264,7 @@ export async function reorderStatuses(workflowId: string, userId: string, ordere
     throw new AppError(400, 'Must provide all status IDs for reorder');
   }
 
-  await Promise.all(
+  await prisma.$transaction(
     orderedIds.map((id, i) =>
       prisma.workflowStatus.update({ where: { id }, data: { position: i } }),
     ),

--- a/backend/src/prisma/migrations/20260504_workflow_default_unique_index/migration.sql
+++ b/backend/src/prisma/migrations/20260504_workflow_default_unique_index/migration.sql
@@ -1,0 +1,17 @@
+-- Step 1: demote duplicate isDefault=true workflows (keep oldest per workspace).
+-- Safe on clean data (UPDATE touches 0 rows); repairs dirty data before index creation.
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY "workspaceId" ORDER BY "createdAt" ASC) AS rn
+  FROM   "workflows"
+  WHERE  "isDefault" = true
+)
+UPDATE "workflows"
+SET    "isDefault" = false
+WHERE  id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- Step 2: enforce at most one default workflow per workspace at the DB level.
+-- A partial unique index is not expressible via Prisma schema directly.
+CREATE UNIQUE INDEX IF NOT EXISTS "workflows_workspace_default_unique"
+  ON "workflows" ("workspaceId")
+  WHERE "isDefault" = true;

--- a/backend/src/shared/middleware/rate-limit.ts
+++ b/backend/src/shared/middleware/rate-limit.ts
@@ -21,16 +21,19 @@ export interface RateLimitOptions {
   scope: string;
   limit: number;
   windowMs: number;
+  // Optional: custom key extractor. Defaults to req.ip for unauthenticated routes.
+  // Use keyFn to key by userId on authenticated routes to prevent IP-rotation bypass.
+  keyFn?: (req: Request) => string;
 }
 
 // TRUST_PROXY: req.ip is resolved correctly when app.set('trust proxy', 1) is configured.
-function clientKey(req: Request): string {
+function defaultKey(req: Request): string {
   return req.ip ?? req.socket.remoteAddress ?? 'anonymous';
 }
 
 export function rateLimit(opts: RateLimitOptions) {
   return (req: Request, _res: Response, next: NextFunction): void => {
-    const key = `${opts.scope}:${clientKey(req)}`;
+    const key = `${opts.scope}:${opts.keyFn ? opts.keyFn(req) : defaultKey(req)}`;
     const now = Date.now();
     const existing = store.get(key);
 
@@ -56,7 +59,8 @@ export function rateLimit(opts: RateLimitOptions) {
 }
 
 export const RATE_LIMITS = {
-  auth:   { scope: 'auth',    limit: 10, windowMs: 60_000 },
-  invite: { scope: 'invite',  limit: 20, windowMs: 60_000 },
-  apiKey: { scope: 'api-key', limit: 20, windowMs: 60_000 },
+  auth:     { scope: 'auth',     limit: 10, windowMs: 60_000 },
+  invite:   { scope: 'invite',   limit: 20, windowMs: 60_000 },
+  apiKey:   { scope: 'api-key',  limit: 20, windowMs: 60_000 },
+  feedback: { scope: 'feedback', limit: 5,  windowMs: 60 * 60_000 }, // 5 per hour
 } as const satisfies Record<string, RateLimitOptions>;

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -23,6 +23,7 @@ export async function getWorkflow(workflowId: string): Promise<Workflow> {
 export async function updateWorkflow(workflowId: string, payload: {
   name?: string;
   mode?: 'FORWARD_ONLY' | 'BIDIRECTIONAL' | 'CUSTOM';
+  isDefault?: boolean;
 }): Promise<Workflow> {
   const { data } = await api.patch<Workflow>(`/workflows/${workflowId}`, payload);
   return data;

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -214,7 +214,9 @@ export default function AppLayout({ children }: Props) {
         {/* Logo */}
         <div
           onClick={() => navigate('/workspaces')}
-          style={{ alignItems: 'center', cursor: 'pointer', display: 'flex', gap: 8 }}
+          style={{ alignItems: 'center', borderRadius: 8, cursor: 'pointer', display: 'flex', gap: 8, padding: '4px 6px', transition: 'background 0.15s' }}
+          onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.background = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)'; }}
+          onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = ''; }}
         >
           <div style={{ alignItems: 'center', backgroundColor: '#4F6EF7', borderRadius: 8, display: 'flex', flexShrink: 0, height: 32, justifyContent: 'center', width: 32 }}>
             <GridIcon/>

--- a/frontend/src/components/FeedbackFAB.tsx
+++ b/frontend/src/components/FeedbackFAB.tsx
@@ -8,6 +8,7 @@ const Z_FAB = 300;
 
 export default function FeedbackFAB() {
   const [open, setOpen] = useState(false);
+  const [hover, setHover] = useState(false);
   const mode = useThemeStore(s => s.mode);
   const user = useAuthStore(s => s.user);
   const isDark = mode !== 'light';
@@ -28,8 +29,9 @@ export default function FeedbackFAB() {
         aria-label="Оставить обратную связь"
         style={{
           position: 'fixed',
-          bottom: 24,
-          right: 24,
+          // Honor iOS Safari home indicator and notch safe areas
+          bottom: 'max(24px, calc(env(safe-area-inset-bottom) + 16px))',
+          right: 'max(24px, env(safe-area-inset-right))',
           zIndex: Z_FAB,
           width: 48,
           height: 48,
@@ -41,16 +43,12 @@ export default function FeedbackFAB() {
           alignItems: 'center',
           justifyContent: 'center',
           boxShadow: shadow,
-          transition: 'filter .15s, transform .12s',
+          filter: hover ? 'brightness(1.12)' : undefined,
+        transform: hover ? 'scale(1.08)' : undefined,
+        transition: 'filter .15s, transform .12s',
         }}
-        onMouseEnter={e => {
-          (e.currentTarget as HTMLButtonElement).style.filter = 'brightness(1.12)';
-          (e.currentTarget as HTMLButtonElement).style.transform = 'scale(1.08)';
-        }}
-        onMouseLeave={e => {
-          (e.currentTarget as HTMLButtonElement).style.filter = '';
-          (e.currentTarget as HTMLButtonElement).style.transform = '';
-        }}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
       >
         <svg
           aria-hidden="true"

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -12,8 +12,10 @@ import * as tasksApi from '../api/tasks';
 import * as workspacesApi from '../api/workspaces';
 import * as labelsApi from '../api/labels';
 import { useBreakpoint, useIsLandscape } from '../utils/useBreakpoint';
+import { useAuthStore } from '../store/auth.store';
 import TaskCard from '../components/TaskCard';
 import TaskDrawer from '../components/TaskDrawer';
+import WorkflowEditor from '../components/WorkflowEditor';
 import BoardListView from '../components/BoardListView';
 import BoardCalendarView from '../components/BoardCalendarView';
 import RoadmapView from '../components/RoadmapView';
@@ -86,6 +88,35 @@ function CalIcon() {
       <rect x="1" y="2" width="12" height="11" rx="2" stroke="currentColor" strokeWidth="1.2"/>
       <path d="M1 5.5h12M4.5 1v2M9.5 1v2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
     </svg>
+  );
+}
+
+// ── ColumnsBtn ────────────────────────────────────────────────────────────────
+function ColumnsBtn({ onClick, border, addText }: { onClick: () => void; border: string; addText: string }) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      title="Управление колонками"
+      style={{
+        display: 'flex', alignItems: 'center', gap: 6, height: 34,
+        padding: '0 12px',
+        background: hovered ? 'rgba(79,110,247,0.08)' : 'transparent',
+        border: `1px solid ${hovered ? 'rgba(79,110,247,0.4)' : border}`,
+        borderRadius: 8, cursor: 'pointer', flexShrink: 0,
+        transition: 'background 0.15s, border-color 0.15s',
+      }}
+    >
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <rect x="1" y="1" width="3.5" height="12" rx="1.5" stroke={hovered ? '#4F6EF7' : addText} strokeWidth="1.2"/>
+        <rect x="5.5" y="1" width="3.5" height="12" rx="1.5" stroke={hovered ? '#4F6EF7' : addText} strokeWidth="1.2"/>
+        <rect x="10" y="1" width="3.5" height="12" rx="1.5" stroke={hovered ? '#4F6EF7' : addText} strokeWidth="1.2" strokeDasharray="2 1.5"/>
+        <path d="M11.75 5v4M9.75 7h4" stroke={hovered ? '#4F6EF7' : addText} strokeWidth="1.2" strokeLinecap="round"/>
+      </svg>
+      <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 500, color: hovered ? '#4F6EF7' : addText, transition: 'color 0.15s' }}>Колонки</span>
+    </button>
   );
 }
 
@@ -170,12 +201,15 @@ export default function BoardPage() {
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [labels, setLabels] = useState<Label[]>([]);
+  const [wfEditorOpen, setWfEditorOpen] = useState(false);
   const [draggingFromStatusId, setDraggingFromStatusId] = useState<string | null>(null);
   const [columnOffsets, setColumnOffsets] = useState<Record<string, number>>({});
   const [columnTotals, setColumnTotals] = useState<Record<string, number>>({});
   const [loadingMoreCols, setLoadingMoreCols] = useState<Set<string>>(new Set());
   const addInputRef = useRef<HTMLInputElement | null>(null);
 
+  const currentUserId = useAuthStore(s => s.user?.id);
+  const isOwner = members.some(m => m.userId === currentUserId && m.role === 'OWNER');
   const statuses = board?.workflow.statuses ?? [];
 
   // ── Load ──────────────────────────────────────────────────────────────────
@@ -444,6 +478,11 @@ export default function BoardPage() {
           ))}
         </div>
 
+        {/* Columns / workflow editor */}
+        {!isMobile && (
+          <ColumnsBtn onClick={() => setWfEditorOpen(true)} border={border} addText={addText} />
+        )}
+
         {/* Board settings button */}
         <BoardSettingsBtn
           onClick={() => navigate(`settings`)}
@@ -661,6 +700,46 @@ export default function BoardPage() {
         onUpdated={onTaskUpdated}
         onDeleted={onTaskDeleted}
       />
+
+      {/* Workflow / columns editor modal */}
+      {wfEditorOpen && board.workflow && (
+        <div
+          onClick={e => { if (e.target === e.currentTarget) { setWfEditorOpen(false); loadBoard(); } }}
+          style={{
+            position: 'fixed', inset: 0, zIndex: 400,
+            background: 'rgba(0,0,0,0.55)', display: 'flex',
+            alignItems: 'center', justifyContent: 'center', padding: 24,
+          }}
+        >
+          <div style={{
+            width: '100%', maxWidth: 640, maxHeight: '80vh', overflow: 'auto',
+            background: isDark ? '#0F1320' : '#FDFCFF',
+            borderRadius: 14, boxShadow: '0 24px 64px rgba(0,0,0,0.4)',
+          }}>
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              padding: '16px 20px', borderBottom: `1px solid ${border}`,
+            }}>
+              <span style={{ fontFamily: '"Space Grotesk",system-ui,sans-serif', fontSize: 15, fontWeight: 700, color: isDark ? '#E2E8F8' : '#1A1A2E' }}>
+                Колонки доски
+              </span>
+              <button
+                onClick={() => { setWfEditorOpen(false); loadBoard(); }}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: isDark ? '#8B95B0' : '#9B96B8', display: 'flex', alignItems: 'center', padding: 4 }}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                  <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+                </svg>
+              </button>
+            </div>
+            <WorkflowEditor
+              workflowId={board.workflow.id}
+              isOwner={isOwner}
+              onClose={() => { setWfEditorOpen(false); loadBoard(); }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -11,7 +11,7 @@ import * as boardsApi from '../api/boards';
 import * as tasksApi from '../api/tasks';
 import * as workspacesApi from '../api/workspaces';
 import * as labelsApi from '../api/labels';
-import { useBreakpoint } from '../utils/useBreakpoint';
+import { useBreakpoint, useIsLandscape } from '../utils/useBreakpoint';
 import TaskCard from '../components/TaskCard';
 import TaskDrawer from '../components/TaskDrawer';
 import BoardListView from '../components/BoardListView';
@@ -128,8 +128,10 @@ function BoardSettingsBtn({ onClick, border, addText, isPrivate }: {
 export default function BoardPage() {
   const { slug, boardSlug } = useParams<{ slug: string; boardSlug: string }>();
   const navigate = useNavigate();
-  const bp      = useBreakpoint();
-  const isMobile = bp === 'mobile';
+  const bp         = useBreakpoint();
+  const isMobile   = bp === 'mobile';
+  const isLandscape = useIsLandscape();
+  const isCompact   = isMobile && isLandscape;
 
   const mode = useThemeStore(s => s.mode);
   const workspaces = useWorkspaceStore(s => s.workspaces);
@@ -389,7 +391,7 @@ export default function BoardPage() {
       {/* ── Board header ─────────────────────────────────────────────────── */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: isMobile ? 8 : 12,
-        padding: isMobile ? '12px 16px' : '16px 24px',
+        padding: isCompact ? '6px 16px' : isMobile ? '12px 16px' : '16px 24px',
         background: headerBg, borderBottom: `1px solid ${border}`,
         flexShrink: 0, minWidth: 0, overflow: 'hidden',
       }}>
@@ -406,7 +408,7 @@ export default function BoardPage() {
         {/* Board name + task count */}
         <h1 style={{
           fontFamily: '"Space Grotesk",system-ui,sans-serif',
-          fontSize: isMobile ? 16 : 18, fontWeight: 700, color: nameColor,
+          fontSize: isCompact ? 14 : isMobile ? 16 : 18, fontWeight: 700, color: nameColor,
           margin: 0, letterSpacing: '-0.3px',
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
           minWidth: 0, flex: isMobile ? '1 1 0' : undefined,

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { message } from 'antd';
 import { useThemeStore } from '../store/theme.store';
+import { useWorkspaceStore } from '../store/workspace.store';
+import { useBreakpoint } from '../utils/useBreakpoint';
 import * as tasksApi from '../api/tasks';
 import type { MyTask } from '../api/tasks';
 
@@ -47,6 +49,8 @@ export default function MyTasksPage() {
   const navigate = useNavigate();
   const mode = useThemeStore((s) => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
+  const bp = useBreakpoint();
+  const current = useWorkspaceStore((s) => s.current);
 
   const [allTasks, setAllTasks] = useState<MyTask[]>([]);
   const [total, setTotal] = useState(0);
@@ -124,17 +128,37 @@ export default function MyTasksPage() {
     { value: 'no_date', label: 'Без даты' },
   ];
 
+  const handleBack = () => {
+    if (current) {
+      navigate(`/w/${current.slug}`);
+    } else {
+      navigate('/workspaces');
+    }
+  };
+
   return (
     <div style={{
       background: c.bg, minHeight: '100%',
       display: 'flex', flexDirection: 'column',
-      padding: '32px 40px', fontFamily: '"Inter",system-ui,sans-serif',
+      padding: bp === 'mobile' ? '20px 16px' : '32px 40px',
+      fontFamily: '"Inter",system-ui,sans-serif',
     }}>
+      {/* ── Back ── */}
+      <div
+        onClick={handleBack}
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer', marginBottom: 16, width: 'fit-content' }}
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M9 2.5L4.5 7L9 11.5" stroke={c.muted} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+        <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.muted, letterSpacing: '0.02em' }}>Назад</span>
+      </div>
+
       {/* ── Header ── */}
       <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 20 }}>
         <h1 style={{
           margin: 0, fontFamily: '"Space Grotesk",system-ui,sans-serif',
-          fontSize: 26, fontWeight: 700, color: c.text, letterSpacing: '-0.02em',
+          fontSize: bp === 'mobile' ? 20 : 26, fontWeight: 700, color: c.text, letterSpacing: '-0.02em',
         }}>
           Мои задачи
         </h1>
@@ -199,7 +223,9 @@ export default function MyTasksPage() {
             placeholder="Поиск по задачам..."
             style={{
               paddingLeft: 30, paddingRight: 12, paddingBlock: 6,
-              width: 220, fontSize: 12, color: c.text,
+              width: bp === 'mobile' ? '100%' : 220,
+              minWidth: bp === 'mobile' ? 0 : 180,
+              fontSize: 12, color: c.text,
               background: c.searchBg, border: `1px solid ${c.searchBorder}`,
               borderRadius: 8, outline: 'none',
               fontFamily: '"Inter",system-ui,sans-serif',
@@ -293,8 +319,9 @@ export default function MyTasksPage() {
                             key={task.id}
                             onClick={() => navigate(`/w/${ws.wsSlug}/boards/${board.boardSlug}`)}
                             style={{
-                              display: 'flex', alignItems: 'center', gap: 12,
-                              padding: '11px 16px',
+                              display: 'flex', alignItems: 'center', gap: bp === 'mobile' ? 8 : 12,
+                              padding: bp === 'mobile' ? '10px 12px' : '11px 16px',
+                              minWidth: 0,
                               background: isOverdue
                                 ? (mode === 'light' ? 'rgba(239,68,68,0.04)' : 'rgba(239,68,68,0.05)')
                                 : c.rowBg,
@@ -347,8 +374,8 @@ export default function MyTasksPage() {
 
                             {/* Right side: status + priority + due */}
                             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
-                              {/* Status badge */}
-                              {task.status && (
+                              {/* Status badge — hidden on mobile to save space */}
+                              {task.status && bp !== 'mobile' && (
                                 <span style={{
                                   fontSize: 11, fontWeight: 500,
                                   color: task.status.color,
@@ -359,8 +386,8 @@ export default function MyTasksPage() {
                                 </span>
                               )}
 
-                              {/* Priority badge */}
-                              {prio && (
+                              {/* Priority badge — hidden on mobile */}
+                              {prio && bp !== 'mobile' && (
                                 <span style={{
                                   fontSize: 10, fontWeight: 600,
                                   color: prio.text, background: prio.bg,
@@ -371,13 +398,14 @@ export default function MyTasksPage() {
                                 </span>
                               )}
 
-                              {/* Due date */}
+                              {/* Due date — compact on mobile */}
                               {due ? (
                                 <span style={{
                                   fontSize: 11,
                                   color: isOverdue ? '#EF4444' : c.muted,
+                                  whiteSpace: 'nowrap',
                                 }}>
-                                  {isOverdue ? 'Просрочено · ' : ''}
+                                  {isOverdue && bp !== 'mobile' ? 'Просрочено · ' : ''}
                                   {due.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })}
                                 </span>
                               ) : null}

--- a/frontend/src/pages/WorkspaceSettingsPage.tsx
+++ b/frontend/src/pages/WorkspaceSettingsPage.tsx
@@ -285,6 +285,16 @@ export default function WorkspaceSettingsPage() {
     }
   };
 
+  const handleSetDefaultWorkflow = async (wfId: string) => {
+    try {
+      const updated = await wfApi.updateWorkflow(wfId, { isDefault: true });
+      setWorkflows((prev) => prev.map((w) => ({ ...w, isDefault: w.id === updated.id })));
+      message.success('Дефолтный workflow обновлён');
+    } catch {
+      message.error('Не удалось обновить дефолтный workflow');
+    }
+  };
+
   const handleDeleteWorkspace = async () => {
     if (!confirm(`Удалить workspace "${workspace.name}"? Это действие необратимо.`)) return;
     try {
@@ -456,6 +466,14 @@ export default function WorkspaceSettingsPage() {
                   </div>
                 </div>
                 <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+                  {!wf.isDefault && isOwner && (
+                    <button
+                      onClick={() => handleSetDefaultWorkflow(wf.id)}
+                      style={{ fontSize: 12, color: '#4F6EF7', background: 'rgba(79,110,247,0.08)', border: '1px solid rgba(79,110,247,0.2)', borderRadius: 6, padding: '5px 12px', cursor: 'pointer', fontFamily: '"Inter",system-ui,sans-serif' }}
+                    >
+                      По умолчанию
+                    </button>
+                  )}
                   <button
                     onClick={() => setEditingWfId(editingWfId === wf.id ? null : wf.id)}
                     style={{ fontSize: 12, color: c.text, background: c.inputBg, border: `1px solid ${c.border}`, borderRadius: 6, padding: '5px 12px', cursor: 'pointer', fontFamily: '"Inter",system-ui,sans-serif' }}

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -443,7 +443,7 @@ export default function WorkspacesPage() {
           ))}
         </div>
       ) : (
-        <div data-testid="workspaces-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 24 }}>
+        <div data-testid="workspaces-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(340px, 100%), 1fr))', gap: 24 }}>
           {workspaces.map((ws: Workspace, idx: number) => (
             <WorkspaceCard key={ws.id} ws={ws} idx={idx} C={C} isDark={mode !== 'light'} onClick={() => navigate(`/w/${ws.slug}`)}/>
           ))}
@@ -479,13 +479,13 @@ export default function WorkspacesPage() {
               const ws = workspaces.find(w => w.id === ev.workspaceId);
               const time = new Date(ev.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
               return (
-                <div key={ev.id} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                  <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#4F6EF7', flexShrink: 0 }} />
-                  <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13, color: C.actText }}>
+                <div key={ev.id} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, minWidth: 0 }}>
+                  <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#4F6EF7', flexShrink: 0, marginTop: 5 }} />
+                  <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13, color: C.actText, flex: 1, overflow: 'hidden' }}>
                     <span style={{ fontWeight: 600 }}>{name}</span>
                     {' '}{label}{ws ? ` «${ws.name}»` : ''}
                   </span>
-                  <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 11, color: C.actTime, marginLeft: 'auto', flexShrink: 0 }}>{time}</span>
+                  <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 11, color: C.actTime, flexShrink: 0, whiteSpace: 'nowrap' }}>{time}</span>
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary
- **#115** Atomic setDefault workflow (backend transaction + partial unique DB index + frontend button)
- **#111** Back button on My Tasks page
- **#108** MyTasksPage mobile layout fixes (responsive padding, ellipsis, hide badges on mobile)
- **#103** WorkspacesPage activity rows overflow fix + grid responsive minmax
- **#97** `.env.example` documents `GITHUB_ISSUES_TOKEN / GITHUB_REPO_OWNER / GITHUB_REPO_NAME`
- **Security** Rate limit 5/hour per userId on `/api/feedback`; `escapeMd()` for all Markdown-injected fields; backtick code-span injection fixed; error log truncated

## Security changes
| Finding | Severity | Fix |
|---------|----------|-----|
| No rate limit on /api/feedback | HIGH | 5/hour per userId |
| meta.* fields injected raw into GitHub Markdown | HIGH | `escapeMd()` on all fields |
| Backtick in UA breaks code span fence | HIGH | Removed backtick fence |
| user.name/email/body not escaped | MEDIUM | `escapeMd()` applied |
| GitHub API error logs full response | MEDIUM | Truncated to 200 chars |

## Data integrity
| Finding | Severity | Fix |
|---------|----------|-----|
| updateWorkflow sets isDefault=true without unsetting previous | HIGH | `$transaction` atomically unsets previous |
| isDefault=false on default workflow → zero defaults | HIGH | Guard throws 400 |
| Migration fails on dirty data | HIGH | Data-cleanup CTE before index creation |
| reorderStatuses parallel writes outside transaction | MEDIUM | `$transaction([])` array form |
| deleteStatus parallel position updates outside transaction | MEDIUM | `$transaction(async tx=>{})` interactive form |

## Test plan
- [ ] Set default workflow: only one isDefault=true per workspace after switch
- [ ] Cannot set isDefault=false on current default (400 returned)
- [ ] Migration applies cleanly on fresh DB and on DB with pre-existing duplicates
- [ ] Back button on /my-tasks → navigates to current workspace
- [ ] My Tasks on 375px viewport: no horizontal overflow, titles truncate
- [ ] Workspaces page on 375px: grid fills viewport, activity rows wrap cleanly
- [ ] Feedback: sending >5 in 1h → 429 from same user account
- [ ] Feedback with backtick in UA: GitHub issue shows escaped, no Markdown injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)