### PR TITLE
fix: skeleton overflow, nginx cache headers, idle session timeout

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowtask-backend",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowtask-backend",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.19.2",
@@ -807,37 +807,37 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
-      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
-      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
-      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.2",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -848,25 +848,25 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
-      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
-      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@redis/bloom": {
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -2591,9 +2591,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3946,15 +3946,15 @@
       "license": "MIT"
     },
     "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.2.0",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
+        "tinyexec": "^1.1.1"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
@@ -3964,9 +3964,9 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -4168,21 +4168,21 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4218,15 +4218,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
-      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.2",
-        "@prisma/engines": "6.19.2"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -4780,9 +4780,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -4986,9 +4986,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/deploy/nginx/flowtask.conf
+++ b/deploy/nginx/flowtask.conf
@@ -1,10 +1,10 @@
 # FlowTask — static frontend + API proxy
 # Place at: /etc/nginx/sites-available/flowtask
 # Enable: ln -s /etc/nginx/sites-available/flowtask /etc/nginx/sites-enabled/
-
-# Security headers snippet — repeated in every location that defines add_header,
-# because nginx drops parent-block add_header directives when a child also uses add_header.
-map $uri $sec_headers_dummy { default 0; }
+#
+# NOTE: nginx drops server-block add_header directives whenever a location block
+# defines its own add_header. Security headers are therefore repeated in every
+# location block that sets any header.
 
 server {
     listen 3200;
@@ -17,7 +17,7 @@ server {
     limit_req_zone $binary_remote_addr zone=flowtask_auth:10m rate=5r/s;
     limit_req_zone $binary_remote_addr zone=flowtask_api:10m rate=30r/s;
 
-    # API proxy → backend PM2 on 3101
+    # ── API proxy → backend PM2 on 3101 ─────────────────────────────────────────
     location /api/ {
         limit_req zone=flowtask_api burst=20 nodelay;
 
@@ -28,6 +28,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 30s;
         client_max_body_size 10m;
@@ -35,9 +36,10 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     }
 
-    # Auth rate limit
+    # Auth endpoints get a tighter rate limit
     location /api/auth/ {
         limit_req zone=flowtask_auth burst=10 nodelay;
 
@@ -46,14 +48,17 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     }
 
-    # index.html — no-store so neither browsers nor intermediate proxies cache it.
-    # Using only add_header (no expires directive) to avoid duplicate Cache-Control headers.
+    # ── index.html ───────────────────────────────────────────────────────────────
+    # no-store: neither browsers nor intermediate proxies may cache the entry point.
+    # Using only add_header (no expires directive) to avoid duplicate Cache-Control.
     location = /index.html {
         try_files $uri /index.html;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
@@ -61,9 +66,11 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
     }
 
-    # SPA fallback — all non-file routes → index.html, same no-store policy.
+    # ── SPA fallback ─────────────────────────────────────────────────────────────
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
@@ -71,11 +78,13 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
     }
 
-    # Hashed static assets — immutable long cache.
-    # Using only add_header (no expires directive) to avoid the duplicate
-    # Cache-Control header that `expires 30d` would append alongside add_header.
+    # ── Hashed static assets — immutable long cache ──────────────────────────────
+    # Files are content-hashed by Vite; hash changes on every code change.
+    # Using only add_header (no expires directive) to avoid duplicate Cache-Control.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         add_header Cache-Control "public, max-age=2592000, immutable" always;
         add_header X-Content-Type-Options "nosniff" always;
@@ -83,11 +92,18 @@ server {
         access_log off;
     }
 
-    # Health check
+    # ── Health check (internal only) ─────────────────────────────────────────────
     location /health {
-        return 200 "flowtask ok\n";
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
+        return 200 "ok\n";
         add_header Content-Type text/plain;
         add_header Cache-Control "no-store" always;
+        add_header X-Content-Type-Options "nosniff" always;
         access_log off;
     }
 }

--- a/deploy/nginx/flowtask.conf
+++ b/deploy/nginx/flowtask.conf
@@ -2,17 +2,16 @@
 # Place at: /etc/nginx/sites-available/flowtask
 # Enable: ln -s /etc/nginx/sites-available/flowtask /etc/nginx/sites-enabled/
 
