### PR TITLE
feat: серверные фильтры доски (gap-02)

### DIFF
--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
+import { logEvent } from '../workspaces/workspaces.service.js';
 import type { CreateBoardDto, UpdateBoardDto } from './boards.dto.js';
 
 async function assertMember(workspaceId: string, userId: string) {
@@ -52,12 +53,16 @@ export async function createBoard(workspaceId: string, userId: string, dto: Crea
   const existing = await prisma.board.findFirst({ where: { workspaceId, prefix } });
   if (existing) throw new AppError(409, `Prefix "${prefix}" already used in this workspace`);
 
-  return prisma.board.create({
+  const board = await prisma.board.create({
     data: { workspaceId, workflowId, name: dto.name, prefix, description: dto.description },
     include: {
       workflow: { include: { statuses: { orderBy: { position: 'asc' } } } },
     },
   });
+
+  await logEvent(workspaceId, userId, 'board_created', 'board', board.id, { name: dto.name, prefix });
+
+  return board;
 }
 
 export async function getBoardByPrefix(workspaceId: string, prefix: string, userId: string) {
@@ -109,7 +114,15 @@ export async function updateBoard(boardId: string, userId: string, dto: UpdateBo
     if (!wf) throw new AppError(404, 'Workflow not found in this workspace');
   }
 
-  return prisma.board.update({ where: { id: boardId }, data: dto });
+  const updated = await prisma.board.update({ where: { id: boardId }, data: dto });
+
+  const meta: Record<string, unknown> = {};
+  if (dto.name !== undefined && dto.name !== board.name) meta.nameFrom = board.name;
+  if (dto.name !== undefined) meta.nameTo = dto.name;
+  if (dto.workflowId !== undefined && dto.workflowId !== board.workflowId) meta.workflowChanged = true;
+  await logEvent(board.workspaceId, userId, 'board_updated', 'board', boardId, { boardName: board.name, ...meta });
+
+  return updated;
 }
 
 export async function deleteBoard(boardId: string, userId: string) {
@@ -117,6 +130,7 @@ export async function deleteBoard(boardId: string, userId: string) {
   if (!board) throw new AppError(404, 'Board not found');
   await assertOwner(board.workspaceId, userId);
   await prisma.board.delete({ where: { id: boardId } });
+  await logEvent(board.workspaceId, userId, 'board_deleted', 'board', boardId, { name: board.name });
 }
 
 // ─── Roadmap ──────────────────────────────────────────────────────────────────

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -310,6 +310,7 @@ export async function updateTask(taskId: string, userId: string, dto: UpdateTask
       include: {
         status: true,
         assignee: { select: { id: true, name: true, avatar: true } },
+        labels: { include: { label: { select: { id: true, name: true, color: true } } } },
         _count: { select: { children: true } },
       },
     }),
@@ -356,6 +357,7 @@ export async function moveTask(taskId: string, userId: string, toStatusId: strin
       include: {
         status: true,
         assignee: { select: { id: true, name: true, avatar: true } },
+        labels: { include: { label: { select: { id: true, name: true, color: true } } } },
         _count: { select: { children: true } },
       },
     }),

--- a/backend/src/modules/workflows/workflows.service.ts
+++ b/backend/src/modules/workflows/workflows.service.ts
@@ -171,6 +171,11 @@ export async function updateWorkflow(workflowId: string, userId: string, dto: Up
     await generateTransitions(workflowId);
   }
 
+  const meta: Record<string, unknown> = { workflowName: workflow.name };
+  if (dto.name !== undefined && dto.name !== workflow.name) { meta.nameFrom = workflow.name; meta.nameTo = dto.name; }
+  if (dto.mode !== undefined && dto.mode !== oldMode) { meta.modeFrom = oldMode; meta.modeTo = dto.mode; }
+  await logEvent(workflow.workspaceId, userId, 'workflow_updated', 'workflow', workflowId, meta);
+
   return updated;
 }
 
@@ -213,6 +218,11 @@ export async function addStatus(workflowId: string, userId: string, dto: AddStat
     await generateTransitions(workflowId);
   }
 
+  await logEvent(workflow.workspaceId, userId, 'workflow_status_added', 'workflow', workflowId, {
+    workflowName: workflow.name,
+    statusName: dto.name,
+  });
+
   return status;
 }
 
