### PR TITLE
fix/feat: labels bug (#128), activity feed (#129), screenshot (#110), @mentions (#131)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^6.19.2",
         "@types/cookie-parser": "^1.4.10",
+        "@types/multer": "^2.1.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -18,6 +19,7 @@
         "express": "^4.21.2",
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.1.1",
         "nodemailer": "^8.0.7",
         "openid-client": "^6.8.4",
         "redis": "^5.11.0",
@@ -1581,6 +1583,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -2129,6 +2140,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2258,6 +2275,23 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2487,6 +2521,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -4356,6 +4405,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4840,6 +4908,20 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -5194,6 +5276,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -5543,6 +5642,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5605,6 +5710,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@prisma/client": "^6.19.2",
     "@types/cookie-parser": "^1.4.10",
+    "@types/multer": "^2.1.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
@@ -33,6 +34,7 @@
     "express": "^4.21.2",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.1.1",
     "nodemailer": "^8.0.7",
     "openid-client": "^6.8.4",
     "redis": "^5.11.0",
@@ -54,6 +56,7 @@
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^9.1.2",
     "globals": "^17.4.0",
@@ -62,7 +65,6 @@
     "tsx": "^4.19.3",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.58.0",
-    "@vitest/coverage-v8": "^3.2.4",
     "vitest": "^3.0.8"
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import checklistsRouter, { taskChecklistsRouter, checklistItemsRouter } from './
 import adminRouter from './modules/admin/admin.router.js';
 import feedbackRouter from './modules/feedback/feedback.router.js';
 import integrationsRouter from './modules/integrations/integrations.router.js';
+import notificationsRouter from './modules/notifications/notifications.router.js';
 
 export function createApp() {
   const app = express();
@@ -62,6 +63,7 @@ export function createApp() {
   app.use('/api/admin', adminRouter);
   app.use('/api/feedback', feedbackRouter);
   app.use('/api/integrations', integrationsRouter);
+  app.use('/api/notifications', notificationsRouter);
 
   // Error handler (must be last)
   app.use(errorHandler);

--- a/backend/src/modules/admin/admin.router.ts
+++ b/backend/src/modules/admin/admin.router.ts
@@ -63,8 +63,9 @@ router.get('/audit-log', async (req, res, next) => {
   try {
     const rawLimit = parseInt(String(req.query.limit ?? '100'), 10);
     const limit = Number.isNaN(rawLimit) ? 100 : Math.min(rawLimit, 500);
-    const logs = await adminService.listAuditLogs(limit);
-    res.json(logs);
+    const rawOffset = parseInt(String(req.query.offset ?? '0'), 10);
+    const offset = Number.isNaN(rawOffset) ? 0 : Math.max(rawOffset, 0);
+    res.json(await adminService.listAuditLogs(limit, offset));
   } catch (err) {
     next(err);
   }

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -141,9 +141,14 @@ export async function reviewRegistrationRequest(
   }
 }
 
-export async function listAuditLogs(limit = 100) {
-  return prisma.auditLog.findMany({
-    orderBy: { createdAt: 'desc' },
-    take: limit,
-  });
+export async function listAuditLogs(limit = 100, offset = 0) {
+  const [logs, total] = await prisma.$transaction([
+    prisma.auditLog.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.auditLog.count(),
+  ]);
+  return { logs, total };
 }

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -91,6 +91,8 @@ export async function getBoard(boardId: string, userId: string) {
         take: 100,
         include: {
           assignee: { select: { id: true, name: true, avatar: true } },
+          status: { select: { id: true, name: true, color: true, category: true } },
+          labels: { include: { label: { select: { id: true, name: true, color: true } } } },
           _count: { select: { children: true } },
         },
       },

--- a/backend/src/modules/comments/comments.router.ts
+++ b/backend/src/modules/comments/comments.router.ts
@@ -10,7 +10,11 @@ export const taskCommentsRouter = Router({ mergeParams: true });
 taskCommentsRouter.use(authenticate);
 
 taskCommentsRouter.get('/', authHandler(async (req, res) => {
-  res.json(await comments.listComments(String(req.params.tid), req.user!.userId));
+  const rawLimit  = parseInt(String(req.query.limit  ?? '50'), 10);
+  const rawOffset = parseInt(String(req.query.offset ?? '0'),  10);
+  const limit  = Math.min(Number.isNaN(rawLimit)  ? 50 : rawLimit,  200);
+  const offset = Math.max(Number.isNaN(rawOffset) ? 0  : rawOffset, 0);
+  res.json(await comments.listComments(String(req.params.tid), req.user!.userId, limit, offset));
 }));
 
 taskCommentsRouter.post('/', validate(createCommentDto), authHandler(async (req, res) => {

--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -17,8 +17,12 @@ async function verifyTaskAccess(taskId: string, userId: string) {
   return member;
 }
 
-export async function listComments(taskId: string, userId: string) {
-  // Verify read access (any member can read)
+export async function listComments(
+  taskId: string,
+  userId: string,
+  limit = 50,
+  offset = 0,
+) {
   const task = await prisma.task.findUnique({ where: { id: taskId }, include: { board: true } });
   if (!task) throw new AppError(404, 'Task not found');
   const member = await prisma.workspaceMember.findUnique({
@@ -26,17 +30,30 @@ export async function listComments(taskId: string, userId: string) {
   });
   if (!member) throw new AppError(403, 'Access denied');
 
-  return prisma.comment.findMany({
-    where: { taskId },
-    orderBy: { createdAt: 'asc' },
-    include: { author: { select: AUTHOR_SELECT } },
-  });
+  const where = { taskId };
+  const [comments, total] = await prisma.$transaction([
+    prisma.comment.findMany({
+      where,
+      orderBy: { createdAt: 'asc' },
+      take: limit,
+      skip: offset,
+      include: { author: { select: AUTHOR_SELECT } },
+    }),
+    prisma.comment.count({ where }),
+  ]);
+  return { comments, total };
 }
 
 export async function createComment(taskId: string, userId: string, dto: CreateCommentDto) {
   await verifyTaskAccess(taskId, userId);
 
-  const task = await prisma.task.findUniqueOrThrow({ where: { id: taskId }, select: { title: true, issueKey: true } });
+  const task = await prisma.task.findUniqueOrThrow({
+    where: { id: taskId },
+    select: {
+      title: true, issueKey: true,
+      board: { select: { prefix: true, workspace: { select: { slug: true } } } },
+    },
+  });
   const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
 
   const comment = await prisma.comment.create({
@@ -50,6 +67,8 @@ export async function createComment(taskId: string, userId: string, dto: CreateC
     taskKey: task.issueKey,
     mentionedBy: author,
     context: 'comment',
+    workspaceSlug: task.board.workspace.slug,
+    boardSlug: task.board.prefix.toLowerCase(),
   }, userId);
 
   return comment;
@@ -67,7 +86,13 @@ export async function updateComment(commentId: string, userId: string, dto: Upda
   });
 
   // Emit notifications for newly added mentions (re-emit all — dedup by context is acceptable at this scale)
-  const task = await prisma.task.findUniqueOrThrow({ where: { id: comment.taskId }, select: { title: true, issueKey: true } });
+  const task = await prisma.task.findUniqueOrThrow({
+    where: { id: comment.taskId },
+    select: {
+      title: true, issueKey: true,
+      board: { select: { prefix: true, workspace: { select: { slug: true } } } },
+    },
+  });
   const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
   await emitMentionNotifications(dto.body, {
     taskId: comment.taskId,
@@ -75,6 +100,8 @@ export async function updateComment(commentId: string, userId: string, dto: Upda
     taskKey: task.issueKey,
     mentionedBy: author,
     context: 'comment',
+    workspaceSlug: task.board.workspace.slug,
+    boardSlug: task.board.prefix.toLowerCase(),
   }, userId);
 
   return updated;

--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -69,6 +69,7 @@ export async function createComment(taskId: string, userId: string, dto: CreateC
     context: 'comment',
     workspaceSlug: task.board.workspace.slug,
     boardSlug: task.board.prefix.toLowerCase(),
+    body: dto.body,
   }, userId);
 
   return comment;
@@ -102,6 +103,7 @@ export async function updateComment(commentId: string, userId: string, dto: Upda
     context: 'comment',
     workspaceSlug: task.board.workspace.slug,
     boardSlug: task.board.prefix.toLowerCase(),
+    body: dto.body,
   }, userId);
 
   return updated;

--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
+import { emitMentionNotifications } from '../notifications/notifications.service.js';
 import type { CreateCommentDto, UpdateCommentDto } from './comments.dto.js';
 
 const AUTHOR_SELECT = { id: true, name: true, avatar: true } as const;
@@ -35,10 +36,23 @@ export async function listComments(taskId: string, userId: string) {
 export async function createComment(taskId: string, userId: string, dto: CreateCommentDto) {
   await verifyTaskAccess(taskId, userId);
 
-  return prisma.comment.create({
+  const task = await prisma.task.findUniqueOrThrow({ where: { id: taskId }, select: { title: true, issueKey: true } });
+  const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
+
+  const comment = await prisma.comment.create({
     data: { taskId, authorId: userId, body: dto.body },
     include: { author: { select: AUTHOR_SELECT } },
   });
+
+  await emitMentionNotifications(dto.body, {
+    taskId,
+    taskTitle: task.title,
+    taskKey: task.issueKey,
+    mentionedBy: author,
+    context: 'comment',
+  }, userId);
+
+  return comment;
 }
 
 export async function updateComment(commentId: string, userId: string, dto: UpdateCommentDto) {
@@ -46,11 +60,24 @@ export async function updateComment(commentId: string, userId: string, dto: Upda
   if (!comment) throw new AppError(404, 'Comment not found');
   if (comment.authorId !== userId) throw new AppError(403, 'Only the author can edit this comment');
 
-  return prisma.comment.update({
+  const updated = await prisma.comment.update({
     where: { id: commentId },
     data: { body: dto.body },
     include: { author: { select: AUTHOR_SELECT } },
   });
+
+  // Emit notifications for newly added mentions (re-emit all — dedup by context is acceptable at this scale)
+  const task = await prisma.task.findUniqueOrThrow({ where: { id: comment.taskId }, select: { title: true, issueKey: true } });
+  const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
+  await emitMentionNotifications(dto.body, {
+    taskId: comment.taskId,
+    taskTitle: task.title,
+    taskKey: task.issueKey,
+    mentionedBy: author,
+    context: 'comment',
+  }, userId);
+
+  return updated;
 }
 
 export async function deleteComment(commentId: string, userId: string) {

--- a/backend/src/modules/feedback/feedback.dto.ts
+++ b/backend/src/modules/feedback/feedback.dto.ts
@@ -1,20 +1,29 @@
 import { z } from 'zod';
 import { stripHtml } from '../../shared/utils/sanitize.js';
 
+const metaSchema = z.object({
+  ua:         z.string().max(500),
+  screen:     z.string().max(50),
+  viewport:   z.string().max(50),
+  url:        z.string().max(500).url().optional().or(z.literal('')),
+  language:   z.string().max(20),
+  deviceType: z.enum(['mobile', 'tablet', 'desktop']).optional(),
+  os:         z.string().max(50).optional(),
+  browser:    z.string().max(50).optional(),
+});
+
 export const feedbackDto = z.object({
   title: stripHtml(z.string().min(3, 'Заголовок слишком короткий').max(200, 'Заголовок слишком длинный')),
   body: stripHtml(z.string().min(10, 'Описание слишком короткое').max(5000, 'Описание слишком длинное')),
   type: z.enum(['bug', 'idea'], { message: 'Тип должен быть bug или idea' }),
-  meta: z.object({
-    ua:         z.string().max(500),
-    screen:     z.string().max(50),
-    viewport:   z.string().max(50),
-    url:        z.string().max(500).url().optional().or(z.literal('')),
-    language:   z.string().max(20),
-    deviceType: z.enum(['mobile', 'tablet', 'desktop']).optional(),
-    os:         z.string().max(50).optional(),
-    browser:    z.string().max(50).optional(),
-  }).optional(),
+  // multipart sends meta as a JSON string; preprocess handles both cases
+  meta: z.preprocess(
+    (v) => (typeof v === 'string' ? JSON.parse(v) : v),
+    metaSchema,
+  ).optional(),
 });
 
 export type FeedbackDto = z.infer<typeof feedbackDto>;
+
+export const SCREENSHOT_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+export const SCREENSHOT_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'] as const;

--- a/backend/src/modules/feedback/feedback.router.ts
+++ b/backend/src/modules/feedback/feedback.router.ts
@@ -1,22 +1,36 @@
 import { Router } from 'express';
+import multer from 'multer';
 import { validate } from '../../shared/middleware/validate.js';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { rateLimit, RATE_LIMITS } from '../../shared/middleware/rate-limit.js';
-import { feedbackDto } from './feedback.dto.js';
+import { feedbackDto, SCREENSHOT_MAX_BYTES, SCREENSHOT_ALLOWED_MIME } from './feedback.dto.js';
 import * as feedbackService from './feedback.service.js';
 import type { AuthRequest } from '../../shared/types/index.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
 
 const router = Router();
 
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: SCREENSHOT_MAX_BYTES, files: 1 },
+  fileFilter: (_req, file, cb) => {
+    if ((SCREENSHOT_ALLOWED_MIME as readonly string[]).includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new AppError(400, 'Допустимые форматы: PNG, JPG, WEBP, GIF') as unknown as null, false);
+    }
+  },
+});
+
 const feedbackLimit = rateLimit({ ...RATE_LIMITS.feedback, keyFn: (req) => (req as AuthRequest).user!.userId });
 
-router.post('/', authenticate, feedbackLimit, validate(feedbackDto), async (req: AuthRequest, res, next) => {
+router.post('/', authenticate, feedbackLimit, upload.single('screenshot'), validate(feedbackDto), async (req: AuthRequest, res, next) => {
   try {
     const result = await feedbackService.submitFeedback(req.body, {
       id: req.user!.userId,
       name: req.user!.name ?? req.user!.email,
       email: req.user!.email,
-    });
+    }, req.file ?? undefined);
     res.json(result);
   } catch (err) {
     next(err);

--- a/backend/src/modules/feedback/feedback.service.ts
+++ b/backend/src/modules/feedback/feedback.service.ts
@@ -15,7 +15,37 @@ function escapeMd(value: string | undefined | null): string {
   return value.replace(/[\r\n]/g, ' ').replace(/[_*`[\]()~>#+=|{}.!\\-]/g, '\\$&');
 }
 
-export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
+async function uploadScreenshotToGitHub(file: Express.Multer.File): Promise<string | null> {
+  if (!config.GITHUB_ISSUES_TOKEN) return null;
+
+  const ext = file.mimetype.split('/')[1] ?? 'png';
+  const filename = `feedback-screenshots/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+  const content = file.buffer.toString('base64');
+
+  const res = await fetch(
+    `https://api.github.com/repos/${config.GITHUB_REPO_OWNER}/${config.GITHUB_REPO_NAME}/contents/${filename}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${config.GITHUB_ISSUES_TOKEN}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({ message: 'chore: feedback screenshot', content }),
+    },
+  );
+
+  if (!res.ok) {
+    console.error('[FEEDBACK] screenshot upload failed: status=%d', res.status);
+    return null;
+  }
+
+  const data = await res.json() as { content: { download_url: string } };
+  return data.content.download_url;
+}
+
+export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser, screenshot?: Express.Multer.File) {
   if (!config.GITHUB_ISSUES_TOKEN) {
     throw new AppError(503, 'Отправка обратной связи временно недоступна');
   }
@@ -27,10 +57,14 @@ export async function submitFeedback(dto: FeedbackDto, user: FeedbackUser) {
         `**Экран:** ${escapeMd(dto.meta.screen)} / вьюпорт: ${escapeMd(dto.meta.viewport)}`,
         `**Язык:** ${escapeMd(dto.meta.language)}`,
         `**URL:** ${escapeMd(dto.meta.url)}`,
-        `**UA:** ${escapeMd(dto.meta.ua)}`,
+        `**UA:** \`${escapeMd(dto.meta.ua)}\``,
       ].join('\n')
     : '*нет данных об устройстве*';
-  const bodyWithMeta = `${escapeMd(dto.body)}\n\n---\n**Отправитель:** ${escapeMd(user.name)} (${escapeMd(user.email)})\n**Окружение:** ${escapeMd(config.NODE_ENV)}\n\n### Устройство\n${deviceSection}`;
+
+  const screenshotUrl = screenshot ? await uploadScreenshotToGitHub(screenshot) : null;
+  const screenshotSection = screenshotUrl ? `\n\n### Скриншот\n![Скриншот](${screenshotUrl})` : '';
+
+  const bodyWithMeta = `${escapeMd(dto.body)}\n\n---\n**Отправитель:** ${escapeMd(user.name)} (${escapeMd(user.email)})\n**Окружение:** ${escapeMd(config.NODE_ENV)}\n\n### Устройство\n${deviceSection}${screenshotSection}`;
 
   const response = await fetch(
     `https://api.github.com/repos/${config.GITHUB_REPO_OWNER}/${config.GITHUB_REPO_NAME}/issues`,

--- a/backend/src/modules/notifications/notifications.router.ts
+++ b/backend/src/modules/notifications/notifications.router.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import * as svc from './notifications.service.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+
+const router = Router();
+
+router.get('/', authenticate, async (req: AuthRequest, res, next) => {
+  try {
+    const limit = Math.min(Number(req.query.limit) || 20, 100);
+    const offset = Number(req.query.offset) || 0;
+    res.json(await svc.listNotifications(req.user!.userId, limit, offset));
+  } catch (err) { next(err); }
+});
+
+router.patch('/read-all', authenticate, async (req: AuthRequest, res, next) => {
+  try {
+    await svc.markAllRead(req.user!.userId);
+    res.json({ ok: true });
+  } catch (err) { next(err); }
+});
+
+router.patch('/:id/read', authenticate, async (req: AuthRequest, res, next) => {
+  try {
+    await svc.markRead(String(req.params.id), req.user!.userId);
+    res.json({ ok: true });
+  } catch (err) { next(err); }
+});
+
+export default router;

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -1,0 +1,75 @@
+import { prisma } from '../../prisma/client.js';
+
+export interface MentionPayload {
+  taskId: string;
+  taskTitle: string;
+  taskKey: string;
+  mentionedBy: { id: string; name: string };
+  context: 'task' | 'comment';
+}
+
+// Extract user IDs from mention markers: @[Display Name](userId)
+const MENTION_RE = /@\[[^\]]*\]\(([a-f0-9-]{36})\)/g;
+
+export function extractMentionedUserIds(text: string | null | undefined): string[] {
+  if (!text) return [];
+  return [...text.matchAll(MENTION_RE)].map((m) => m[1]);
+}
+
+export async function emitMentionNotifications(
+  text: string | null | undefined,
+  payload: MentionPayload,
+  authorId: string,
+) {
+  const userIds = extractMentionedUserIds(text);
+  const recipients = userIds.filter((id) => id !== authorId);
+  if (recipients.length === 0) return;
+
+  // Deduplicate
+  const unique = [...new Set(recipients)];
+
+  // Verify users exist (avoid FK violation on stale mentions)
+  const existing = await prisma.user.findMany({
+    where: { id: { in: unique } },
+    select: { id: true },
+  });
+  const validIds = new Set(existing.map((u) => u.id));
+
+  await prisma.notification.createMany({
+    data: unique
+      .filter((id) => validIds.has(id))
+      .map((userId) => ({
+        userId,
+        type: 'mention',
+        payload: payload as object,
+      })),
+    skipDuplicates: false,
+  });
+}
+
+export async function listNotifications(userId: string, limit = 20, offset = 0) {
+  const [items, unread] = await prisma.$transaction([
+    prisma.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.notification.count({ where: { userId, isRead: false } }),
+  ]);
+  return { items, unread };
+}
+
+export async function markRead(notificationId: string, userId: string) {
+  return prisma.notification.updateMany({
+    where: { id: notificationId, userId },
+    data: { isRead: true },
+  });
+}
+
+export async function markAllRead(userId: string) {
+  return prisma.notification.updateMany({
+    where: { userId, isRead: false },
+    data: { isRead: true },
+  });
+}

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -22,8 +22,8 @@ export async function emitMentionNotifications(
   authorId: string,
 ) {
   const userIds = extractMentionedUserIds(text);
-  const recipients = userIds.filter((id) => id !== authorId);
-  if (recipients.length === 0) return;
+  if (userIds.length === 0) return;
+  const recipients = userIds;
 
   // Deduplicate
   const unique = [...new Set(recipients)];

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -8,6 +8,7 @@ export interface MentionPayload {
   context: 'task' | 'comment';
   workspaceSlug: string;
   boardSlug: string;
+  body?: string;
 }
 
 // Extract user IDs from mention markers: @[Display Name](userId)

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -6,6 +6,8 @@ export interface MentionPayload {
   taskKey: string;
   mentionedBy: { id: string; name: string };
   context: 'task' | 'comment';
+  workspaceSlug: string;
+  boardSlug: string;
 }
 
 // Extract user IDs from mention markers: @[Display Name](userId)

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -231,8 +231,10 @@ export async function getTask(taskId: string, userId: string) {
       },
       comments: {
         orderBy: { createdAt: 'asc' },
+        take: 50,
         include: { author: { select: { id: true, name: true, avatar: true } } },
       },
+      _count: { select: { comments: true, children: true } },
       checklists: {
         orderBy: { orderIndex: 'asc' },
         include: { items: { orderBy: { orderIndex: 'asc' } } },

--- a/backend/src/modules/workspaces/workspaces.router.ts
+++ b/backend/src/modules/workspaces/workspaces.router.ts
@@ -68,7 +68,11 @@ router.get('/:id/boards/by-prefix/:prefix', authHandler(async (req, res) => {
 }));
 
 router.get('/:id/history', authHandler(async (req, res) => {
-  res.json(await ws.getWorkspaceHistory(String(req.params.id), req.user!.userId));
+  const rawLimit  = parseInt(String(req.query.limit  ?? '50'), 10);
+  const rawOffset = parseInt(String(req.query.offset ?? '0'),  10);
+  const limit  = Math.min(Number.isNaN(rawLimit)  ? 50 : rawLimit,  200);
+  const offset = Math.max(Number.isNaN(rawOffset) ? 0  : rawOffset, 0);
+  res.json(await ws.getWorkspaceHistory(String(req.params.id), req.user!.userId, limit, offset));
 }));
 
 export default router;

--- a/backend/src/modules/workspaces/workspaces.service.ts
+++ b/backend/src/modules/workspaces/workspaces.service.ts
@@ -273,15 +273,24 @@ export async function searchMembers(workspaceId: string, query: string) {
 
 // ─── Workspace History ────────────────────────────────────────────────────────
 
-export async function getWorkspaceHistory(workspaceId: string, userId: string) {
+export async function getWorkspaceHistory(
+  workspaceId: string,
+  userId: string,
+  limit = 50,
+  offset = 0,
+) {
   await assertOwner(workspaceId, userId);
 
-  return prisma.workspaceEvent.findMany({
-    where: { workspaceId },
-    include: {
-      user: { select: { id: true, name: true, avatar: true } },
-    },
-    orderBy: { createdAt: 'desc' },
-    take: 100,
-  });
+  const where = { workspaceId };
+  const [events, total] = await prisma.$transaction([
+    prisma.workspaceEvent.findMany({
+      where,
+      include: { user: { select: { id: true, name: true, avatar: true } } },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.workspaceEvent.count({ where }),
+  ]);
+  return { events, total };
 }

--- a/backend/src/prisma/migrations/20260506_add_notifications/migration.sql
+++ b/backend/src/prisma/migrations/20260506_add_notifications/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "notifications_userId_isRead_createdAt_idx" ON "notifications"("userId", "isRead", "createdAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   workspaceEvents      WorkspaceEvent[]
   reviewedRegistrations RegistrationRequest[] @relation("RegistrationReviewer")
   feedbacks             Feedback[]
+  notifications         Notification[]
 
   @@map("users")
 }
@@ -444,4 +445,20 @@ model TaskHistory {
 
   @@index([taskId, createdAt])
   @@map("task_history")
+}
+
+// ─── Notifications ────────────────────────────────────────────────────────────
+
+model Notification {
+  id        String   @id @default(uuid())
+  userId    String                          // recipient
+  type      String                          // "mention"
+  payload   Json                            // { taskId, taskTitle, taskKey, mentionedBy: {id,name}, context: "task"|"comment" }
+  isRead    Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, isRead, createdAt(sort: Desc)])
+  @@map("notifications")
 }

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -1,8 +1,14 @@
 import api from './client';
 import type { Comment } from '../types';
 
-export async function listComments(taskId: string): Promise<Comment[]> {
-  const { data } = await api.get<Comment[]>(`/tasks/${taskId}/comments`);
+export async function listComments(
+  taskId: string,
+  params?: { limit?: number; offset?: number },
+): Promise<{ comments: Comment[]; total: number }> {
+  const { data } = await api.get<{ comments: Comment[]; total: number }>(
+    `/tasks/${taskId}/comments`,
+    { params },
+  );
   return data;
 }
 

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,0 +1,36 @@
+import api from './client';
+
+export interface MentionPayload {
+  taskId: string;
+  taskTitle: string;
+  taskKey: string;
+  mentionedBy: { id: string; name: string };
+  context: 'task' | 'comment';
+}
+
+export interface Notification {
+  id: string;
+  userId: string;
+  type: string;
+  payload: MentionPayload;
+  isRead: boolean;
+  createdAt: string;
+}
+
+export interface NotificationsResponse {
+  items: Notification[];
+  unread: number;
+}
+
+export async function listNotifications(limit = 20, offset = 0): Promise<NotificationsResponse> {
+  const { data } = await api.get<NotificationsResponse>('/notifications', { params: { limit, offset } });
+  return data;
+}
+
+export async function markRead(id: string): Promise<void> {
+  await api.patch(`/notifications/${id}/read`);
+}
+
+export async function markAllRead(): Promise<void> {
+  await api.patch('/notifications/read-all');
+}

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -6,6 +6,8 @@ export interface MentionPayload {
   taskKey: string;
   mentionedBy: { id: string; name: string };
   context: 'task' | 'comment';
+  workspaceSlug: string;
+  boardSlug: string;
 }
 
 export interface Notification {

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -8,6 +8,7 @@ export interface MentionPayload {
   context: 'task' | 'comment';
   workspaceSlug: string;
   boardSlug: string;
+  body?: string;
 }
 
 export interface Notification {

--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -68,7 +68,13 @@ export async function inviteByEmail(
   return data;
 }
 
-export async function getWorkspaceHistory(workspaceId: string): Promise<WorkspaceEvent[]> {
-  const { data } = await api.get<WorkspaceEvent[]>(`/workspaces/${workspaceId}/history`);
+export async function getWorkspaceHistory(
+  workspaceId: string,
+  params?: { limit?: number; offset?: number },
+): Promise<{ events: WorkspaceEvent[]; total: number }> {
+  const { data } = await api.get<{ events: WorkspaceEvent[]; total: number }>(
+    `/workspaces/${workspaceId}/history`,
+    { params },
+  );
   return data;
 }

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '../store/auth.store';
 import { useWorkspaceStore } from '../store/workspace.store';
 import { useThemeStore } from '../store/theme.store';
 import { useBreakpoint, useIsLandscape } from '../utils/useBreakpoint';
+import NotificationBell from './NotificationBell';
 
 
 interface Props { children: React.ReactNode }
@@ -337,6 +338,9 @@ export default function AppLayout({ children }: Props) {
             </svg>
           )}
         </button>
+
+        {/* Notification Bell */}
+        <NotificationBell />
 
         {/* Avatar */}
         <div style={{ position: 'relative' }}>

--- a/frontend/src/components/CommentThread.tsx
+++ b/frontend/src/components/CommentThread.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { message } from 'antd';
 import { useThemeStore } from '../store/theme.store';
-import type { Comment } from '../types';
+import type { Comment, WorkspaceMember } from '../types';
 import * as commentsApi from '../api/comments';
 import { useAuthStore } from '../store/auth.store';
+import MentionTextarea from './MentionTextarea';
 
 // ── Design tokens ──────────────────────────────────────────────────────────────
 type C = Record<string, string>;
@@ -36,10 +37,11 @@ interface Props {
   taskId: string;
   comments: Comment[];
   onCommentsChanged: (comments: Comment[]) => void;
+  members?: WorkspaceMember[];
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
-export default function CommentThread({ taskId, comments, onCommentsChanged }: Props) {
+export default function CommentThread({ taskId, comments, onCommentsChanged, members = [] }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
   const c = isDark ? DARK : LIGHT;
@@ -250,18 +252,13 @@ export default function CommentThread({ taskId, comments, onCommentsChanged }: P
           </span>
         </div>
         <div style={{ flex: 1 }}>
-          <textarea
+          <MentionTextarea
             value={newBody}
-            onChange={e => setNewBody(e.target.value)}
-            placeholder="Написать комментарий..."
+            onChange={setNewBody}
+            members={members}
+            placeholder="Написать комментарий... (@имя для упоминания)"
             rows={2}
-            onKeyDown={e => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) submit(); }}
-            style={{
-              ...textareaStyle(false),
-              color: newBody ? c.inputText : c.inputPlaceholder,
-            }}
-            onFocus={e => { (e.target as HTMLTextAreaElement).style.borderColor = c.inputBorderFocus; }}
-            onBlur={e => { (e.target as HTMLTextAreaElement).style.borderColor = c.inputBorder; }}
+            style={textareaStyle(false)}
           />
           {newBody.trim() && (
             <button

--- a/frontend/src/components/CommentThread.tsx
+++ b/frontend/src/components/CommentThread.tsx
@@ -4,7 +4,7 @@ import { useThemeStore } from '../store/theme.store';
 import type { Comment, WorkspaceMember } from '../types';
 import * as commentsApi from '../api/comments';
 import { useAuthStore } from '../store/auth.store';
-import MentionTextarea from './MentionTextarea';
+import MentionTextarea, { renderMentions } from './MentionTextarea';
 
 // ── Design tokens ──────────────────────────────────────────────────────────────
 type C = Record<string, string>;
@@ -165,7 +165,7 @@ export default function CommentThread({ taskId, comments, onCommentsChanged, mem
                   fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13,
                   color: c.bodyText, whiteSpace: 'pre-wrap', flex: 1, lineHeight: '18px',
                 }}>
-                  {comment.body}
+                  {renderMentions(comment.body)}
                 </span>
                 {currentUser?.id === comment.authorId && (
                   <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>

--- a/frontend/src/components/CommentThread.tsx
+++ b/frontend/src/components/CommentThread.tsx
@@ -36,15 +36,17 @@ function avatarInitials(name: string): string { return name.split(/\s+/).map(w =
 interface Props {
   taskId: string;
   comments: Comment[];
+  commentsTotal?: number;
   onCommentsChanged: (comments: Comment[]) => void;
   members?: WorkspaceMember[];
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
-export default function CommentThread({ taskId, comments, onCommentsChanged, members = [] }: Props) {
+export default function CommentThread({ taskId, comments, commentsTotal, onCommentsChanged, members = [] }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
   const c = isDark ? DARK : LIGHT;
+  const [loadingMore, setLoadingMore] = useState(false);
 
   const currentUser = useAuthStore(s => s.user);
   const [newBody, setNewBody]     = useState('');
@@ -239,6 +241,32 @@ export default function CommentThread({ taskId, comments, onCommentsChanged, mem
           </div>
         </div>
       ))}
+
+      {/* Load more comments */}
+      {commentsTotal !== undefined && comments.length < commentsTotal && (
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 12 }}>
+          <button
+            onClick={async () => {
+              setLoadingMore(true);
+              try {
+                const { comments: more } = await commentsApi.listComments(taskId, { offset: comments.length });
+                onCommentsChanged([...comments, ...more]);
+              } catch { message.error('Не удалось загрузить комментарии'); }
+              finally { setLoadingMore(false); }
+            }}
+            disabled={loadingMore}
+            style={{
+              fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
+              color: '#4F6EF7', background: 'transparent',
+              border: '1px solid #4F6EF7', borderRadius: 7,
+              padding: '4px 14px', cursor: 'pointer',
+              opacity: loadingMore ? 0.5 : 1,
+            }}
+          >
+            {loadingMore ? 'Загрузка...' : `Ещё комментарии (${commentsTotal - comments.length})`}
+          </button>
+        </div>
+      )}
 
       {/* New comment input */}
       <div style={{ display: 'flex', gap: 10 }}>

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Modal, Form, Input, Radio, Button, message } from 'antd';
 import api from '../api/client';
 import { formatApiError } from '../utils/apiError';
@@ -8,9 +8,15 @@ interface FeedbackModalProps {
   onClose: () => void;
 }
 
+const SCREENSHOT_MAX_BYTES = 5 * 1024 * 1024;
+const SCREENSHOT_ALLOWED = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+
 export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   const [loading, setLoading] = useState(false);
   const [form] = Form.useForm();
+  const [screenshot, setScreenshot] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   function collectDeviceMeta() {
     const ua = navigator.userAgent;
@@ -47,12 +53,46 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
     };
   }
 
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] ?? null;
+    if (!file) return;
+    if (!SCREENSHOT_ALLOWED.includes(file.type)) {
+      message.error('Допустимые форматы: PNG, JPG, WEBP, GIF');
+      return;
+    }
+    if (file.size > SCREENSHOT_MAX_BYTES) {
+      message.error('Файл не должен превышать 5 МБ');
+      return;
+    }
+    setScreenshot(file);
+    setPreview(URL.createObjectURL(file));
+  }
+
+  function removeScreenshot() {
+    setScreenshot(null);
+    if (preview) URL.revokeObjectURL(preview);
+    setPreview(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }
+
+  function handleClose() {
+    form.resetFields();
+    removeScreenshot();
+    onClose();
+  }
+
   const onFinish = async (values: { title: string; body: string; type: 'bug' | 'idea' }) => {
     setLoading(true);
     try {
-      const res = await api.post<{ url: string; number: number }>('/feedback', {
-        ...values,
-        meta: collectDeviceMeta(),
+      const formData = new FormData();
+      formData.append('title', values.title);
+      formData.append('body', values.body);
+      formData.append('type', values.type);
+      formData.append('meta', JSON.stringify(collectDeviceMeta()));
+      if (screenshot) formData.append('screenshot', screenshot);
+
+      const res = await api.post<{ url: string; number: number }>('/feedback', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
       });
       message.success(
         <span>
@@ -61,8 +101,7 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
         </span>,
         5,
       );
-      form.resetFields();
-      onClose();
+      handleClose();
     } catch (err) {
       message.error(formatApiError(err));
     } finally {
@@ -73,7 +112,7 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   return (
     <Modal
       open={open}
-      onCancel={() => { form.resetFields(); onClose(); }}
+      onCancel={handleClose}
       footer={null}
       title="Обратная связь"
       width={480}
@@ -91,6 +130,34 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
         <Form.Item name="body" label="Описание" rules={[{ required: true, message: 'Введите описание' }, { min: 10, message: 'Минимум 10 символов' }]}>
           <Input.TextArea rows={4} placeholder="Подробное описание..." />
         </Form.Item>
+
+        <Form.Item label="Скриншот (необязательно)">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+          {preview ? (
+            <div style={{ position: 'relative', display: 'inline-block' }}>
+              <img src={preview} alt="Скриншот" style={{ maxWidth: '100%', maxHeight: 160, borderRadius: 6, border: '1px solid #d9d9d9', display: 'block' }} />
+              <button
+                type="button"
+                onClick={removeScreenshot}
+                style={{ position: 'absolute', top: 4, right: 4, background: 'rgba(0,0,0,0.55)', border: 'none', borderRadius: '50%', width: 22, height: 22, cursor: 'pointer', color: '#fff', fontSize: 12, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                title="Удалить скриншот"
+              >
+                ✕
+              </button>
+            </div>
+          ) : (
+            <Button type="dashed" onClick={() => fileInputRef.current?.click()} block>
+              Прикрепить скриншот
+            </Button>
+          )}
+        </Form.Item>
+
         <Form.Item style={{ marginBottom: 0 }}>
           <Button type="primary" htmlType="submit" loading={loading} block>
             Отправить

--- a/frontend/src/components/MentionTextarea.tsx
+++ b/frontend/src/components/MentionTextarea.tsx
@@ -11,12 +11,44 @@ interface Props {
   style?: React.CSSProperties;
 }
 
+const MENTION_RE = /@\[([^\]]+)\]\([^)]+\)/g;
+
+// Convert stored @[Name](userId) → display @Name
+function storedToDisplay(text: string): string {
+  return text.replace(/@\[([^\]]+)\]\([^)]+\)/g, '@$1');
+}
+
+// Map a position in the display string to the equivalent position in the stored string
+function displayPosToStoredPos(displayPos: number, stored: string): number {
+  MENTION_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let storedIdx = 0;
+  let displayIdx = 0;
+
+  while ((match = MENTION_RE.exec(stored)) !== null) {
+    const chunkLen = match.index - storedIdx;
+    if (displayIdx + chunkLen >= displayPos) {
+      return storedIdx + (displayPos - displayIdx);
+    }
+    displayIdx += chunkLen;
+    storedIdx = match.index;
+
+    const displayMentionLen = 1 + match[1].length; // @Name
+    if (displayIdx + displayMentionLen >= displayPos) {
+      return storedIdx + match[0].length;
+    }
+    displayIdx += displayMentionLen;
+    storedIdx += match[0].length;
+  }
+  return storedIdx + (displayPos - displayIdx);
+}
+
 // Render text with @[Name](userId) markers as styled spans for display
 export function renderMentions(text: string): React.ReactNode[] {
-  const MENTION_RE = /@\[([^\]]+)\]\([^)]+\)/g;
   const parts: React.ReactNode[] = [];
   let last = 0;
   let match: RegExpExecArray | null;
+  MENTION_RE.lastIndex = 0;
   while ((match = MENTION_RE.exec(text)) !== null) {
     if (match.index > last) parts.push(text.slice(last, match.index));
     parts.push(
@@ -39,10 +71,22 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
   const hoverBg = isDark ? '#1C2236' : '#F5F5FF';
   const mutedColor = isDark ? '#8B949E' : '#9B96B8';
 
+  // displayValue is what the textarea renders; value prop holds @[Name](userId) format
+  const storedRef = useRef(value);
+  const [displayValue, setDisplayValue] = useState(() => storedToDisplay(value));
+
+  // Sync when parent resets value (e.g. after submit)
+  useEffect(() => {
+    if (value !== storedRef.current) {
+      storedRef.current = value;
+      setDisplayValue(storedToDisplay(value));
+    }
+  }, [value]);
+
   const [query, setQuery] = useState('');
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [dropdownPos, setDropdownPos] = useState({ top: 0, left: 0 });
-  const [atStart, setAtStart] = useState(0);
+  const [atStart, setAtStart] = useState(0); // position in displayValue
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -57,22 +101,41 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
   }
 
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    const val = e.target.value;
-    const cursor = e.target.selectionStart ?? val.length;
-    onChange(val);
+    const newDisplay = e.target.value;
+    const cursor = e.target.selectionStart ?? newDisplay.length;
+    const oldDisplay = displayValue;
+    const oldStored = storedRef.current;
 
-    // Find the last @ before cursor
-    const textBeforeCursor = val.slice(0, cursor);
+    // Compute diff: common prefix + suffix
+    let prefixLen = 0;
+    while (prefixLen < oldDisplay.length && prefixLen < newDisplay.length &&
+           oldDisplay[prefixLen] === newDisplay[prefixLen]) prefixLen++;
+
+    let oldSuffix = 0;
+    while (
+      oldSuffix < oldDisplay.length - prefixLen &&
+      oldSuffix < newDisplay.length - prefixLen &&
+      oldDisplay[oldDisplay.length - 1 - oldSuffix] === newDisplay[newDisplay.length - 1 - oldSuffix]
+    ) oldSuffix++;
+
+    const displayInserted = newDisplay.slice(prefixLen, newDisplay.length - oldSuffix);
+    const storedPrefixPos = displayPosToStoredPos(prefixLen, oldStored);
+    const storedDeleteEnd = displayPosToStoredPos(prefixLen + (oldDisplay.length - prefixLen - oldSuffix), oldStored);
+    const newStored = oldStored.slice(0, storedPrefixPos) + displayInserted + oldStored.slice(storedDeleteEnd);
+
+    storedRef.current = newStored;
+    setDisplayValue(newDisplay);
+    onChange(newStored);
+
+    // Detect @ trigger in displayValue
+    const textBeforeCursor = newDisplay.slice(0, cursor);
     const atIdx = textBeforeCursor.lastIndexOf('@');
     if (atIdx !== -1) {
       const segment = textBeforeCursor.slice(atIdx + 1);
-      // Only trigger if no space in the segment (user is still typing the mention)
       if (!segment.includes(' ') && !segment.includes('\n')) {
         setQuery(segment);
         setAtStart(atIdx);
         setDropdownOpen(true);
-
-        // Position dropdown below cursor using a simple heuristic
         if (textareaRef.current) {
           const rect = textareaRef.current.getBoundingClientRect();
           setDropdownPos({ top: rect.height + 4, left: 0 });
@@ -84,16 +147,27 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
   }
 
   function selectMember(member: WorkspaceMember) {
-    const before = value.slice(0, atStart);
-    const after = value.slice(textareaRef.current?.selectionStart ?? atStart + query.length + 1);
-    const mention = `@[${member.user.name}](${member.user.id})`;
-    const newVal = before + mention + ' ' + after;
-    onChange(newVal);
+    // atStart is a position in displayValue
+    const beforeDisplay = displayValue.slice(0, atStart);
+    const cursorInDisplay = textareaRef.current?.selectionStart ?? atStart + query.length + 1;
+    const afterDisplay = displayValue.slice(cursorInDisplay);
+
+    const mentionDisplay = `@${member.user.name} `;
+    const mentionStored = `@[${member.user.name}](${member.user.id}) `;
+
+    const newDisplay = beforeDisplay + mentionDisplay + afterDisplay;
+    const storedBefore = storedRef.current.slice(0, displayPosToStoredPos(atStart, storedRef.current));
+    const storedAfter = storedRef.current.slice(displayPosToStoredPos(cursorInDisplay, storedRef.current));
+    const newStored = storedBefore + mentionStored + storedAfter;
+
+    storedRef.current = newStored;
+    setDisplayValue(newDisplay);
+    onChange(newStored);
     setDropdownOpen(false);
-    // Restore focus
+
     setTimeout(() => {
       if (textareaRef.current) {
-        const pos = (before + mention + ' ').length;
+        const pos = (beforeDisplay + mentionDisplay).length;
         textareaRef.current.focus();
         textareaRef.current.setSelectionRange(pos, pos);
       }
@@ -115,7 +189,7 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
     <div ref={containerRef} style={{ position: 'relative' }}>
       <textarea
         ref={textareaRef}
-        value={value}
+        value={displayValue}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}

--- a/frontend/src/components/MentionTextarea.tsx
+++ b/frontend/src/components/MentionTextarea.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useState } from 'react';
+import { useThemeStore } from '../store/theme.store';
+import type { WorkspaceMember } from '../types';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  members: WorkspaceMember[];
+  placeholder?: string;
+  rows?: number;
+  style?: React.CSSProperties;
+}
+
+// Render text with @[Name](userId) markers as styled spans for display
+export function renderMentions(text: string): React.ReactNode[] {
+  const MENTION_RE = /@\[([^\]]+)\]\([^)]+\)/g;
+  const parts: React.ReactNode[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = MENTION_RE.exec(text)) !== null) {
+    if (match.index > last) parts.push(text.slice(last, match.index));
+    parts.push(
+      <span key={match.index} style={{ color: '#4F6EF7', fontWeight: 500 }}>@{match[1]}</span>
+    );
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+}
+
+export default function MentionTextarea({ value, onChange, members, placeholder, rows = 4, style }: Props) {
+  const mode = useThemeStore(s => s.mode);
+  const isDark = mode === 'dark';
+  const inputBg = isDark ? '#1C2236' : '#FAFAFA';
+  const inputBorder = isDark ? '#2A3352' : '#E8E5F0';
+  const textColor = isDark ? '#E2E8F8' : '#1A1A2E';
+  const dropBg = isDark ? '#0F1320' : '#FFFFFF';
+  const dropBorder = isDark ? '#1C2236' : '#E8E5F0';
+  const hoverBg = isDark ? '#1C2236' : '#F5F5FF';
+  const mutedColor = isDark ? '#8B949E' : '#9B96B8';
+
+  const [query, setQuery] = useState('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [dropdownPos, setDropdownPos] = useState({ top: 0, left: 0 });
+  const [atStart, setAtStart] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = query.length === 0
+    ? members.slice(0, 8)
+    : members.filter(m => m.user.name.toLowerCase().includes(query.toLowerCase())).slice(0, 8);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (dropdownOpen && e.key === 'Escape') {
+      setDropdownOpen(false);
+    }
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const val = e.target.value;
+    const cursor = e.target.selectionStart ?? val.length;
+    onChange(val);
+
+    // Find the last @ before cursor
+    const textBeforeCursor = val.slice(0, cursor);
+    const atIdx = textBeforeCursor.lastIndexOf('@');
+    if (atIdx !== -1) {
+      const segment = textBeforeCursor.slice(atIdx + 1);
+      // Only trigger if no space in the segment (user is still typing the mention)
+      if (!segment.includes(' ') && !segment.includes('\n')) {
+        setQuery(segment);
+        setAtStart(atIdx);
+        setDropdownOpen(true);
+
+        // Position dropdown below cursor using a simple heuristic
+        if (textareaRef.current) {
+          const rect = textareaRef.current.getBoundingClientRect();
+          setDropdownPos({ top: rect.height + 4, left: 0 });
+        }
+        return;
+      }
+    }
+    setDropdownOpen(false);
+  }
+
+  function selectMember(member: WorkspaceMember) {
+    const before = value.slice(0, atStart);
+    const after = value.slice(textareaRef.current?.selectionStart ?? atStart + query.length + 1);
+    const mention = `@[${member.user.name}](${member.user.id})`;
+    const newVal = before + mention + ' ' + after;
+    onChange(newVal);
+    setDropdownOpen(false);
+    // Restore focus
+    setTimeout(() => {
+      if (textareaRef.current) {
+        const pos = (before + mention + ' ').length;
+        textareaRef.current.focus();
+        textareaRef.current.setSelectionRange(pos, pos);
+      }
+    }, 0);
+  }
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative' }}>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        rows={rows}
+        style={{
+          width: '100%', resize: 'vertical',
+          background: inputBg, border: `1px solid ${inputBorder}`,
+          borderRadius: 6, padding: '8px 10px',
+          fontSize: 13, color: textColor,
+          fontFamily: '"Inter",system-ui,sans-serif',
+          outline: 'none', boxSizing: 'border-box',
+          ...style,
+        }}
+      />
+      {dropdownOpen && filtered.length > 0 && (
+        <div style={{
+          position: 'absolute', top: dropdownPos.top, left: dropdownPos.left,
+          background: dropBg, border: `1px solid ${dropBorder}`,
+          borderRadius: 8, boxShadow: '0 6px 18px rgba(0,0,0,0.18)',
+          zIndex: 600, minWidth: 200, maxWidth: 280,
+        }}>
+          {filtered.map(m => (
+            <button
+              key={m.userId}
+              type="button"
+              onMouseDown={e => { e.preventDefault(); selectMember(m); }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                width: '100%', padding: '8px 12px',
+                background: 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left',
+                fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13, color: textColor,
+              }}
+              onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = hoverBg; }}
+              onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+            >
+              <span style={{
+                width: 24, height: 24, borderRadius: '50%',
+                background: '#4F6EF7', color: '#fff', flexShrink: 0,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: 9, fontWeight: 700,
+              }}>
+                {m.user.name.split(/\s+/).map((p: string) => p[0]).slice(0, 2).join('').toUpperCase()}
+              </span>
+              <div>
+                <div style={{ fontSize: 13, fontWeight: 500 }}>{m.user.name}</div>
+                <div style={{ fontSize: 11, color: mutedColor }}>{m.user.email}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -18,6 +18,7 @@ export default function NotificationBell() {
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<Notification[]>([]);
   const [unread, setUnread] = useState(0);
+  const [dropPos, setDropPos] = useState({ top: 0, right: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
@@ -58,13 +59,22 @@ export default function NotificationBell() {
       setUnread(prev => Math.max(0, prev - 1));
     }
     setOpen(false);
-    navigate(`/tasks/${n.payload.taskId}`);
+    const { workspaceSlug, boardSlug } = n.payload;
+    if (workspaceSlug && boardSlug) {
+      navigate(`/w/${workspaceSlug}/boards/${boardSlug}`);
+    }
   };
 
   return (
     <div ref={containerRef} style={{ position: 'relative' }}>
       <button
-        onClick={() => setOpen(v => !v)}
+        onClick={() => {
+          if (!open && containerRef.current) {
+            const rect = containerRef.current.getBoundingClientRect();
+            setDropPos({ top: rect.bottom + 6, right: window.innerWidth - rect.right });
+          }
+          setOpen(v => !v);
+        }}
         style={{ position: 'relative', background: 'none', border: 'none', cursor: 'pointer', padding: 6, color: muted, display: 'flex', alignItems: 'center' }}
         title="Уведомления"
       >
@@ -88,9 +98,9 @@ export default function NotificationBell() {
 
       {open && (
         <div style={{
-          position: 'absolute', top: 'calc(100% + 6px)', right: 0, width: 320,
+          position: 'fixed', top: dropPos.top, right: dropPos.right, width: 320,
           background: bg, border: `1px solid ${border}`, borderRadius: 10,
-          boxShadow: '0 8px 24px rgba(0,0,0,0.18)', zIndex: 500,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.28)', zIndex: 9999,
           fontFamily: '"Inter",system-ui,sans-serif',
         }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', borderBottom: `1px solid ${border}` }}>

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -6,14 +6,25 @@ import type { Notification } from '../api/notifications';
 
 const POLL_MS = 30_000;
 
+const AVATAR_PALETTE = ['#4F6EF7','#8B5CF6','#22C55E','#F59E0B','#EC4899','#EF4444','#0EA5E9'];
+function avatarColor(name: string) { return AVATAR_PALETTE[(name?.charCodeAt(0) ?? 0) % AVATAR_PALETTE.length]; }
+function avatarInitials(name: string) { return name.split(/\s+/).map(w => w[0]).slice(0, 2).join('').toUpperCase() || '?'; }
+function bodyPreview(body?: string): string {
+  if (!body) return '';
+  return body.replace(/@\[([^\]]+)\]\([^)]+\)/g, '@$1').slice(0, 120);
+}
+
 export default function NotificationBell() {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
   const bg = isDark ? '#0F1320' : '#FFFFFF';
   const border = isDark ? '#1C2236' : '#E8E5F0';
   const text = isDark ? '#E2E8F8' : '#1A1A2E';
+  const subText = isDark ? '#8B95B0' : '#6B7194';
   const muted = isDark ? '#8B949E' : '#9B96B8';
-  const hover = isDark ? '#1C2236' : '#F5F5FF';
+  const hoverBg = isDark ? '#141928' : '#F8F7FF';
+  const previewBg = isDark ? '#0A0E1A' : '#F5F5FF';
+  const unreadDot = isDark ? 'rgba(79,110,247,0.08)' : 'rgba(79,110,247,0.05)';
 
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<Notification[]>([]);
@@ -59,9 +70,9 @@ export default function NotificationBell() {
       setUnread(prev => Math.max(0, prev - 1));
     }
     setOpen(false);
-    const { workspaceSlug, boardSlug } = n.payload;
+    const { workspaceSlug, boardSlug, taskId } = n.payload;
     if (workspaceSlug && boardSlug) {
-      navigate(`/w/${workspaceSlug}/boards/${boardSlug}`);
+      navigate(`/w/${workspaceSlug}/boards/${boardSlug}?taskId=${taskId}`);
     }
   };
 
@@ -98,12 +109,13 @@ export default function NotificationBell() {
 
       {open && (
         <div style={{
-          position: 'fixed', top: dropPos.top, right: dropPos.right, width: 320,
+          position: 'fixed', top: dropPos.top, right: dropPos.right, width: 380,
           background: bg, border: `1px solid ${border}`, borderRadius: 10,
-          boxShadow: '0 8px 24px rgba(0,0,0,0.28)', zIndex: 9999,
+          boxShadow: '0 8px 32px rgba(0,0,0,0.22)', zIndex: 9999,
           fontFamily: '"Inter",system-ui,sans-serif',
         }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', borderBottom: `1px solid ${border}` }}>
+          {/* Header */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '11px 16px', borderBottom: `1px solid ${border}` }}>
             <span style={{ fontSize: 13, fontWeight: 600, color: text }}>Уведомления</span>
             {unread > 0 && (
               <button onClick={handleMarkAllRead} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 11, color: '#4F6EF7', padding: 0 }}>
@@ -111,37 +123,84 @@ export default function NotificationBell() {
               </button>
             )}
           </div>
-          <div style={{ maxHeight: 360, overflowY: 'auto' }}>
+
+          {/* List */}
+          <div style={{ maxHeight: 440, overflowY: 'auto' }}>
             {items.length === 0 ? (
-              <div style={{ padding: '24px 14px', textAlign: 'center', fontSize: 13, color: muted }}>Нет уведомлений</div>
-            ) : items.map(n => (
-              <div
-                key={n.id}
-                onClick={() => handleClick(n)}
-                style={{
-                  padding: '10px 14px', cursor: 'pointer',
-                  background: n.isRead ? 'transparent' : (isDark ? 'rgba(79,110,247,0.06)' : 'rgba(79,110,247,0.04)'),
-                  borderBottom: `1px solid ${border}`,
-                  display: 'flex', gap: 10, alignItems: 'flex-start',
-                }}
-                onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.background = hover; }}
-                onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = n.isRead ? 'transparent' : (isDark ? 'rgba(79,110,247,0.06)' : 'rgba(79,110,247,0.04)'); }}
-              >
-                {!n.isRead && (
-                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: '#4F6EF7', flexShrink: 0, marginTop: 4 }} />
-                )}
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <span style={{ fontSize: 13, color: text, lineHeight: '18px', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    <span style={{ fontWeight: 500 }}>{n.payload.mentionedBy.name}</span>
-                    {n.payload.context === 'comment' ? ' упомянул(а) вас в комментарии к ' : ' упомянул(а) вас в задаче '}
-                    <span style={{ color: '#4F6EF7' }}>{n.payload.taskKey}</span>
-                  </span>
-                  <span style={{ fontSize: 11, color: muted }}>
-                    {new Date(n.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}
-                  </span>
+              <div style={{ padding: '28px 16px', textAlign: 'center', fontSize: 13, color: muted }}>Нет уведомлений</div>
+            ) : items.map(n => {
+              const preview = bodyPreview(n.payload.body);
+              return (
+                <div
+                  key={n.id}
+                  onClick={() => handleClick(n)}
+                  style={{
+                    padding: '12px 16px', cursor: 'pointer',
+                    background: n.isRead ? 'transparent' : unreadDot,
+                    borderBottom: `1px solid ${border}`,
+                  }}
+                  onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.background = hoverBg; }}
+                  onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = n.isRead ? 'transparent' : unreadDot; }}
+                >
+                  <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                    {/* Avatar */}
+                    <div style={{
+                      width: 30, height: 30, borderRadius: '50%', flexShrink: 0,
+                      background: avatarColor(n.payload.mentionedBy.name),
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    }}>
+                      <span style={{ fontSize: 10, fontWeight: 700, color: '#fff' }}>
+                        {avatarInitials(n.payload.mentionedBy.name)}
+                      </span>
+                    </div>
+
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      {/* Who + where */}
+                      <div style={{ fontSize: 13, color: text, lineHeight: '18px', marginBottom: 2 }}>
+                        <span style={{ fontWeight: 600 }}>{n.payload.mentionedBy.name}</span>
+                        <span style={{ color: subText }}>
+                          {n.payload.context === 'comment' ? ' упомянул(а) вас в комментарии · ' : ' упомянул(а) вас в задаче · '}
+                        </span>
+                        <span style={{ color: '#4F6EF7', fontWeight: 500 }}>{n.payload.taskKey}</span>
+                      </div>
+
+                      {/* Task title */}
+                      <div style={{ fontSize: 12, color: subText, marginBottom: preview ? 6 : 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {n.payload.taskTitle}
+                      </div>
+
+                      {/* Comment preview */}
+                      {preview && (
+                        <div style={{
+                          fontSize: 12, color: text, lineHeight: '17px',
+                          background: previewBg, borderRadius: 6,
+                          padding: '6px 8px', marginBottom: 6,
+                          display: '-webkit-box', WebkitLineClamp: 2,
+                          WebkitBoxOrient: 'vertical', overflow: 'hidden',
+                        }}>
+                          {preview}
+                        </div>
+                      )}
+
+                      {/* Footer: time + open button */}
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <span style={{ fontSize: 11, color: muted }}>
+                          {new Date(n.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}
+                        </span>
+                        <span style={{ fontSize: 11, color: '#4F6EF7', fontWeight: 500 }}>
+                          Открыть задачу →
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Unread dot */}
+                    {!n.isRead && (
+                      <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#4F6EF7', flexShrink: 0, marginTop: 6 }} />
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useThemeStore } from '../store/theme.store';
+import * as notificationsApi from '../api/notifications';
+import type { Notification } from '../api/notifications';
+
+const POLL_MS = 30_000;
+
+export default function NotificationBell() {
+  const mode = useThemeStore(s => s.mode);
+  const isDark = mode === 'dark';
+  const bg = isDark ? '#0F1320' : '#FFFFFF';
+  const border = isDark ? '#1C2236' : '#E8E5F0';
+  const text = isDark ? '#E2E8F8' : '#1A1A2E';
+  const muted = isDark ? '#8B949E' : '#9B96B8';
+  const hover = isDark ? '#1C2236' : '#F5F5FF';
+
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<Notification[]>([]);
+  const [unread, setUnread] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  const load = useCallback(async () => {
+    try {
+      const res = await notificationsApi.listNotifications();
+      setItems(res.items);
+      setUnread(res.unread);
+    } catch { /* silent */ }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const timer = setInterval(load, POLL_MS);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const handleMarkAllRead = async () => {
+    await notificationsApi.markAllRead();
+    setItems(prev => prev.map(n => ({ ...n, isRead: true })));
+    setUnread(0);
+  };
+
+  const handleClick = async (n: Notification) => {
+    if (!n.isRead) {
+      await notificationsApi.markRead(n.id);
+      setItems(prev => prev.map(x => x.id === n.id ? { ...x, isRead: true } : x));
+      setUnread(prev => Math.max(0, prev - 1));
+    }
+    setOpen(false);
+    navigate(`/tasks/${n.payload.taskId}`);
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative' }}>
+      <button
+        onClick={() => setOpen(v => !v)}
+        style={{ position: 'relative', background: 'none', border: 'none', cursor: 'pointer', padding: 6, color: muted, display: 'flex', alignItems: 'center' }}
+        title="Уведомления"
+      >
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+          <path d="M9 1.5C9 1.5 5.25 3 5.25 9V13.5H12.75V9C12.75 3 9 1.5 9 1.5Z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/>
+          <path d="M7.5 13.5C7.5 14.328 8.172 15 9 15C9.828 15 10.5 14.328 10.5 13.5" stroke="currentColor" strokeWidth="1.3"/>
+          <path d="M3.75 13.5H14.25" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+        </svg>
+        {unread > 0 && (
+          <span style={{
+            position: 'absolute', top: 2, right: 2,
+            background: '#EF4444', color: '#fff',
+            fontSize: 9, fontWeight: 700, fontFamily: '"Inter",system-ui,sans-serif',
+            borderRadius: '50%', width: 14, height: 14,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}>
+            {unread > 9 ? '9+' : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div style={{
+          position: 'absolute', top: 'calc(100% + 6px)', right: 0, width: 320,
+          background: bg, border: `1px solid ${border}`, borderRadius: 10,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.18)', zIndex: 500,
+          fontFamily: '"Inter",system-ui,sans-serif',
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', borderBottom: `1px solid ${border}` }}>
+            <span style={{ fontSize: 13, fontWeight: 600, color: text }}>Уведомления</span>
+            {unread > 0 && (
+              <button onClick={handleMarkAllRead} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 11, color: '#4F6EF7', padding: 0 }}>
+                Прочитать все
+              </button>
+            )}
+          </div>
+          <div style={{ maxHeight: 360, overflowY: 'auto' }}>
+            {items.length === 0 ? (
+              <div style={{ padding: '24px 14px', textAlign: 'center', fontSize: 13, color: muted }}>Нет уведомлений</div>
+            ) : items.map(n => (
+              <div
+                key={n.id}
+                onClick={() => handleClick(n)}
+                style={{
+                  padding: '10px 14px', cursor: 'pointer',
+                  background: n.isRead ? 'transparent' : (isDark ? 'rgba(79,110,247,0.06)' : 'rgba(79,110,247,0.04)'),
+                  borderBottom: `1px solid ${border}`,
+                  display: 'flex', gap: 10, alignItems: 'flex-start',
+                }}
+                onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.background = hover; }}
+                onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = n.isRead ? 'transparent' : (isDark ? 'rgba(79,110,247,0.06)' : 'rgba(79,110,247,0.04)'); }}
+              >
+                {!n.isRead && (
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: '#4F6EF7', flexShrink: 0, marginTop: 4 }} />
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ fontSize: 13, color: text, lineHeight: '18px', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <span style={{ fontWeight: 500 }}>{n.payload.mentionedBy.name}</span>
+                    {n.payload.context === 'comment' ? ' упомянул(а) вас в комментарии к ' : ' упомянул(а) вас в задаче '}
+                    <span style={{ color: '#4F6EF7' }}>{n.payload.taskKey}</span>
+                  </span>
+                  <span style={{ fontSize: 11, color: muted }}>
+                    {new Date(n.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -643,6 +643,7 @@ export default function TaskDrawer({
                 taskId={task.id}
                 comments={task.comments ?? []}
                 onCommentsChanged={handleCommentsChanged}
+                members={members}
               />
             )
 

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -642,6 +642,7 @@ export default function TaskDrawer({
               <CommentThread
                 taskId={task.id}
                 comments={task.comments ?? []}
+                commentsTotal={task._count?.comments}
                 onCommentsChanged={handleCommentsChanged}
                 members={members}
               />

--- a/frontend/src/components/WorkspaceHistoryTimeline.tsx
+++ b/frontend/src/components/WorkspaceHistoryTimeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { message } from 'antd';
 import { useThemeStore } from '../store/theme.store';
 import type { WorkspaceEvent } from '../types';
@@ -75,13 +75,17 @@ function formatDate(iso: string): string {
 interface Props { workspaceId: string; }
 
 // ── Component ─────────────────────────────────────────────────────────────────
+const PAGE_SIZE = 50;
+
 export default function WorkspaceHistoryTimeline({ workspaceId }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
   const c = isDark ? DARK : LIGHT;
 
   const [events, setEvents] = useState<WorkspaceEvent[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   // Inject spin keyframe once into document head
   const keyframeInjected = useRef(false);
@@ -102,8 +106,8 @@ export default function WorkspaceHistoryTimeline({ workspaceId }: Props) {
     const fetchData = async () => {
       setLoading(true);
       try {
-        const data = await workspacesApi.getWorkspaceHistory(workspaceId);
-        if (!controller.signal.aborted) setEvents(data);
+        const { events: evs, total: t } = await workspacesApi.getWorkspaceHistory(workspaceId, { limit: PAGE_SIZE });
+        if (!controller.signal.aborted) { setEvents(evs); setTotal(t); }
       } catch {
         if (!controller.signal.aborted) message.error('Не удалось загрузить историю');
       } finally {
@@ -113,6 +117,24 @@ export default function WorkspaceHistoryTimeline({ workspaceId }: Props) {
     fetchData();
     return () => controller.abort();
   }, [workspaceId]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore) return;
+    const capturedId = workspaceId;
+    const capturedOffset = events.length;
+    setLoadingMore(true);
+    try {
+      const { events: more } = await workspacesApi.getWorkspaceHistory(capturedId, { limit: PAGE_SIZE, offset: capturedOffset });
+      setEvents(prev => {
+        if (workspaceId !== capturedId) return prev; // workspace changed — discard
+        return [...prev, ...more];
+      });
+    } catch {
+      message.error('Не удалось загрузить историю');
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [workspaceId, events.length, loadingMore]);
 
   if (loading) {
     return (
@@ -206,6 +228,23 @@ export default function WorkspaceHistoryTimeline({ workspaceId }: Props) {
           </div>
         );
       })}
+      {events.length < total && (
+        <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 12 }}>
+          <button
+            onClick={loadMore}
+            disabled={loadingMore}
+            style={{
+              fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
+              color: '#4F6EF7', background: 'transparent',
+              border: '1px solid #4F6EF7', borderRadius: 7,
+              padding: '5px 18px', cursor: 'pointer',
+              opacity: loadingMore ? 0.5 : 1,
+            }}
+          >
+            {loadingMore ? 'Загрузка...' : `Загрузить ещё (${total - events.length})`}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -194,11 +194,20 @@ export default function BoardPage() {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [addingTo, setAddingTo] = useState<string | null>(null);
   const [addTitle, setAddTitle] = useState('');
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const v = searchParams.get('view');
     return (v === 'roadmap' || v === 'list' || v === 'calendar') ? v : 'board';
   });
+
+  // Auto-open drawer when navigated from a notification (?taskId=...)
+  useEffect(() => {
+    const tid = searchParams.get('taskId');
+    if (tid) {
+      setSelectedTaskId(tid);
+      setSearchParams(p => { p.delete('taskId'); return p; }, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [labels, setLabels] = useState<Label[]>([]);

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -246,8 +246,8 @@ export default function WorkspaceDashboardPage() {
       .then(setBoards)
       .catch(() => setBoards([]))
       .finally(() => setBoardsLoading(false));
-    workspacesApi.getWorkspaceHistory(currentId)
-      .then(evs => setActivity(evs.slice(0, 6)))
+    workspacesApi.getWorkspaceHistory(currentId, { limit: 6 })
+      .then(({ events }) => setActivity(events))
       .catch(() => {});
   }, [currentId]);
 

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -385,8 +385,8 @@ export default function WorkspacesPage() {
     if (workspaces.length === 0) return;
     const ownerWs = workspaces.find(w => w.role === 'OWNER');
     if (!ownerWs) return;
-    workspacesApi.getWorkspaceHistory(ownerWs.id)
-      .then(events => setRecentEvents(events.slice(0, 5)))
+    workspacesApi.getWorkspaceHistory(ownerWs.id, { limit: 5 })
+      .then(({ events }) => setRecentEvents(events))
       .catch(() => {});
   }, [workspaces]);
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -245,6 +245,6 @@ export interface Task {
   labels?: TaskLabel[];
   comments?: Comment[];
   checklists?: Checklist[];
-  _count?: { children: number };
+  _count?: { children: number; comments?: number };
   statusHistory?: { id: string; statusId: string; startedAt: string; endedAt: string | null }[];
 }


### PR DESCRIPTION
## Summary

- **#128 fix:** Labels were not updating on kanban cards after editing in TaskDrawer — `handleLabelsChanged` now calls `onUpdated` to propagate changes to board state
- **#129 fix:** Activity feed now shows human-readable events for board/workflow mutations — added `logEvent` calls in boards.service and workflows.service with structured meta, expanded `ACTION_LABELS` on frontend to 15 event types with meta interpolation
- **#110 feat:** Screenshot attachment in feedback form — multer multipart upload on backend, GitHub Contents API storage, image embedded as Markdown in GitHub issue body; client-side preview with 5MB + MIME validation
- **#131 feat:** @mention users in tasks/comments/subtasks + in-app notification bell — `@[Name](userId)` format, `Notification` Prisma model, REST API, 30s polling bell with unread badge, `MentionTextarea` component with autocomplete dropdown

## Test plan

- [ ] Edit labels on a task in TaskDrawer → verify kanban card updates immediately without page reload
- [ ] Create/rename/delete a board → activity feed shows "создал доску «X»" / "переименовал доску «X» → «Y»" / "удалил доску «X»"
- [ ] Add/rename/delete a workflow status → feed shows corresponding human-readable event
- [ ] Open feedback modal → attach a screenshot (PNG/JPG ≤5MB) → submit → verify image appears in GitHub issue body
- [ ] Try attaching a file >5MB or wrong MIME → verify client-side error shown
- [ ] Write a comment with `@UserName` → target user sees notification bell badge
- [ ] Click notification → navigates to the task
- [ ] Click "Прочитать всё" → badge clears
- [ ] Apply pending Prisma migration (`notifications` table) before testing #131

🤖 Generated with [Claude Code](https://claude.ai/claude-code)