### PR TITLE
fix: prevent StrictMode double-loadUser race + seed superadmin flag

### DIFF
--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -11,8 +11,8 @@ async function main() {
   // ─── Users ────────────────────────────────────────────────────────────────
   const superadmin = await prisma.user.upsert({
     where: { email: 'novak.pavel@flowtask.dev' },
-    update: {},
-    create: { email: 'novak.pavel@flowtask.dev', password, name: 'Pavel Novak' },
+    update: { isSuperadmin: true },
+    create: { email: 'novak.pavel@flowtask.dev', password, name: 'Pavel Novak', isSuperadmin: true },
   });
 
   const admin = await prisma.user.upsert({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useState, useRef } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { ConfigProvider, theme, Spin } from 'antd';
 import { useAuthStore } from './store/auth.store';
@@ -101,7 +101,12 @@ export default function App() {
   const mode = useThemeStore((s) => s.mode);
   const isDark = mode !== 'light';
 
-  useEffect(() => { loadUser(); }, [loadUser]);
+  const hasLoadedUser = useRef(false);
+  useEffect(() => {
+    if (hasLoadedUser.current) return;
+    hasLoadedUser.current = true;
+    loadUser();
+  }, [loadUser]);
 
   return (
     <ConfigProvider


### PR DESCRIPTION
## Summary
- **App.tsx**: добавлен `useRef`-гард в `useEffect` загрузки пользователя — React StrictMode дважды запускал `loadUser()`, второй вызов получал 401 (токен уже ротирован первым) и сбрасывал auth-стейт → E2E-тесты уходили на /login
- **seed.ts**: добавлен `isSuperadmin: true` для `novak.pavel@flowtask.dev` в блоки `create` и `update` — флаг в БД теперь всегда в sync с config-derived проверкой в getMe()

Closes #119 (E2E redirects to /login in CI)

## Test plan
- [ ] Запустить E2E тесты — тесты не должны уходить на /login из-за двойного loadUser
- [ ] Войти под novak.pavel@flowtask.dev — должен видеть раздел Пользователи как суперадмин