### PR TITLE
feat: gap-07 — enforce maximum subtask nesting depth (5 levels)

### DIFF
--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -69,7 +69,6 @@ export async function createComment(taskId: string, userId: string, dto: CreateC
     context: 'comment',
     workspaceSlug: task.board.workspace.slug,
     boardSlug: task.board.prefix.toLowerCase(),
-    body: dto.body,
   }, userId);
 
   return comment;
@@ -103,7 +102,6 @@ export async function updateComment(commentId: string, userId: string, dto: Upda
     context: 'comment',
     workspaceSlug: task.board.workspace.slug,
     boardSlug: task.board.prefix.toLowerCase(),
-    body: dto.body,
   }, userId);
 
   return updated;

--- a/backend/src/modules/feedback/feedback.dto.ts
+++ b/backend/src/modules/feedback/feedback.dto.ts
@@ -18,7 +18,7 @@ export const feedbackDto = z.object({
   type: z.enum(['bug', 'idea'], { message: 'Тип должен быть bug или idea' }),
   // multipart sends meta as a JSON string; preprocess handles both cases
   meta: z.preprocess(
-    (v) => (typeof v === 'string' ? JSON.parse(v) : v),
+    (v) => { try { return typeof v === 'string' ? JSON.parse(v) : v; } catch { return undefined; } },
     metaSchema,
   ).optional(),
 });

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -8,6 +8,7 @@ export interface MentionPayload {
   context: 'task' | 'comment';
   workspaceSlug: string;
   boardSlug: string;
+  body?: string;
 }
 
 // Extract user IDs from mention markers: @[Display Name](userId)

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -22,14 +22,13 @@ export function extractMentionedUserIds(text: string | null | undefined): string
 export async function emitMentionNotifications(
   text: string | null | undefined,
   payload: MentionPayload,
-  authorId: string,
+  authorId?: string,
 ) {
   const userIds = extractMentionedUserIds(text);
   if (userIds.length === 0) return;
-  const recipients = userIds;
 
-  // Deduplicate
-  const unique = [...new Set(recipients)];
+  // Deduplicate; optionally exclude author (pass authorId to suppress self-notifications)
+  const unique = [...new Set(authorId ? userIds.filter((id) => id !== authorId) : userIds)];
 
   // Verify users exist (avoid FK violation on stale mentions)
   const existing = await prisma.user.findMany({

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -8,7 +8,6 @@ export interface MentionPayload {
   context: 'task' | 'comment';
   workspaceSlug: string;
   boardSlug: string;
-  body?: string;
 }
 
 // Extract user IDs from mention markers: @[Display Name](userId)

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -58,6 +58,10 @@ async function generateIssueKey(boardId: string): Promise<{ issueKey: string; is
   throw new AppError(500, 'Could not generate unique issue key after 10 attempts');
 }
 
+// ─── Depth limit ─────────────────────────────────────────────────────────────
+
+const MAX_SUBTASK_DEPTH = 5; // tasks at depth 0-4 allowed; depth 5 is rejected
+
 // ─── Materialized path helpers ────────────────────────────────────────────────
 
 async function buildPath(parentId: string | null | undefined): Promise<{ path: string; depth: number }> {
@@ -160,8 +164,13 @@ export async function createTask(boardId: string, userId: string, dto: CreateTas
     }
   }
 
-  const { issueKey, issueNumber } = await generateIssueKey(boardId);
   const { path, depth } = await buildPath(dto.parentId);
+
+  if (depth >= MAX_SUBTASK_DEPTH) {
+    throw new AppError(400, `Maximum subtask nesting depth (${MAX_SUBTASK_DEPTH}) reached`);
+  }
+
+  const { issueKey, issueNumber } = await generateIssueKey(boardId);
 
   // orderIndex = max + 1 in same status
   const maxOrder = await prisma.task.aggregate({

--- a/backend/src/modules/workspaces/workspaces.service.ts
+++ b/backend/src/modules/workspaces/workspaces.service.ts
@@ -131,12 +131,17 @@ export async function getWorkspace(workspaceId: string, userId: string) {
 export async function updateWorkspace(workspaceId: string, userId: string, dto: UpdateWorkspaceDto) {
   await assertOwner(workspaceId, userId);
 
+  const current = await prisma.workspace.findUniqueOrThrow({ where: { id: workspaceId }, select: { name: true, isPrivate: true } });
+
   const updated = await prisma.workspace.update({
     where: { id: workspaceId },
     data: dto,
   });
 
-  await logEvent(workspaceId, userId, 'workspace_updated', 'workspace', workspaceId, dto as Record<string, unknown>);
+  const meta: Record<string, unknown> = {};
+  if (dto.name !== undefined && dto.name !== current.name) { meta.nameFrom = current.name; meta.nameTo = dto.name; }
+  if (dto.isPrivate !== undefined && dto.isPrivate !== current.isPrivate) meta.isPrivate = dto.isPrivate;
+  await logEvent(workspaceId, userId, 'workspace_updated', 'workspace', workspaceId, meta);
 
   return updated;
 }

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -8,7 +8,6 @@ export interface MentionPayload {
   context: 'task' | 'comment';
   workspaceSlug: string;
   boardSlug: string;
-  body?: string;
 }
 
 export interface Notification {

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -8,6 +8,7 @@ export interface MentionPayload {
   context: 'task' | 'comment';
   workspaceSlug: string;
   boardSlug: string;
+  body?: string;
 }
 
 export interface Notification {

--- a/frontend/src/components/CommentThread.tsx
+++ b/frontend/src/components/CommentThread.tsx
@@ -266,7 +266,7 @@ export default function CommentThread({ taskId, comments, commentsTotal, onComme
             onClick={async () => {
               setLoadingMore(true);
               try {
-                const { comments: more } = await commentsApi.listComments(taskId, { offset: comments.length });
+                const more = await commentsApi.listComments(taskId);
                 onCommentsChanged([...comments, ...more]);
               } catch { message.error('Не удалось загрузить комментарии'); }
               finally { setLoadingMore(false); }

--- a/frontend/src/components/CommentThread.tsx
+++ b/frontend/src/components/CommentThread.tsx
@@ -46,17 +46,15 @@ function commentCharCounterStyle(len: number, metaColor: string): React.CSSPrope
 interface Props {
   taskId: string;
   comments: Comment[];
-  commentsTotal?: number;
   onCommentsChanged: (comments: Comment[]) => void;
   members?: WorkspaceMember[];
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
-export default function CommentThread({ taskId, comments, commentsTotal, onCommentsChanged, members = [] }: Props) {
+export default function CommentThread({ taskId, comments, onCommentsChanged, members = [] }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
   const c = isDark ? DARK : LIGHT;
-  const [loadingMore, setLoadingMore] = useState(false);
 
   const currentUser = useAuthStore(s => s.user);
   const [newBody, setNewBody]     = useState('');
@@ -139,15 +137,13 @@ export default function CommentThread({ taskId, comments, commentsTotal, onComme
             {editingId === comment.id ? (
               /* Edit mode */
               <div>
-                <textarea
+                <MentionTextarea
                   value={editBody}
-                  onChange={e => setEditBody(e.target.value)}
-                  autoFocus
+                  onChange={setEditBody}
+                  members={members}
                   rows={2}
                   maxLength={COMMENT_MAX}
-                  style={textareaStyle(false)}
-                  onFocus={e => { (e.target as HTMLTextAreaElement).style.borderColor = c.inputBorderFocus; }}
-                  onBlur={e => { (e.target as HTMLTextAreaElement).style.borderColor = c.inputBorder; }}
+                  style={{ ...textareaStyle(true), marginBottom: 0 }}
                 />
                 {editBody.length > 0 && (
                   <div style={commentCharCounterStyle(editBody.length, c.metaText)}>{editBody.length} / {COMMENT_MAX}</div>
@@ -258,32 +254,6 @@ export default function CommentThread({ taskId, comments, commentsTotal, onComme
           </div>
         </div>
       ))}
-
-      {/* Load more comments */}
-      {commentsTotal !== undefined && comments.length < commentsTotal && (
-        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 12 }}>
-          <button
-            onClick={async () => {
-              setLoadingMore(true);
-              try {
-                const more = await commentsApi.listComments(taskId);
-                onCommentsChanged([...comments, ...more]);
-              } catch { message.error('Не удалось загрузить комментарии'); }
-              finally { setLoadingMore(false); }
-            }}
-            disabled={loadingMore}
-            style={{
-              fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
-              color: '#4F6EF7', background: 'transparent',
-              border: '1px solid #4F6EF7', borderRadius: 7,
-              padding: '4px 14px', cursor: 'pointer',
-              opacity: loadingMore ? 0.5 : 1,
-            }}
-          >
-            {loadingMore ? 'Загрузка...' : `Ещё комментарии (${commentsTotal - comments.length})`}
-          </button>
-        </div>
-      )}
 
       {/* New comment input */}
       <div style={{ display: 'flex', gap: 10 }}>

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Modal, Form, Input, Radio, Button, message } from 'antd';
 import api from '../api/client';
 import { formatApiError } from '../utils/apiError';
@@ -17,6 +17,8 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   const [screenshot, setScreenshot] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => () => { if (preview) URL.revokeObjectURL(preview); }, [preview]);
 
   function collectDeviceMeta() {
     const ua = navigator.userAgent;

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -70,9 +70,9 @@ export default function NotificationBell() {
       setUnread(prev => Math.max(0, prev - 1));
     }
     setOpen(false);
-    const { workspaceSlug, boardSlug } = n.payload;
+    const { workspaceSlug, boardSlug, taskId } = n.payload;
     if (workspaceSlug && boardSlug) {
-      navigate(`/w/${workspaceSlug}/boards/${boardSlug}`);
+      navigate(`/w/${workspaceSlug}/boards/${boardSlug}?taskId=${taskId}`);
     }
   };
 
@@ -109,9 +109,9 @@ export default function NotificationBell() {
 
       {open && (
         <div style={{
-          position: 'fixed', top: dropPos.top, right: dropPos.right, width: 320,
+          position: 'fixed', top: dropPos.top, right: dropPos.right, width: 380,
           background: bg, border: `1px solid ${border}`, borderRadius: 10,
-          boxShadow: '0 8px 24px rgba(0,0,0,0.28)', zIndex: 9999,
+          boxShadow: '0 8px 32px rgba(0,0,0,0.22)', zIndex: 9999,
           fontFamily: '"Inter",system-ui,sans-serif',
         }}>
           {/* Header */}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -72,7 +72,7 @@ export default function NotificationBell() {
     setOpen(false);
     const { workspaceSlug, boardSlug, taskId } = n.payload;
     if (workspaceSlug && boardSlug) {
-      navigate(`/w/${workspaceSlug}/boards/${boardSlug}?taskId=${taskId}`);
+      navigate(`/w/${workspaceSlug}/boards/${boardSlug}`, { state: { openTaskId: taskId } });
     }
   };
 

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -70,9 +70,9 @@ export default function NotificationBell() {
       setUnread(prev => Math.max(0, prev - 1));
     }
     setOpen(false);
-    const { workspaceSlug, boardSlug, taskId } = n.payload;
+    const { workspaceSlug, boardSlug } = n.payload;
     if (workspaceSlug && boardSlug) {
-      navigate(`/w/${workspaceSlug}/boards/${boardSlug}?taskId=${taskId}`);
+      navigate(`/w/${workspaceSlug}/boards/${boardSlug}`);
     }
   };
 
@@ -109,9 +109,9 @@ export default function NotificationBell() {
 
       {open && (
         <div style={{
-          position: 'fixed', top: dropPos.top, right: dropPos.right, width: 380,
+          position: 'fixed', top: dropPos.top, right: dropPos.right, width: 320,
           background: bg, border: `1px solid ${border}`, borderRadius: 10,
-          boxShadow: '0 8px 32px rgba(0,0,0,0.22)', zIndex: 9999,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.28)', zIndex: 9999,
           fontFamily: '"Inter",system-ui,sans-serif',
         }}>
           {/* Header */}

--- a/frontend/src/components/SubtaskTree.tsx
+++ b/frontend/src/components/SubtaskTree.tsx
@@ -36,6 +36,9 @@ function findFirstStatusId(statuses: WorkflowStatus[]): string | undefined {
   return statuses[0]?.id;
 }
 
+// Must match MAX_SUBTASK_DEPTH in backend/src/modules/tasks/tasks.service.ts
+const MAX_SUBTASK_DEPTH = 5;
+
 // ── Props ──────────────────────────────────────────────────────────────────────
 interface Props {
   tasks: Task[];
@@ -43,13 +46,14 @@ interface Props {
   boardId: string;
   statuses: WorkflowStatus[];
   depth?: number;
+  parentDepth?: number; // absolute depth of the parent task — used to enforce depth limit
   onRefresh: () => void;
   onOpenTask?: (taskId: string) => void;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 export default function SubtaskTree({
-  tasks, parentId, boardId, statuses, depth = 0, onRefresh, onOpenTask,
+  tasks, parentId, boardId, statuses, depth = 0, parentDepth, onRefresh, onOpenTask,
 }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
@@ -101,9 +105,14 @@ export default function SubtaskTree({
     try {
       await tasksApi.createTask(boardId, { title: addTitle.trim(), parentId, statusId: findFirstStatusId(statuses) });
       setAddTitle(''); setAdding(false); onRefresh();
-    } catch { message.error('Не удалось создать подзадачу'); }
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+      message.error(msg ?? 'Не удалось создать подзадачу');
+    }
     finally { setSaving(false); }
   };
+
+  const canAddSubtask = parentDepth === undefined || parentDepth + 1 < MAX_SUBTASK_DEPTH;
 
   return (
     <div style={{ position: 'relative' }}>
@@ -266,6 +275,7 @@ export default function SubtaskTree({
                   boardId={boardId}
                   statuses={statuses}
                   depth={depth + 1}
+                  parentDepth={task.depth}
                   onRefresh={() => { fetchSubtree(task.id); onRefresh(); }}
                   onOpenTask={onOpenTask}
                 />
@@ -275,8 +285,8 @@ export default function SubtaskTree({
         );
       })}
 
-      {/* Add subtask row */}
-      {adding ? (
+      {/* Add subtask row — hidden when parent is at max allowed depth */}
+      {canAddSubtask && adding ? (
         <div style={{
           display: 'flex', alignItems: 'center', gap: 6,
           paddingLeft: indent + (depth > 0 ? 12 : 0), paddingTop: 4,
@@ -320,7 +330,7 @@ export default function SubtaskTree({
             Отмена
           </button>
         </div>
-      ) : (
+      ) : canAddSubtask ? (
         <div
           role="button"
           tabIndex={0}
@@ -340,7 +350,7 @@ export default function SubtaskTree({
           </svg>
           <span>Добавить подзадачу</span>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/TaskDrawer.tsx
+++ b/frontend/src/components/TaskDrawer.tsx
@@ -605,6 +605,7 @@ export default function TaskDrawer({
                       parentId={task.id}
                       boardId={boardId}
                       statuses={statuses}
+                      parentDepth={task.depth}
                       onRefresh={refreshTask}
                       onOpenTask={setSubtaskId}
                     />

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams, useLocation } from 'react-router-dom';
 import {
   DragDropContext, Droppable, Draggable, type DropResult, type DragStart,
 } from '@hello-pangea/dnd';
@@ -183,20 +183,22 @@ export default function BoardPage() {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [addingTo, setAddingTo] = useState<string | null>(null);
   const [addTitle, setAddTitle] = useState('');
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const v = searchParams.get('view');
     return (v === 'roadmap' || v === 'list' || v === 'calendar') ? v : 'board';
   });
 
-  // Auto-open drawer when navigated from a notification (?taskId=...)
+  // Auto-open drawer when navigated from a notification (via router state)
   useEffect(() => {
-    const tid = searchParams.get('taskId');
-    if (tid) {
-      setSelectedTaskId(tid);
-      setSearchParams(p => { p.delete('taskId'); return p; }, { replace: true });
+    const state = location.state as { openTaskId?: string } | null;
+    if (state?.openTaskId) {
+      setSelectedTaskId(state.openTaskId);
+      // Clear state so back navigation doesn't re-trigger
+      window.history.replaceState({}, '', location.pathname + location.search);
     }
-  }, [searchParams, setSearchParams]);
+  }, [location.state, location.pathname, location.search]);
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [labels, setLabels] = useState<Label[]>([]);


### PR DESCRIPTION
## Summary

- **#128 fix:** Labels missing on kanban cards at initial load — added \`labels\` + \`status\` to \`getBoard\` tasks include; \`handleLabelsChanged\` now calls \`onUpdated\` to propagate to board state
- **#129 fix:** Activity feed shows human-readable events for board/workflow mutations — \`logEvent\` calls in \`boards.service\` and \`workflows.service\` with structured meta; \`ACTION_LABELS\` on frontend expanded to 15 event types with meta interpolation
- **#110 feat:** Screenshot in feedback form — multer multipart, GitHub Contents API storage, image embedded as Markdown in issue body; client-side MIME + 5MB validation + preview
- **#131 feat:** @mention users in comments + in-app notification bell — \`@[Name](userId)\` stored format, dual-state \`MentionTextarea\` (shows \`@Name\`, stores full format), \`Notification\` model + REST API + 30s polling bell with rich notification cards (avatar, who, task key, comment preview, "Открыть задачу →")

## Code & security review findings addressed

| Severity | Finding | Fix |
|----------|---------|-----|
| HIGH | \`authorId\` unused in \`emitMentionNotifications\` — misleading API | Made optional; callers pass it to suppress self-spam |
| MEDIUM | \`workspace_updated\` logged entire DTO verbatim | Replaced with controlled \`nameFrom/nameTo/isPrivate\` meta |
| LOW | Unguarded \`JSON.parse\` in feedback.dto preprocess | Wrapped in try/catch → 400 instead of 500 |
| LOW | ObjectURL not revoked on FeedbackModal unmount | Added \`useEffect\` cleanup |
| LOW | Edit textarea used raw \`<textarea>\` | Replaced with \`MentionTextarea\` — edits support @mentions |
| LOW | "Load more comments" fetched from offset 0 (duplicates) | Removed |

## Navigation fix

Notification click previously used \`?taskId=\` URL param → broke back button. Now uses React Router \`location.state\` → no URL pollution, back button works.

## Test plan

- [ ] Open board → labels visible on kanban cards without adding new ones
- [ ] Create/rename/delete board → activity feed shows human-readable event
- [ ] Open feedback → attach PNG/JPG ≤5MB → submit → image in GitHub issue
- [ ] Try >5MB or wrong MIME → client-side error shown
- [ ] Write comment with \`@Name\` → dropdown appears → select → textarea shows \`@Name\` (not UUID)
- [ ] Submit comment → mentioned user sees bell badge
- [ ] Click notification card → navigated to correct board, task drawer opens automatically
- [ ] Back button works after notification navigation
- [ ] Edit existing comment → @ autocomplete works
- [ ] Apply migration: \`backend/src/prisma/migrations/20260506_add_notifications/migration.sql\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)