### PR TITLE
feat: SSO support — Keycloak + Avanpost via OIDC/PKCE

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^4.21.2",
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
+        "openid-client": "^6.8.4",
         "redis": "^5.11.0",
         "sanitize-html": "^2.17.3",
         "zod": "^3.24.2"
@@ -3623,6 +3624,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -3970,6 +3980,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4018,6 +4037,19 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "express": "^4.21.2",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
+    "openid-client": "^6.8.4",
     "redis": "^5.11.0",
     "sanitize-html": "^2.17.3",
     "zod": "^3.24.2"

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -17,9 +17,27 @@ const envSchema = z.object({
   GITHUB_ISSUES_TOKEN: z.string().optional(),
   GITHUB_REPO_OWNER: z.string().default('NovakPAai'),
   GITHUB_REPO_NAME: z.string().default('flow-tasks'),
+  // SSO / OIDC
+  SSO_ENABLED: z.coerce.boolean().default(false),
+  SSO_ONLY: z.coerce.boolean().default(false),
+  OIDC_PROVIDER: z.enum(['keycloak', 'avanpost']).optional(),
+  OIDC_ISSUER_URL: z.string().url().optional(),
+  OIDC_CLIENT_ID: z.string().optional(),
+  OIDC_CLIENT_SECRET: z.string().optional(),
+  OIDC_REDIRECT_URI: z.string().url().optional(),
+  OIDC_SCOPE: z.string().default('openid profile email'),
 });
 
 export const config = envSchema.parse(process.env);