+# Security headers snippet — repeated in every location that defines add_header,
+# because nginx drops parent-block add_header directives when a child also uses add_header.
+map $uri $sec_headers_dummy { default 0; }
+
 server {
     listen 3200;
     server_name _;
 
     root /opt/flowtask/frontend/dist;
     index index.html;
-
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # Rate limiting
     limit_req_zone $binary_remote_addr zone=flowtask_auth:10m rate=5r/s;
@@ -32,6 +31,10 @@ server {
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 30s;
         client_max_body_size 10m;
+
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
     # Auth rate limit
@@ -43,28 +46,40 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
-    # index.html — never cache so browsers always get the latest entry point
+    # index.html — no-store so neither browsers nor intermediate proxies cache it.
+    # Using only add_header (no expires directive) to avoid duplicate Cache-Control headers.
     location = /index.html {
         try_files $uri /index.html;
-        expires -1;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
-    # SPA fallback — all routes → index.html
+    # SPA fallback — all non-file routes → index.html, same no-store policy.
     location / {
         try_files $uri $uri/ /index.html;
-        expires -1;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
-    # Static assets — long cache
+    # Hashed static assets — immutable long cache.
+    # Using only add_header (no expires directive) to avoid the duplicate
+    # Cache-Control header that `expires 30d` would append alongside add_header.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires 30d;
-        add_header Cache-Control "public, max-age=2592000, immutable";
+        add_header Cache-Control "public, max-age=2592000, immutable" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        etag on;
         access_log off;
     }
 
@@ -72,6 +87,7 @@ server {
     location /health {
         return 200 "flowtask ok\n";
         add_header Content-Type text/plain;
+        add_header Cache-Control "no-store" always;
         access_log off;
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowtask-frontend",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowtask-frontend",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@ant-design/icons": "^5.6.1",
@@ -2962,12 +2962,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -4204,9 +4204,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5807,9 +5807,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -7594,9 +7594,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,9 +32,9 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
   const [showWarning, setShowWarning] = useState(false);
   const [countdown, setCountdown] = useState(WARN_SECONDS);
 
-  const handleIdle = useCallback(async () => {
+  const handleIdle = useCallback(() => {
     setShowWarning(false);
-    try { await logout(); } catch { /* best-effort — navigate regardless */ }
+    void logout().catch(() => {});
     navigate('/login', { state: { timedOut: true } });
   }, [logout, navigate]);
 
@@ -66,9 +66,9 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
     resetTimer();
   }, [resetTimer]);
 
-  const handleLogoutNow = useCallback(async () => {
+  const handleLogoutNow = useCallback(() => {
     setShowWarning(false);
-    try { await logout(); } catch {}
+    void logout().catch(() => {});
     navigate('/login');
   }, [logout, navigate]);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { ConfigProvider, theme, Spin } from 'antd';
 import { useAuthStore } from './store/auth.store';
@@ -6,6 +6,7 @@ import { useThemeStore } from './store/theme.store';
 import { useIdleTimeout } from './hooks/useIdleTimeout';
 import AppLayout from './components/AppLayout';
 import OnboardingProvider from './components/OnboardingProvider';
+import SessionTimeoutModal from './components/SessionTimeoutModal';
 import LoginPage from './pages/LoginPage';
 import HomePage from './pages/HomePage';
 import WorkspacesPage from './pages/WorkspacesPage';
@@ -20,17 +21,56 @@ import ResetPasswordPage from './pages/ResetPasswordPage';
 import RoadmapsPage from './pages/RoadmapsPage';
 import FeedbackFAB from './components/FeedbackFAB';
 
+const WARN_SECONDS = 60;
+
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const user = useAuthStore((s) => s.user);
   const loading = useAuthStore((s) => s.loading);
   const logout = useAuthStore((s) => s.logout);
   const mode = useThemeStore((s) => s.mode);
   const navigate = useNavigate();
+  const [showWarning, setShowWarning] = useState(false);
+  const [countdown, setCountdown] = useState(WARN_SECONDS);
 
-  useIdleTimeout(useCallback(async () => {
-    await logout();
+  const handleIdle = useCallback(async () => {
+    setShowWarning(false);
+    try { await logout(); } catch { /* best-effort — navigate regardless */ }
     navigate('/login', { state: { timedOut: true } });
-  }, [logout, navigate]));
+  }, [logout, navigate]);
+
+  const handleWarn = useCallback(() => {
+    setShowWarning(true);
+    setCountdown(WARN_SECONDS);
+  }, []);
+
+  const handleActivityReset = useCallback(() => {
+    setShowWarning(false);
+  }, []);
+
+  const resetTimer = useIdleTimeout(handleIdle, {
+    onWarn: handleWarn,
+    onActivityReset: handleActivityReset,
+  });
+
+  // Countdown tick while warning modal is open
+  useEffect(() => {
+    if (!showWarning) return;
+    const tick = setInterval(() => {
+      setCountdown((c) => Math.max(0, c - 1));
+    }, 1000);
+    return () => clearInterval(tick);
+  }, [showWarning]);
+
+  const handleStay = useCallback(() => {
+    setShowWarning(false);
+    resetTimer();
+  }, [resetTimer]);
+
+  const handleLogoutNow = useCallback(async () => {
+    setShowWarning(false);
+    try { await logout(); } catch {}
+    navigate('/login');
+  }, [logout, navigate]);
 
   if (loading) {
     return (
@@ -41,9 +81,17 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
   }
   if (!user) return <Navigate to="/login" replace />;
   return (
-    <OnboardingProvider>
-      <AppLayout>{children}</AppLayout>
-    </OnboardingProvider>
+    <>
+      <SessionTimeoutModal
+        open={showWarning}
+        countdown={countdown}
+        onStay={handleStay}
+        onLogout={handleLogoutNow}
+      />
+      <OnboardingProvider>
+        <AppLayout>{children}</AppLayout>
+      </OnboardingProvider>
+    </>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect, useCallback } from 'react';
+import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { ConfigProvider, theme, Spin } from 'antd';
 import { useAuthStore } from './store/auth.store';
 import { useThemeStore } from './store/theme.store';
+import { useIdleTimeout } from './hooks/useIdleTimeout';
 import AppLayout from './components/AppLayout';
 import OnboardingProvider from './components/OnboardingProvider';
 import LoginPage from './pages/LoginPage';
@@ -22,7 +23,14 @@ import FeedbackFAB from './components/FeedbackFAB';
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const user = useAuthStore((s) => s.user);
   const loading = useAuthStore((s) => s.loading);
+  const logout = useAuthStore((s) => s.logout);
   const mode = useThemeStore((s) => s.mode);
+  const navigate = useNavigate();
+
+  useIdleTimeout(useCallback(async () => {
+    await logout();
+    navigate('/login', { state: { timedOut: true } });
+  }, [logout, navigate]));
 
   if (loading) {
     return (

--- a/frontend/src/components/SessionTimeoutModal.tsx
+++ b/frontend/src/components/SessionTimeoutModal.tsx
@@ -1,0 +1,47 @@
+import { Modal, Button } from 'antd';
+
+interface Props {
+  open: boolean;
+  countdown: number;
+  onStay: () => void;
+  onLogout: () => void;
+}
+
+function pluralSeconds(n: number): string {
+  const last2 = n % 100;
+  const last1 = n % 10;
+  if (last2 >= 11 && last2 <= 14) return 'секунд';
+  if (last1 === 1) return 'секунда';
+  if (last1 >= 2 && last1 <= 4) return 'секунды';
+  return 'секунд';
+}
+
+export default function SessionTimeoutModal({ open, countdown, onStay, onLogout }: Props) {
+  return (
+    <Modal
+      open={open}
+      title="Время сессии истекает"
+      closable={false}
+      maskClosable={false}
+      keyboard={false}
+      width={400}
+      footer={[
+        <Button key="logout" onClick={onLogout}>
+          Выйти
+        </Button>,
+        <Button key="stay" type="primary" onClick={onStay} autoFocus>
+          Остаться
+        </Button>,
+      ]}
+    >
+      <p style={{ margin: '8px 0 0', lineHeight: '22px' }}>
+        Вы были неактивны. Сессия завершится через{' '}
+        <strong>{countdown}</strong>{' '}
+        {pluralSeconds(countdown)}.
+      </p>
+      <p style={{ margin: '8px 0 0', lineHeight: '22px', opacity: 0.7, fontSize: 13 }}>
+        Нажмите «Остаться», чтобы продолжить работу.
+      </p>
+    </Modal>
+  );
+}

--- a/frontend/src/hooks/useIdleTimeout.ts
+++ b/frontend/src/hooks/useIdleTimeout.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+
+const IDLE_MS = 5 * 60 * 1000; // 5 minutes
+
+const ACTIVITY_EVENTS = [
+  'mousemove', 'mousedown', 'keydown',
+  'scroll', 'touchstart', 'click',
+] as const;
+
+/**
+ * Calls onIdle after idleMs of no user activity.
+ * Timer resets on mousemove, mousedown, keydown, scroll, touchstart, click.
+ */
+export function useIdleTimeout(onIdle: () => void, idleMs = IDLE_MS) {
+  // Keep a stable ref so the timer doesn't restart when the callback identity changes.
+  const onIdleRef = useRef(onIdle);
+  useEffect(() => { onIdleRef.current = onIdle; }, [onIdle]);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const reset = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => onIdleRef.current(), idleMs);
+    };
+
+    reset();
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, reset, { passive: true });
+    }
+    return () => {
+      clearTimeout(timer);
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, reset);
+      }
+    };
+  }, [idleMs]);
+}

--- a/frontend/src/hooks/useIdleTimeout.ts
+++ b/frontend/src/hooks/useIdleTimeout.ts
@@ -1,38 +1,89 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 
-const IDLE_MS = 5 * 60 * 1000; // 5 minutes
+const IDLE_MS = 30 * 60 * 1000;   // 30 minutes
+const WARN_BEFORE_MS = 60 * 1000; // warn 60 s before logout
 
 const ACTIVITY_EVENTS = [
   'mousemove', 'mousedown', 'keydown',
   'scroll', 'touchstart', 'click',
 ] as const;
 
+export interface IdleTimeoutOptions {
+  /** Called 60 s (warnBeforeMs) before the idle deadline. */
+  onWarn?: () => void;
+  /** Called when user activity resets the timers (not on initial mount). */
+  onActivityReset?: () => void;
+  idleMs?: number;
+  warnBeforeMs?: number;
+}
+
 /**
- * Calls onIdle after idleMs of no user activity.
- * Timer resets on mousemove, mousedown, keydown, scroll, touchstart, click.
+ * Fires options.onWarn 60 s before logout, then onIdle at the deadline.
+ * Returns a manual reset() for "Stay logged in" buttons.
+ * - Any user activity restarts both timers and calls onActivityReset.
+ * - Timers pause while the tab is hidden; resume (and reset) on visibility.
  */
-export function useIdleTimeout(onIdle: () => void, idleMs = IDLE_MS) {
-  // Keep a stable ref so the timer doesn't restart when the callback identity changes.
+export function useIdleTimeout(
+  onIdle: () => void,
+  options: IdleTimeoutOptions = {},
+): () => void {
+  const { onWarn, onActivityReset, idleMs = IDLE_MS, warnBeforeMs = WARN_BEFORE_MS } = options;
+
   const onIdleRef = useRef(onIdle);
+  const onWarnRef = useRef(onWarn);
+  const onActivityResetRef = useRef(onActivityReset);
   useEffect(() => { onIdleRef.current = onIdle; }, [onIdle]);
+  useEffect(() => { onWarnRef.current = onWarn; }, [onWarn]);
+  useEffect(() => { onActivityResetRef.current = onActivityReset; }, [onActivityReset]);
+
+  const resetRef = useRef<() => void>(() => {});
 
   useEffect(() => {
-    let timer: ReturnType<typeof setTimeout>;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let warnTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const reset = () => {
-      clearTimeout(timer);
-      timer = setTimeout(() => onIdleRef.current(), idleMs);
+    const schedule = () => {
+      clearTimeout(idleTimer);
+      clearTimeout(warnTimer);
+      if (onWarnRef.current && warnBeforeMs < idleMs) {
+        warnTimer = setTimeout(() => onWarnRef.current?.(), idleMs - warnBeforeMs);
+      }
+      idleTimer = setTimeout(() => onIdleRef.current(), idleMs);
     };
 
-    reset();
-    for (const event of ACTIVITY_EVENTS) {
-      window.addEventListener(event, reset, { passive: true });
-    }
-    return () => {
-      clearTimeout(timer);
-      for (const event of ACTIVITY_EVENTS) {
-        window.removeEventListener(event, reset);
+    const handleActivity = () => {
+      onActivityResetRef.current?.();
+      schedule();
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        clearTimeout(idleTimer);
+        clearTimeout(warnTimer);
+      } else {
+        onActivityResetRef.current?.();
+        schedule();
       }
     };
-  }, [idleMs]);
+
+    resetRef.current = schedule;
+
+    schedule(); // initial setup — does NOT call onActivityReset
+
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, handleActivity, { passive: true });
+    }
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      clearTimeout(idleTimer);
+      clearTimeout(warnTimer);
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, handleActivity);
+      }
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [idleMs, warnBeforeMs]);
+
+  return useCallback(() => resetRef.current(), []);
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -341,8 +341,11 @@ export default function LoginPage() {
   useEffect(() => {
     if ((location.state as { timedOut?: boolean } | null)?.timedOut) {
       message.warning('Время сессии истекло. Войдите снова.');
+      // Clear the flag so Back/Forward navigation doesn't replay the toast.
+      navigate(location.pathname, { replace: true, state: {} });
     }
-  }, [location.state]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally run once on mount
 
   useEffect(() => {
     authApi.getRegistrationDomain().then(setRegistrationDomain).catch(() => {});

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { message, Modal, Form, Input, Button } from 'antd';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '../store/auth.store';
 import { useThemeStore } from '../store/theme.store';
 import { useBreakpoint, useResponsiveValue } from '../utils/useBreakpoint';
@@ -336,6 +336,13 @@ export default function LoginPage() {
   const { login, register } = useAuthStore();
   const emailPrefix = useMemo(() => buildEmailPrefix(firstName, lastName), [firstName, lastName]);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if ((location.state as { timedOut?: boolean } | null)?.timedOut) {
+      message.warning('Сессия завершена из-за неактивности. Войдите снова.');
+    }
+  }, [location.state]);
 
   useEffect(() => {
     authApi.getRegistrationDomain().then(setRegistrationDomain).catch(() => {});

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -340,7 +340,7 @@ export default function LoginPage() {
 
   useEffect(() => {
     if ((location.state as { timedOut?: boolean } | null)?.timedOut) {
-      message.warning('Сессия завершена из-за неактивности. Войдите снова.');
+      message.warning('Время сессии истекло. Войдите снова.');
     }
   }, [location.state]);
 

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -437,7 +437,7 @@ export default function WorkspacesPage() {
 
       {/* Cards grid */}
       {loading ? (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 24 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(340px, 100%), 1fr))', gap: 24 }}>
           {[0, 1].map(i => (
             <div key={i} style={{ backgroundColor: C.cardBg, border: `1px solid ${C.cardBorder}`, borderRadius: 12, height: 200, opacity: 0.4 }}/>
           ))}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,4 +9,16 @@ export default defineConfig({
       '/api': 'http://localhost:3101',
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Stable vendor chunks: vendor hash changes only when dependencies change,
+        // not on every app code change — keeps browser cache efficient after deploys.
+        manualChunks: {
+          vendor: ['react', 'react-dom', 'react-router-dom'],
+          antd: ['antd'],
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary

- **Skeleton grid**: loading-скелетон на WorkspacesPage использовал старый `minmax(340px,1fr)` — горизонтальный overflow на мобиле сохранялся во время загрузки
- **nginx дублирующиеся Cache-Control**: `expires -1` + `add_header Cache-Control` давали два отдельных заголовка; прокси/CDN читали только первый (`no-cache`, а не `no-store`) и кешировали `index.html` между деплоями; то же — `expires 30d` у статики
- **nginx security headers**: заголовки из server-блока (`X-Frame-Options` и др.) молча дропались во всех location-блоках, где был свой `add_header` — повторены явно в каждом блоке
- **Vite manualChunks**: стабильные vendor/antd чанки — хэш библиотек не меняется при изменении кода приложения
- **Idle timeout 5 мин**: новый хук `useIdleTimeout`, вызывается в `PrivateRoute`; при бездействии — logout + редирект на `/login` с уведомлением

## Test plan

- [ ] На мобиле (<360px) loading-скелетон не вызывает горизонтальный скролл
- [ ] После деплоя перезагрузка страницы всегда отдаёт свежий `index.html` (проверить в DevTools → Network, `Cache-Control: no-cache, no-store, must-revalidate`, один заголовок)
- [ ] JS/CSS в `/assets/` отдаются с `Cache-Control: public, max-age=2592000, immutable`, один заголовок
- [ ] Security headers присутствуют на всех ответах (HTML, JS, API)
- [ ] После 5 минут без действий — автоматический выход, появляется предупреждение «Сессия завершена из-за неактивности»
- [ ] Любое движение мышью/клик/скролл сбрасывает таймер