### PR TITLE
fix: E2E — StrictMode double-loadUser race + seed superadmin flag

### DIFF
--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -11,8 +11,8 @@ async function main() {
   // ─── Users ────────────────────────────────────────────────────────────────
   const superadmin = await prisma.user.upsert({
     where: { email: 'novak.pavel@flowtask.dev' },
-    update: {},
-    create: { email: 'novak.pavel@flowtask.dev', password, name: 'Pavel Novak' },
+    update: { isSuperadmin: true },
+    create: { email: 'novak.pavel@flowtask.dev', password, name: 'Pavel Novak', isSuperadmin: true },
   });
 
   const admin = await prisma.user.upsert({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useState, useRef } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { ConfigProvider, theme, Spin } from 'antd';
 import { useAuthStore } from './store/auth.store';
@@ -101,7 +101,12 @@ export default function App() {
   const mode = useThemeStore((s) => s.mode);
   const isDark = mode !== 'light';
 
-  useEffect(() => { loadUser(); }, [loadUser]);
+  const hasLoadedUser = useRef(false);
+  useEffect(() => {
+    if (hasLoadedUser.current) return;
+    hasLoadedUser.current = true;
+    loadUser();
+  }, [loadUser]);
 
   return (
     <ConfigProvider


### PR DESCRIPTION
## Summary

- **App.tsx**: Guard `useEffect` with `useRef` so React StrictMode's double-fire in dev/e2e mode doesn't trigger two concurrent `refreshToken()` calls. The second call would get 401 (token already rotated by the first) and clear auth state, causing board and admin E2E tests to redirect to `/login`.
- **seed.ts**: Set `isSuperadmin: true` on `novak.pavel@flowtask.dev` in both `create` and `update` blocks so the DB flag stays in sync with the config-derived check in `getMe()`.

## Root cause

React StrictMode (enabled in `main.tsx`) fires `useEffect` twice on mount in development. Both fires call `loadUser()` concurrently with the same refresh-token cookie. The backend's token rotation (`auth.service.ts`) deletes the old token atomically — so the second concurrent `/auth/refresh` request receives 401 ("token already consumed"). The second call's `catch` sets `user = null, loading = false`, which makes `PrivateRoute` redirect to `/login` even though the first call succeeded.

## Test plan

- [ ] E2E CI passes: board tests find `[data-onboarding="create-board"]`
- [ ] E2E CI passes: admin test stays on `/admin/users` and shows "Управление пользователями"
- [ ] No regression in workspace / smoke tests