+
+if (config.SSO_ENABLED) {
+  const ssoRequired = ['OIDC_ISSUER_URL', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET', 'OIDC_REDIRECT_URI', 'OIDC_PROVIDER'] as const;
+  const missing = ssoRequired.filter((k) => !config[k]);
+  if (missing.length) {
+    console.error(`FATAL: SSO_ENABLED=true but missing required vars: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+}
 
 if (config.NODE_ENV === 'production') {
   const weakPatterns = ['change-me', 'changeme', 'replace', 'secret', 'password'];

--- a/backend/src/modules/auth/auth.router.ts
+++ b/backend/src/modules/auth/auth.router.ts
@@ -5,6 +5,7 @@ import { registerDto, loginDto, updateProfileDto, forgotPasswordDto, resetPasswo
 import * as authService from './auth.service.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { config } from '../../config.js';
+import ssoRouter from './sso/sso.router.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 
 const REFRESH_COOKIE_OPTS = {
@@ -98,5 +99,7 @@ router.post('/reset-password', validate(resetPasswordDto), async (req, res, next
     next(err);
   }
 });
+
+router.use('/sso', ssoRouter);
 
 export default router;

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -85,6 +85,11 @@ export async function login(dto: LoginDto) {
     throw new AppError(401, 'Неверный email или пароль');
   }
 
+  // Block local login for SSO-only users (except superadmins who always retain local access)
+  if (user.ssoOnly && !user.isSuperadmin) {
+    throw new AppError(403, 'Вход по паролю недоступен. Используйте SSO.');
+  }
+
   const valid = await comparePassword(dto.password, user.password);
   if (!valid) {
     await recordFailedAttempt(normalizedEmail);

--- a/backend/src/modules/auth/sso/claims-mapper.ts
+++ b/backend/src/modules/auth/sso/claims-mapper.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { config } from '../../../config.js';
+
+export interface MappedClaims {
+  sub: string;
+  email: string;
+  name: string;
+  emailVerified: boolean;
+}
+
+const emailSchema = z.string().email();
+
+// Both Keycloak and Avanpost use standard OIDC claims.
+// Keycloak may put display name in "name"; Avanpost may use given_name + family_name.
+export function mapClaims(raw: Record<string, unknown>): MappedClaims {
+  const sub = String(raw['sub'] ?? '').trim();
+  const rawEmail = String(raw['email'] ?? '').trim();
+  const emailVerified = raw['email_verified'] !== false; // treat absent as true (IdP-verified accounts)
+
+  if (!sub) throw new Error('OIDC claims missing required "sub"');
+
+  const emailResult = emailSchema.safeParse(rawEmail);
+  if (!emailResult.success) throw new Error(`OIDC claims: invalid email "${rawEmail}"`);
+  const email = emailResult.data;
+
+  let name = String(raw['name'] ?? '').trim();
+  if (!name) {
+    const given = String(raw['given_name'] ?? '').trim();
+    const family = String(raw['family_name'] ?? '').trim();
+    name = [given, family].filter(Boolean).join(' ');
+  }
+  if (!name) name = email.split('@')[0];
+
+  return { sub, email, name, emailVerified };
+}
+
+export function buildSsoSubjectId(sub: string): string {
+  const provider = config.OIDC_PROVIDER ?? 'oidc';
+  return `${provider}:${sub}`;
+}

--- a/backend/src/modules/auth/sso/jit-provision.ts
+++ b/backend/src/modules/auth/sso/jit-provision.ts
@@ -1,0 +1,70 @@
+import { prisma } from '../../../prisma/client.js';
+import { config } from '../../../config.js';
+import { logger } from '../../../shared/utils/logger.js';
+import { AppError } from '../../../shared/middleware/error-handler.js';
+import type { MappedClaims } from './claims-mapper.js';
+import { buildSsoSubjectId } from './claims-mapper.js';
+
+export interface ProvisionedUser {
+  id: string;
+  email: string;
+  name: string;
+  isSuperadmin: boolean;
+  ssoOnly: boolean;
+}
+
+const SELECT = { id: true, email: true, name: true, isSuperadmin: true, ssoOnly: true } as const;
+
+export async function jitProvision(claims: MappedClaims): Promise<ProvisionedUser> {
+  const ssoSubjectId = buildSsoSubjectId(claims.sub);
+  const provider = config.OIDC_PROVIDER ?? 'oidc';
+
+  // 1. Fastest path: returning SSO user
+  const existing = await prisma.user.findUnique({ where: { ssoSubjectId }, select: SELECT });
+  if (existing) return existing;
+
+  // 2. Email fallback: link existing local account to this SSO identity.
+  //    Guard: only link when the IdP has verified the email address, otherwise an
+  //    attacker could register with someone else's email on an IdP without verification
+  //    and take over an existing FlowTask account.
+  const byEmail = await prisma.user.findUnique({ where: { email: claims.email }, select: SELECT });
+  if (byEmail) {
+    if (!claims.emailVerified) {
+      throw new AppError(403, 'Email не подтверждён провайдером идентификации. Обратитесь к администратору.');
+    }
+    await prisma.user.update({
+      where: { id: byEmail.id },
+      data: { ssoSubjectId, authProvider: provider },
+    });
+    logger.info('SSO: linked existing account', { userId: byEmail.id, provider });
+    return byEmail;
+  }
+
+  // 3. Create new user — SSO-provisioned, no local password hash.
+  //    Handle concurrent JIT provisions for the same user (double callback, parallel tabs)
+  //    by catching the unique constraint violation and falling back to a lookup.
+  try {
+    const created = await prisma.user.create({
+      data: {
+        email: claims.email,
+        name: claims.name,
+        password: '',
+        ssoSubjectId,
+        authProvider: provider,
+        ssoOnly: config.SSO_ONLY,
+      },
+      select: SELECT,
+    });
+    logger.info('SSO: provisioned new user', { userId: created.id, provider });
+    return created;
+  } catch (err: unknown) {
+    const isPrismaUniqueViolation =
+      err instanceof Error && 'code' in err && (err as { code: string }).code === 'P2002';
+    if (!isPrismaUniqueViolation) throw err;
+
+    // Lost the race — the other request already created the user
+    const raceWinner = await prisma.user.findUnique({ where: { ssoSubjectId }, select: SELECT });
+    if (!raceWinner) throw new AppError(500, 'SSO provisioning conflict — please retry');
+    return raceWinner;
+  }
+}

--- a/backend/src/modules/auth/sso/sso.config.ts
+++ b/backend/src/modules/auth/sso/sso.config.ts
@@ -1,0 +1,33 @@
+import { discovery } from 'openid-client';
+import { config } from '../../../config.js';
+import { logger } from '../../../shared/utils/logger.js';
+
+// Promise singleton — concurrent first requests share one discovery call.
+let clientPromise: ReturnType<typeof discovery> | null = null;
+
+export function getOidcClient(): ReturnType<typeof discovery> {
+  if (!clientPromise) {
+    if (!config.SSO_ENABLED || !config.OIDC_ISSUER_URL || !config.OIDC_CLIENT_ID) {
+      return Promise.reject(new Error('SSO is not configured')) as ReturnType<typeof discovery>;
+    }
+
+    clientPromise = discovery(
+      new URL(config.OIDC_ISSUER_URL),
+      config.OIDC_CLIENT_ID,
+      config.OIDC_CLIENT_SECRET,
+    ).then((client) => {
+      logger.info('OIDC discovery completed', { provider: config.OIDC_PROVIDER, issuer: config.OIDC_ISSUER_URL });
+      return client;
+    }).catch((err) => {
+      clientPromise = null; // reset so next call retries
+      logger.error('OIDC discovery failed', { provider: config.OIDC_PROVIDER, error: String(err) });
+      throw err;
+    });
+  }
+
+  return clientPromise;
+}
+
+export function resetOidcClient() {
+  clientPromise = null;
+}

--- a/backend/src/modules/auth/sso/sso.router.ts
+++ b/backend/src/modules/auth/sso/sso.router.ts
@@ -1,0 +1,71 @@
+import { Router } from 'express';
+import { initiateSsoLogin, handleSsoCallback } from './sso.service.js';
+import { config } from '../../../config.js';
+import { AppError } from '../../../shared/middleware/error-handler.js';
+import { rateLimit } from '../../../shared/middleware/rate-limit.js';
+import { logger } from '../../../shared/utils/logger.js';
+
+const REFRESH_COOKIE_OPTS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict' as const,
+  maxAge: 7 * 24 * 60 * 60 * 1000,
+  path: '/',
+};
+
+const ssoRateLimit = rateLimit({ scope: 'sso', limit: 20, windowMs: 60_000 });
+
+const router = Router();
+
+// GET /api/auth/sso/status — frontend polls this to decide whether to show SSO button
+router.get('/status', (_req, res) => {
+  res.json({
+    enabled: config.SSO_ENABLED,
+    provider: config.SSO_ENABLED ? config.OIDC_PROVIDER : null,
+    ssoOnly: config.SSO_ONLY,
+  });
+});
+
+// GET /api/auth/sso/login?returnUrl=/dashboard
+router.get('/login', ssoRateLimit, async (req, res, next) => {
+  try {
+    if (!config.SSO_ENABLED) throw new AppError(404, 'SSO is not enabled');
+
+    const raw = typeof req.query.returnUrl === 'string' ? req.query.returnUrl : '/';
+    // Restrict to same-origin paths: must start with / but NOT // (protocol-relative open redirect)
+    const safePath = raw.startsWith('/') && !raw.startsWith('//') ? raw : '/';
+
+    const authUrl = await initiateSsoLogin(safePath);
+    res.redirect(authUrl);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /api/auth/sso/callback — OIDC provider redirects here after authentication
+router.get('/callback', ssoRateLimit, async (req, res, next) => {
+  try {
+    if (!config.SSO_ENABLED) throw new AppError(404, 'SSO is not enabled');
+
+    const state = typeof req.query.state === 'string' ? req.query.state : '';
+    if (!state) throw new AppError(400, 'Missing state parameter');
+
+    // Build URLSearchParams from query so sso.service can reconstruct the validated callback URL
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(req.query)) {
+      if (typeof v === 'string') params.set(k, v);
+    }
+
+    const { refreshToken } = await handleSsoCallback(state, params);
+
+    res.cookie('refreshToken', refreshToken, REFRESH_COOKIE_OPTS);
+    // Redirect to the SPA — no token in the URL.
+    // The frontend detects sso_return=1, calls /auth/refresh to get the access token.
+    res.redirect('/?sso_return=1');
+  } catch (err) {
+    logger.warn('SSO callback error', { error: String(err) });
+    res.redirect('/?error=sso_failed');
+  }
+});
+
+export default router;

--- a/backend/src/modules/auth/sso/sso.service.ts
+++ b/backend/src/modules/auth/sso/sso.service.ts
@@ -1,0 +1,119 @@
+import crypto from 'crypto';
+import {
+  buildAuthorizationUrl,
+  authorizationCodeGrant,
+  randomPKCECodeVerifier,
+  calculatePKCECodeChallenge,
+} from 'openid-client';
+import { getOidcClient } from './sso.config.js';
+import { mapClaims } from './claims-mapper.js';
+import { jitProvision } from './jit-provision.js';
+import { setCachedJson, getAndDeleteCachedJson, setUserSession } from '../../../shared/redis.js';
+import { config } from '../../../config.js';
+import { AppError } from '../../../shared/middleware/error-handler.js';
+import { logger } from '../../../shared/utils/logger.js';
+import jwt from 'jsonwebtoken';
+import { prisma } from '../../../prisma/client.js';
+
+const STATE_TTL_SECONDS = 300;
+const MAX_SESSIONS = 5;
+
+interface StatePayload {
+  verifier: string;
+  returnUrl: string;
+}
+
+function stateKey(state: string) {
+  return `sso:state:${state}`;
+}
+
+export async function initiateSsoLogin(returnUrl: string): Promise<string> {
+  const client = await getOidcClient();
+  const verifier = randomPKCECodeVerifier();
+  const challenge = await calculatePKCECodeChallenge(verifier);
+  const state = crypto.randomBytes(16).toString('hex');
+
+  const payload: StatePayload = { verifier, returnUrl };
+  await setCachedJson(stateKey(state), payload, STATE_TTL_SECONDS);
+
+  const authUrl = buildAuthorizationUrl(client, {
+    redirect_uri: config.OIDC_REDIRECT_URI!,
+    scope: config.OIDC_SCOPE,
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+
+  return authUrl.href;
+}
+
+export interface SsoSession {
+  // Raw refresh token — caller sets it as HttpOnly cookie.
+  // Access token is NOT returned here; the frontend calls /auth/refresh to obtain it.
+  refreshToken: string;
+}
+
+export async function handleSsoCallback(
+  receivedState: string,
+  callbackParams: URLSearchParams,
+): Promise<SsoSession> {
+  // Atomic get-and-delete — prevents state replay even under concurrent requests
+  const statePayload = await getAndDeleteCachedJson<StatePayload>(stateKey(receivedState));
+  if (!statePayload) throw new AppError(400, 'SSO state expired or invalid');
+
+  const client = await getOidcClient();
+
+  // Reconstruct callback URL from the registered redirect URI + received query params
+  // so we never trust Host headers from the incoming request.
+  const callbackUrl = new URL(config.OIDC_REDIRECT_URI!);
+  callbackParams.forEach((v, k) => callbackUrl.searchParams.set(k, v));
+
+  let tokens;
+  try {
+    tokens = await authorizationCodeGrant(client, callbackUrl, {
+      pkceCodeVerifier: statePayload.verifier,
+      expectedState: receivedState,
+    });
+  } catch (err) {
+    logger.warn('SSO callback token exchange failed', { error: String(err) });
+    throw new AppError(401, 'SSO authentication failed');
+  }
+
+  const rawClaims = tokens.claims();
+  if (!rawClaims) throw new AppError(401, 'No claims in OIDC token response');
+
+  const claims = mapClaims(rawClaims as Record<string, unknown>);
+  const user = await jitProvision(claims);
+
+  // Enforce per-user session cap — same LRU logic as local login
+  await prisma.$transaction(async (tx) => {
+    const all = await tx.refreshToken.findMany({
+      where: { userId: user.id },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true },
+    });
+    if (all.length >= MAX_SESSIONS) {
+      const toDelete = all.slice(0, all.length - MAX_SESSIONS + 1).map((t) => t.id);
+      await tx.refreshToken.deleteMany({ where: { id: { in: toDelete } } });
+    }
+  });
+
+  const refreshTokenRaw = crypto.randomBytes(40).toString('hex');
+  const refreshTokenHash = crypto.createHash('sha256').update(refreshTokenRaw).digest('hex');
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+  await prisma.refreshToken.create({
+    data: { userId: user.id, token: refreshTokenHash, expiresAt },
+  });
+
+  const nowIso = new Date().toISOString();
+  await Promise.all([
+    prisma.user.update({
+      where: { id: user.id },
+      data: { loginCount: { increment: 1 }, lastLoginAt: new Date() },
+    }),
+    setUserSession(user.id, { email: user.email, createdAt: nowIso, lastSeenAt: nowIso }),
+  ]);
+
+  return { refreshToken: refreshTokenRaw };
+}

--- a/backend/src/prisma/migrations/20260505_add_sso_fields/migration.sql
+++ b/backend/src/prisma/migrations/20260505_add_sso_fields/migration.sql
@@ -1,0 +1,14 @@
+-- SSO preparation: Keycloak + Avanpost via standard OIDC.
+-- Adds ssoSubjectId (composite key "<provider>:<sub>"), authProvider, ssoOnly to users table.
+
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "sso_subject_id" TEXT,
+  ADD COLUMN IF NOT EXISTS "auth_provider"  TEXT NOT NULL DEFAULT 'local',
+  ADD COLUMN IF NOT EXISTS "sso_only"       BOOLEAN NOT NULL DEFAULT false;
+
+-- Migrate existing keycloakId values to ssoSubjectId with keycloak prefix
+UPDATE "users"
+  SET "sso_subject_id" = 'keycloak:' || "keycloakId"
+  WHERE "keycloakId" IS NOT NULL AND "sso_subject_id" IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "users_sso_subject_id_key" ON "users"("sso_subject_id");

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -15,7 +15,10 @@ model User {
   password      String
   name          String
   avatar        String?
-  keycloakId    String?   @unique
+  keycloakId    String?   @unique                     // legacy — will be migrated to ssoSubjectId
+  ssoSubjectId  String?   @unique @map("sso_subject_id") // provider sub claim: "<provider>:<sub>"
+  authProvider  String    @default("local") @map("auth_provider") // "local" | "keycloak" | "avanpost"
+  ssoOnly       Boolean   @default(false) @map("sso_only") // local login disabled for this user
   loginCount    Int       @default(0)
   lastLoginAt   DateTime?
   isSuperadmin  Boolean   @default(false)

--- a/backend/src/shared/redis.ts
+++ b/backend/src/shared/redis.ts
@@ -1,5 +1,6 @@
 import { createClient, type RedisClientType } from 'redis';
 import { config } from '../config.js';
+import { logger } from './utils/logger.js';
 
 type RedisClient = RedisClientType;
 
@@ -45,7 +46,7 @@ export async function getCachedJson<T>(key: string): Promise<T | null> {
     if (!raw) return null;
     return JSON.parse(raw) as T;
   } catch (err) {
-    console.error('Redis read error:', err);
+    logger.error('Redis read error', { key, error: String(err) });
     return null;
   }
 }
@@ -56,7 +57,22 @@ export async function setCachedJson<T>(key: string, value: T, ttlSeconds = confi
   try {
     await redis.set(key, JSON.stringify(value), { EX: ttlSeconds });
   } catch (err) {
-    console.error('Redis write error:', err);
+    logger.error('Redis write error', { key, error: String(err) });
+  }
+}
+
+// Atomic get-and-delete — used for one-time-use state tokens (SSO PKCE, exchange codes).
+// Returns null when key is absent, expired, or Redis is unavailable.
+export async function getAndDeleteCachedJson<T>(key: string): Promise<T | null> {
+  const redis = await getRedisClientInternal();
+  if (!redis) return null;
+  try {
+    const raw = await redis.getDel(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    logger.error('Redis getdel error', { key, error: String(err) });
+    return null;
   }
 }
 
@@ -77,7 +93,7 @@ export async function setUserSession(userId: string, session: Omit<UserSession, 
   try {
     await redis.set(buildSessionKey(userId), JSON.stringify({ userId, ...session }), { EX: SESSION_TTL_SECONDS });
   } catch (err) {
-    console.error('Redis session write error:', err);
+    logger.error('Redis session write error', { userId, error: String(err) });
   }
 }
 
@@ -87,6 +103,6 @@ export async function deleteUserSession(userId: string): Promise<void> {
   try {
     await redis.del(buildSessionKey(userId));
   } catch (err) {
-    console.error('Redis session delete error:', err);
+    logger.error('Redis session delete error', { userId, error: String(err) });
   }
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -34,3 +34,14 @@ export async function getRegistrationDomain(): Promise<string> {
   const { data } = await api.get<{ domain: string }>('/auth/registration-domain');
   return data.domain;
 }
+
+export interface SsoStatus {
+  enabled: boolean;
+  provider: string | null;
+  ssoOnly: boolean;
+}
+
+export async function getSsoStatus(): Promise<SsoStatus> {
+  const { data } = await api.get<SsoStatus>('/auth/sso/status');
+  return data;
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -333,6 +333,7 @@ export default function LoginPage() {
   const [forgotEmail, setForgotEmail] = useState('');
   const [forgotLoading, setForgotLoading] = useState(false);
   const [forgotDone, setForgotDone] = useState(false);
+  const [ssoStatus, setSsoStatus] = useState<{ enabled: boolean; provider: string | null; ssoOnly: boolean } | null>(null);
   const { login, register } = useAuthStore();
   const emailPrefix = useMemo(() => buildEmailPrefix(firstName, lastName), [firstName, lastName]);
   const navigate = useNavigate();
@@ -349,6 +350,25 @@ export default function LoginPage() {
 
   useEffect(() => {
     authApi.getRegistrationDomain().then(setRegistrationDomain).catch(() => {});
+    authApi.getSsoStatus().then(setSsoStatus).catch(() => {});
+  }, []);
+
+  // Handle SSO return: the backend sets a refreshToken cookie and redirects here.
+  // We call /auth/refresh to exchange it for an access token — no token in the URL.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    if (params.get('error') === 'sso_failed') {
+      message.error('Ошибка SSO-аутентификации. Попробуйте ещё раз.');
+      window.history.replaceState(null, '', window.location.pathname);
+      return;
+    }
+
+    if (!params.get('sso_return')) return;
+
+    window.history.replaceState(null, '', window.location.pathname);
+    useAuthStore.getState().loadUser().then(() => navigate('/'));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -527,6 +547,37 @@ export default function LoginPage() {
               {loading ? '...' : showRegister ? 'Отправить заявку' : 'Войти'}
             </div>
           </button>
+
+          {/* SSO button — only on the login tab, only when SSO is configured */}
+          {!showRegister && ssoStatus?.enabled && (
+            <>
+              <div style={{
+                alignItems: 'center', display: 'flex', gap: 10, marginBottom: 20,
+              }}>
+                <div style={{ flex: 1, height: 1, backgroundColor: C.inputBorder }} />
+                <span style={{ color: C.muted, fontFamily: '"Inter", system-ui, sans-serif', fontSize: 12 }}>или</span>
+                <div style={{ flex: 1, height: 1, backgroundColor: C.inputBorder }} />
+              </div>
+              <a
+                href={`/api/auth/sso/login?returnUrl=${encodeURIComponent('/')}`}
+                style={{
+                  alignItems: 'center', backgroundColor: C.inputBg,
+                  border: `1px solid ${C.inputBorder}`, borderRadius: 8, boxSizing: 'border-box',
+                  color: C.title, cursor: 'pointer', display: 'flex',
+                  fontFamily: '"Inter", system-ui, sans-serif', fontSize: 14, fontWeight: 500,
+                  gap: 10, justifyContent: 'center', marginBottom: 20,
+                  paddingBlock: '12px', paddingInline: '16px',
+                  textDecoration: 'none', transition: 'border-color 0.15s',
+                  width: '100%',
+                }}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                  <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                </svg>
+                Войти через {ssoStatus.provider === 'keycloak' ? 'Keycloak' : ssoStatus.provider === 'avanpost' ? 'Avanpost' : 'SSO'}
+              </a>
+            </>
+          )}
 
           {/* Toggle login/register */}
           <div style={{ textAlign: 'center' }}>

--- a/frontend/src/store/auth.store.ts
+++ b/frontend/src/store/auth.store.ts
@@ -42,7 +42,8 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   loadUser: async () => {
     try {
-      // Try to restore session via HttpOnly refresh token cookie
+      // Try to restore session via HttpOnly refresh token cookie.
+      // Also used by the SSO callback flow (sso_return=1).
       const { accessToken } = await authApi.refreshToken();
       setAccessToken(accessToken);
       const user = await authApi.getMe();


### PR DESCRIPTION
## Summary

- Adds provider-agnostic SSO using **openid-client v6** with PKCE Authorization Code Flow
- Supports **Keycloak** and **Avanpost** as OIDC providers (configured via `OIDC_PROVIDER`)
- Local password login is fully preserved; `SSO_ONLY=true` blocks it for non-superadmins
- **No tokens in URLs** — access token flows via `/auth/refresh` cookie exchange (same as existing local login)

## New files

| File | Purpose |
|------|---------|
| `backend/src/modules/auth/sso/sso.config.ts` | OIDC discovery, promise singleton |
| `backend/src/modules/auth/sso/claims-mapper.ts` | Standard OIDC claims → internal fields, `email_verified` guard |
| `backend/src/modules/auth/sso/jit-provision.ts` | JIT user provisioning: ssoSubjectId → email → create |
| `backend/src/modules/auth/sso/sso.service.ts` | PKCE flow, atomic state, session management |
| `backend/src/modules/auth/sso/sso.router.ts` | `GET /api/auth/sso/status|login|callback` |
| `backend/src/prisma/migrations/20260505_add_sso_fields/migration.sql` | Additive migration |

## Env vars (all optional when `SSO_ENABLED=false`)

```
SSO_ENABLED=true
SSO_ONLY=false
OIDC_PROVIDER=keycloak        # or avanpost
OIDC_ISSUER_URL=https://auth.example.com/realms/flowtask
OIDC_CLIENT_ID=flowtask
OIDC_CLIENT_SECRET=...
OIDC_REDIRECT_URI=https://flowtask.example.com/api/auth/sso/callback
OIDC_SCOPE=openid profile email
```

## Security review findings addressed

All CRITICAL and HIGH findings from dual review resolved before commit:

| Finding | Fix |
|---------|-----|
| Non-atomic state read+delete → replay window | `redis.getDel` (GETDEL atomic op) |
| Access token in URL fragment | Removed — uses refresh cookie + `/auth/refresh` (existing flow) |
| Startup crash on missing OIDC vars | Fail-fast validation when `SSO_ENABLED=true` |
| `//evil.com` open redirect bypass | `startsWith('/') && !startsWith('//')` guard |
| No rate limiting on SSO routes | `rateLimit({ scope: 'sso', limit: 20, windowMs: 60s })` |
| `callbackUrl` from `Host` header | Built from `config.OIDC_REDIRECT_URI` only |
| Missing `setUserSession` parity | Added — matches local login flow |
| Missing refresh token LRU parity | Added — `$transaction` LRU eviction before create |
| Email account linking without `email_verified` | Guard in `jit-provision.ts` |
| TOCTOU race on concurrent JIT provision | `P2002` catch → retry lookup |
| `console.error` in `redis.ts` | Replaced with structured `logger.error` |

## Test plan

- [ ] `SSO_ENABLED=false` (default) — login page shows no SSO button, all local flows unchanged
- [ ] `SSO_ENABLED=true OIDC_PROVIDER=keycloak` — "Войти через Keycloak" button appears
- [ ] Click SSO button → redirected to Keycloak → return to app, session established
- [ ] New user first SSO login → JIT provisioned, lands in workspace
- [ ] Existing local user SSO login with same email + `email_verified=true` → linked
- [ ] `SSO_ONLY=true` → local password login blocked (non-superadmin); superadmin still passes
- [ ] Invalid/expired state in callback → 400, redirect to `/?error=sso_failed`
- [ ] `tsc --noEmit` exits 0 on both backend and frontend ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)