@@ -220,9 +230,19 @@ export async function updateStatus(statusId: string, userId: string, dto: Update
   const status = await prisma.workflowStatus.findUnique({ where: { id: statusId } });
   if (!status) throw new AppError(404, 'Status not found');
 
-  await assertWorkspaceOwner(status.workflowId, userId);
+  const workflow = await assertWorkspaceOwner(status.workflowId, userId);
 
-  return prisma.workflowStatus.update({ where: { id: statusId }, data: dto });
+  const updated = await prisma.workflowStatus.update({ where: { id: statusId }, data: dto });
+
+  if (dto.name !== undefined && dto.name !== status.name) {
+    await logEvent(workflow.workspaceId, userId, 'workflow_status_renamed', 'workflow', status.workflowId, {
+      workflowName: workflow.name,
+      nameFrom: status.name,
+      nameTo: dto.name,
+    });
+  }
+
+  return updated;
 }
 
 export async function deleteStatus(statusId: string, userId: string) {
@@ -249,6 +269,11 @@ export async function deleteStatus(statusId: string, userId: string) {
   if (workflow.mode !== 'CUSTOM') {
     await generateTransitions(status.workflowId);
   }
+
+  await logEvent(workflow.workspaceId, userId, 'workflow_status_deleted', 'workflow', status.workflowId, {
+    workflowName: workflow.name,
+    statusName: status.name,
+  });
 }
 
 export async function reorderStatuses(workflowId: string, userId: string, orderedIds: string[]) {

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -173,8 +173,10 @@ export default function TaskDrawer({
     } catch { message.error('Ошибка удаления'); }
   };
 
-  const handleLabelsChanged = (labels: TaskLabel[]) =>
+  const handleLabelsChanged = (labels: TaskLabel[]) => {
     setTask((prev) => prev ? { ...prev, labels } : prev);
+    if (task) onUpdated({ ...task, labels });
+  };
   const handleCommentsChanged = (comments: Comment[]) =>
     setTask((prev) => prev ? { ...prev, comments } : prev);
   const handleChecklistsChanged = (checklists: Checklist[]) =>

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -40,30 +40,19 @@ function columnsToList(columns: Columns): Task[] {
   return Object.values(columns).flat();
 }
 
-function applyFilters(tasks: Task[], f: FilterState): Task[] {
-  return tasks.filter(t => {
-    if (f.search && !t.title.toLowerCase().includes(f.search.toLowerCase())) return false;
-    if (f.statusId && t.statusId !== f.statusId) return false;
-    if (f.priority && t.priority !== f.priority) return false;
-    if (f.assigneeId && t.assigneeId !== f.assigneeId) return false;
-    if (f.labelId && !(t.labels ?? []).some(tl => tl.labelId === f.labelId)) return false;
-    if (f.duePreset) {
-      const now = new Date();
-      const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-      const tomorrow = new Date(today); tomorrow.setDate(tomorrow.getDate() + 1);
-      const nextWeek = new Date(today); nextWeek.setDate(nextWeek.getDate() + 7);
-      const nextWeekEnd = new Date(nextWeek); nextWeekEnd.setDate(nextWeekEnd.getDate() + 7);
-      const due = t.dueDate ? new Date(t.dueDate) : null;
-      if (f.duePreset === 'no_date' && due) return false;
-      if (f.duePreset === 'no_date' && !due) return true;
-      if (!due) return false;
-      if (f.duePreset === 'today' && !(due >= today && due < tomorrow)) return false;
-      if (f.duePreset === 'this_week' && !(due >= today && due < nextWeek)) return false;
-      if (f.duePreset === 'next_week' && !(due >= nextWeek && due < nextWeekEnd)) return false;
-      if (f.duePreset === 'overdue' && !(due < today)) return false;
-    }
-    return true;
-  });
+/** Map non-empty filter fields to API query params (statusId omitted — columns have it) */
+function toApiParams(f: FilterState): Record<string, string> {
+  const p: Record<string, string> = {};
+  if (f.search)     p.search     = f.search;
+  if (f.priority)   p.priority   = f.priority;
+  if (f.assigneeId) p.assigneeId = f.assigneeId;
+  if (f.labelId)    p.labelId    = f.labelId;
+  if (f.duePreset)  p.duePreset  = f.duePreset;
+  return p;
+}
+
+function isFilterActive(f: FilterState): boolean {
+  return !!(f.search || f.priority || f.assigneeId || f.labelId || f.duePreset);
 }
 
 // ── View icons ─────────────────────────────────────────────────────────────────
@@ -207,6 +196,10 @@ export default function BoardPage() {
   const [columnOffsets, setColumnOffsets] = useState<Record<string, number>>({});
   const [columnTotals, setColumnTotals] = useState<Record<string, number>>({});
   const [loadingMoreCols, setLoadingMoreCols] = useState<Set<string>>(new Set());
+  const [filterLoading, setFilterLoading] = useState(false);
+  const hadActiveFiltersRef = useRef(false);
+  const filterFetchIdRef = useRef(0);
+  const lastBoardIdRef = useRef<string | null>(null);
   const addInputRef = useRef<HTMLInputElement | null>(null);
 
   const currentUserId = useAuthStore(s => s.user?.id);
@@ -262,6 +255,62 @@ export default function BoardPage() {
     if (addingTo) setTimeout(() => addInputRef.current?.focus(), 50);
   }, [addingTo]);
 
+  // ── Server-side filters ───────────────────────────────────────────────────
+  const fetchFilteredColumns = useCallback(async (f: FilterState, b: Board) => {
+    const fetchId = ++filterFetchIdRef.current;
+    const params = toApiParams(f);
+    setFilterLoading(true);
+    try {
+      const results = await Promise.all(
+        b.workflow.statuses.map(s =>
+          tasksApi.listTasks(b.id, { ...params, statusId: s.id, rootOnly: 'true', limit: '100', offset: '0' })
+            .then(r => [s.id, r] as const),
+        ),
+      );
+      if (fetchId !== filterFetchIdRef.current) return; // discard stale response
+      const newCols: Columns = {};
+      const newOffsets: Record<string, number> = {};
+      const newTotals: Record<string, number> = {};
+      for (const [sid, { tasks, total }] of results) {
+        newCols[sid] = tasks;
+        newOffsets[sid] = tasks.length;
+        if (total > tasks.length) newTotals[sid] = total;
+      }
+      setColumns(newCols);
+      setColumnOffsets(newOffsets);
+      setColumnTotals(newTotals);
+    } catch {
+      if (fetchId === filterFetchIdRef.current) {
+        message.error('Не удалось применить фильтры');
+      }
+    } finally {
+      if (fetchId === filterFetchIdRef.current) setFilterLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!board) return;
+    // Reset guard when navigating to a different board
+    if (board.id !== lastBoardIdRef.current) {
+      lastBoardIdRef.current = board.id;
+      hadActiveFiltersRef.current = false;
+    }
+    const active = isFilterActive(filters);
+    if (!active) {
+      if (hadActiveFiltersRef.current) {
+        hadActiveFiltersRef.current = false;
+        loadBoard();
+      }
+      return;
+    }
+    hadActiveFiltersRef.current = true;
+    const timer = setTimeout(
+      () => { fetchFilteredColumns(filters, board); },
+      filters.search ? 300 : 0,
+    );
+    return () => clearTimeout(timer);
+  }, [filters, board, loadBoard, fetchFilteredColumns]);
+
   // ── DnD ───────────────────────────────────────────────────────────────────
   const onDragStart = (start: DragStart) => {
     setDraggingFromStatusId(start.source.droppableId);
@@ -313,11 +362,16 @@ export default function BoardPage() {
 
   // ── Load more (column pagination) ────────────────────────────────────────
   const loadMoreColumn = async (statusId: string) => {
-    if (!board || loadingMoreCols.has(statusId)) return;
+    if (!board || loadingMoreCols.has(statusId) || filterLoading) return;
     const offset = columnOffsets[statusId] ?? 0;
+    // Snapshot active filters so a mid-flight filter change doesn't corrupt results
+    const snapshotParams = toApiParams(filters);
+    const snapshotFetchId = filterFetchIdRef.current;
     setLoadingMoreCols(prev => new Set(prev).add(statusId));
     try {
-      const { tasks: more, total } = await tasksApi.listTasks(board.id, { statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
+      const { tasks: more, total } = await tasksApi.listTasks(board.id, { ...snapshotParams, statusId, offset: String(offset), limit: '100', rootOnly: 'true' });
+      // Discard if a new filter fetch has started since we began
+      if (filterFetchIdRef.current !== snapshotFetchId) return;
       setColumns(prev => ({ ...prev, [statusId]: [...(prev[statusId] ?? []), ...more] }));
       setColumnOffsets(prev => ({ ...prev, [statusId]: offset + more.length }));
       setColumnTotals(prev => ({ ...prev, [statusId]: total }));
@@ -371,20 +425,25 @@ export default function BoardPage() {
   };
 
   // ── Filtered data ─────────────────────────────────────────────────────────
+  // Server already applied search/priority/assignee/label/due filters.
+  // Only statusId is applied client-side (column visibility / list view).
   const allTasks = useMemo(() => columnsToList(columns), [columns]);
-  const filteredTasks = useMemo(() => applyFilters(allTasks, filters), [allTasks, filters]);
+  const filteredTasks = useMemo(
+    () => filters.statusId ? allTasks.filter(t => t.statusId === filters.statusId) : allTasks,
+    [allTasks, filters.statusId],
+  );
   const hasMoreTasks = useMemo(
     () => Object.entries(columnTotals).some(([sid, total]) => (columns[sid]?.length ?? 0) < total),
     [columnTotals, columns],
   );
   const filteredColumns = useMemo(() => {
-    const ids = new Set(filteredTasks.map(t => t.id));
+    if (!filters.statusId) return columns;
     const result: Columns = {};
-    for (const [sid, tasks] of Object.entries(columns)) {
-      result[sid] = tasks.filter(t => ids.has(t.id));
+    for (const sid of Object.keys(columns)) {
+      result[sid] = sid === filters.statusId ? columns[sid] : [];
     }
     return result;
-  }, [columns, filteredTasks]);
+  }, [columns, filters.statusId]);
 
   // ── Loading state ─────────────────────────────────────────────────────────
   if (loading) {
@@ -513,6 +572,12 @@ export default function BoardPage() {
         labels={labels}
         onChange={setFilters}
       />
+      {filterLoading && (
+        <>
+          <style>{`@keyframes ft-shimmer{0%{background-position:-200% center}100%{background-position:200% center}}`}</style>
+          <div style={{ height: 2, backgroundImage: 'linear-gradient(90deg,#4F6EF7,#7C3AED,#4F6EF7)', backgroundSize: '200% 100%', borderRadius: 1, animation: 'ft-shimmer 1.2s linear infinite' }} />
+        </>
+      )}
 
       {/* ── View content ─────────────────────────────────────────────────── */}
       <div style={{ flex: 1, overflow: viewMode === 'board' || viewMode === 'roadmap' ? 'hidden' : 'auto', display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -516,14 +516,27 @@ export default function WorkspaceDashboardPage() {
                 const name = ev.user?.name ?? 'Кто-то';
                 const nameParts = name.trim().split(/\s+/);
                 const isFem = /[аяАЯ]$/u.test(nameParts[nameParts.length - 1] ?? '');
+                const m = (ev.meta ?? {}) as Record<string, string>;
+
                 const ACTION_LABELS: Record<string, string> = {
-                  workspace_created: isFem ? 'создала пространство' : 'создал пространство',
-                  workspace_updated: isFem ? 'обновила настройки' : 'обновил настройки',
-                  member_added:      isFem ? 'добавила участника' : 'добавил участника',
-                  member_removed:    isFem ? 'удалила участника' : 'удалил участника',
-                  board_created:     isFem ? 'создала доску' : 'создал доску',
-                  board_deleted:     isFem ? 'удалила доску' : 'удалил доску',
-                  member_role_changed: isFem ? 'изменила роль' : 'изменил роль',
+                  workspace_created:       isFem ? 'создала пространство' : 'создал пространство',
+                  workspace_updated:       isFem ? 'обновила настройки пространства' : 'обновил настройки пространства',
+                  member_added:            isFem ? `добавила участника ${m.name ?? ''}` : `добавил участника ${m.name ?? ''}`,
+                  member_removed:          isFem ? `удалила участника ${m.name ?? ''}` : `удалил участника ${m.name ?? ''}`,
+                  member_role_changed:     isFem ? `изменила роль ${m.name ?? ''}` : `изменил роль ${m.name ?? ''}`,
+                  board_created:           isFem ? `создала доску «${m.name ?? ''}»` : `создал доску «${m.name ?? ''}»`,
+                  board_updated:           m.nameFrom
+                    ? (isFem ? `переименовала доску «${m.nameFrom}» → «${m.nameTo ?? ''}»` : `переименовал доску «${m.nameFrom}» → «${m.nameTo ?? ''}»`)
+                    : (isFem ? `обновила доску «${m.boardName ?? ''}»` : `обновил доску «${m.boardName ?? ''}»`),
+                  board_deleted:           isFem ? `удалила доску «${m.name ?? ''}»` : `удалил доску «${m.name ?? ''}»`,
+                  workflow_created:        isFem ? `создала воркфлоу «${m.name ?? ''}»` : `создал воркфлоу «${m.name ?? ''}»`,
+                  workflow_updated:        m.nameFrom
+                    ? (isFem ? `переименовала воркфлоу «${m.nameFrom}» → «${m.nameTo ?? ''}»` : `переименовал воркфлоу «${m.nameFrom}» → «${m.nameTo ?? ''}»`)
+                    : (isFem ? `обновила воркфлоу «${m.workflowName ?? ''}»` : `обновил воркфлоу «${m.workflowName ?? ''}»`),
+                  workflow_deleted:        isFem ? `удалила воркфлоу «${m.name ?? ''}»` : `удалил воркфлоу «${m.name ?? ''}»`,
+                  workflow_status_added:   isFem ? `добавила колонку «${m.statusName ?? ''}» в воркфлоу «${m.workflowName ?? ''}»` : `добавил колонку «${m.statusName ?? ''}» в воркфлоу «${m.workflowName ?? ''}»`,
+                  workflow_status_renamed: isFem ? `переименовала колонку «${m.nameFrom ?? ''}» → «${m.nameTo ?? ''}»` : `переименовал колонку «${m.nameFrom ?? ''}» → «${m.nameTo ?? ''}»`,
+                  workflow_status_deleted: isFem ? `удалила колонку «${m.statusName ?? ''}» из воркфлоу «${m.workflowName ?? ''}»` : `удалил колонку «${m.statusName ?? ''}» из воркфлоу «${m.workflowName ?? ''}»`,
                 };
                 const label = ACTION_LABELS[ev.action] ?? ev.action;
                 const time  = new Date(ev.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });


### PR DESCRIPTION
## Summary

- Удалён `applyFilters()` — клиентская фильтрация не работала корректно на больших досках (>100 задач/колонка); фильтр применялся только к загруженным задачам
- Добавлен `fetchFilteredColumns`: при активных фильтрах перезапрашивает все колонки параллельно с server-side params (`search`, `priority`, `assigneeId`, `labelId`, `duePreset`)
- `statusId` фильтр остаётся клиентским — используется только для скрытия колонок в kanban / фильтрации плоского списка
- Shimmer-прогресс-бар под FilterBar во время загрузки фильтров

## Race conditions / safety

- **Stale response guard**: `filterFetchIdRef` — быстрая смена фильтров отбрасывает устаревшие ответы
- **loadMoreColumn**: блокируется при `filterLoading=true`; снимок фильтров на старте предотвращает corruption при смене фильтра mid-flight
- **Board navigation**: `lastBoardIdRef` сбрасывает `hadActiveFiltersRef` при переходе на другую доску

## Test plan

- [ ] Фильтр по исполнителю возвращает корректные задачи даже если в колонке >100 задач
- [ ] Фильтр по приоритету, лейблу, дедлайну работают через сервер
- [ ] Поиск дебаунсится (300ms), лишних запросов нет
- [ ] Сброс фильтра перезагружает оригинальное состояние доски
- [ ] Быстрое переключение фильтров — на экране только результат последнего
- [ ] Кнопка "Загрузить ещё" недоступна пока идёт filterLoading
- [ ] `tsc --noEmit` без ошибок

🤖 Generated with [Claude Code](https://claude.ai/claude-code)