### PR TITLE
feat: gap-08 notification triggers + email opt-out

### DIFF
--- a/backend/src/modules/auth/auth.dto.ts
+++ b/backend/src/modules/auth/auth.dto.ts
@@ -23,7 +23,8 @@ export const refreshDto = z.object({
 export const updateProfileDto = z.object({
   name: stripHtml(z.string().min(1).max(255)).optional(),
   email: z.string().email().optional(),
-}).refine((d) => d.name !== undefined || d.email !== undefined, {
+  emailNotifications: z.boolean().optional(),
+}).refine((d) => d.name !== undefined || d.email !== undefined || d.emailNotifications !== undefined, {
   message: 'Укажите хотя бы одно поле для обновления',
 });
 

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -207,14 +207,15 @@ export async function updateProfile(userId: string, dto: UpdateProfileDto) {
     dto = { ...dto, email: normalizedEmail };
   }
 
-  const data: Record<string, string> = {};
+  const data: Record<string, unknown> = {};
   if (dto.name !== undefined) data.name = dto.name;
   if (dto.email !== undefined) data.email = dto.email;
+  if (dto.emailNotifications !== undefined) data.emailNotifications = dto.emailNotifications;
 
   const user = await prisma.user.update({
     where: { id: userId },
     data,
-    select: { id: true, email: true, name: true, avatar: true, loginCount: true, createdAt: true },
+    select: { id: true, email: true, name: true, avatar: true, loginCount: true, createdAt: true, emailNotifications: true },
   });
   const firstName = extractFirstName(user.name);
   return { ...user, firstName };
@@ -223,7 +224,7 @@ export async function updateProfile(userId: string, dto: UpdateProfileDto) {
 export async function getMe(userId: string) {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { id: true, email: true, name: true, avatar: true, loginCount: true, createdAt: true, isSuperadmin: true },
+    select: { id: true, email: true, name: true, avatar: true, loginCount: true, createdAt: true, isSuperadmin: true, emailNotifications: true },
   });
   if (!user) throw new AppError(404, 'Пользователь не найден');
   const firstName = extractFirstName(user.name);

--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
-import { emitMentionNotifications } from '../notifications/notifications.service.js';
+import { emitMentionNotifications, emitCommentNotification } from '../notifications/notifications.service.js';
 import type { CreateCommentDto, UpdateCommentDto } from './comments.dto.js';
 
 const AUTHOR_SELECT = { id: true, name: true, avatar: true } as const;
@@ -70,6 +70,8 @@ export async function createComment(taskId: string, userId: string, dto: CreateC
     workspaceSlug: task.board.workspace.slug,
     boardSlug: task.board.prefix.toLowerCase(),
   }, userId);
+
+  emitCommentNotification(taskId, userId).catch(() => {});
 
   return comment;
 }

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -1,4 +1,8 @@
 import { prisma } from '../../prisma/client.js';
+import { sendNotificationEmail } from '../../shared/utils/email.js';
+import { escapeHtml, sanitizeEmailHeader } from '../../shared/utils/sanitize.js';
+import { config } from '../../config.js';
+import { logger } from '../../shared/utils/logger.js';
 
 export interface MentionPayload {
   taskId: string;
@@ -74,4 +78,146 @@ export async function markAllRead(userId: string) {
     where: { userId, isRead: false },
     data: { isRead: true },
   });
+}
+
+// ─── Trigger emitters ─────────────────────────────────────────────────────────
+
+export async function emitTaskAssignedNotification(
+  taskId: string,
+  assigneeId: string,
+  actorId: string,
+): Promise<void> {
+  if (assigneeId === actorId) return;
+
+  const [task, actor] = await Promise.all([
+    prisma.task.findUnique({
+      where: { id: taskId },
+      select: {
+        title: true, issueKey: true,
+        board: { select: { prefix: true, workspace: { select: { slug: true } } } },
+      },
+    }),
+    prisma.user.findUnique({ where: { id: actorId }, select: { id: true, name: true } }),
+  ]);
+  if (!task || !actor) return;
+
+  const payload = {
+    taskId,
+    taskTitle: task.title,
+    taskKey: task.issueKey,
+    workspaceSlug: task.board.workspace.slug,
+    boardSlug: task.board.prefix.toLowerCase(),
+    actor,
+  };
+
+  await prisma.notification.create({
+    data: { userId: assigneeId, type: 'task_assigned', payload: payload as object },
+  });
+
+  const assignee = await prisma.user.findUnique({
+    where: { id: assigneeId },
+    select: { email: true, emailNotifications: true },
+  });
+  if (assignee?.emailNotifications) {
+    const url = `${config.APP_URL}/w/${task.board.workspace.slug}/boards/${task.board.prefix.toLowerCase()}`;
+    void sendNotificationEmail(
+      assignee.email,
+      sanitizeEmailHeader(`Задача назначена: ${task.issueKey}`),
+      `<p><b>${escapeHtml(actor.name)}</b> назначил(а) вас на задачу <a href="${url}">${task.issueKey}: ${escapeHtml(task.title)}</a></p>`,
+      `${actor.name} назначил(а) вас на задачу ${task.issueKey}: ${task.title}`,
+    ).catch((err) => logger.warn('notification_email_failed', { type: 'task_assigned', error: String(err) }));
+  }
+}
+
+export async function emitCommentNotification(
+  taskId: string,
+  authorId: string,
+): Promise<void> {
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    select: {
+      title: true, issueKey: true, creatorId: true, assigneeId: true,
+      board: { select: { prefix: true, workspace: { select: { slug: true } } } },
+    },
+  });
+  if (!task) return;
+
+  const recipients = new Set<string>();
+  if (task.assigneeId && task.assigneeId !== authorId) recipients.add(task.assigneeId);
+  if (task.creatorId !== authorId) recipients.add(task.creatorId);
+  if (recipients.size === 0) return;
+
+  const author = await prisma.user.findUnique({
+    where: { id: authorId },
+    select: { id: true, name: true },
+  });
+  if (!author) return;
+
+  const payload = {
+    taskId,
+    taskTitle: task.title,
+    taskKey: task.issueKey,
+    workspaceSlug: task.board.workspace.slug,
+    boardSlug: task.board.prefix.toLowerCase(),
+    actor: author,
+  };
+
+  await prisma.notification.createMany({
+    data: [...recipients].map((userId) => ({
+      userId,
+      type: 'comment_added',
+      payload: payload as object,
+    })),
+    skipDuplicates: false,
+  });
+
+  const recipientUsers = await prisma.user.findMany({
+    where: { id: { in: [...recipients] }, emailNotifications: true },
+    select: { email: true },
+  });
+  const url = `${config.APP_URL}/w/${task.board.workspace.slug}/boards/${task.board.prefix.toLowerCase()}`;
+  for (const u of recipientUsers) {
+    void sendNotificationEmail(
+      u.email,
+      sanitizeEmailHeader(`Новый комментарий: ${task.issueKey}`),
+      `<p><b>${escapeHtml(author.name)}</b> прокомментировал(а) задачу <a href="${url}">${task.issueKey}: ${escapeHtml(task.title)}</a></p>`,
+      `${author.name} прокомментировал(а) задачу ${task.issueKey}: ${task.title}`,
+    ).catch((err) => logger.warn('notification_email_failed', { type: 'comment_added', error: String(err) }));
+  }
+}
+
+export async function emitMemberAddedNotification(
+  workspaceId: string,
+  addedUserId: string,
+  actorId: string,
+): Promise<void> {
+  const [workspace, actor] = await Promise.all([
+    prisma.workspace.findUnique({ where: { id: workspaceId }, select: { name: true, slug: true } }),
+    prisma.user.findUnique({ where: { id: actorId }, select: { id: true, name: true } }),
+  ]);
+  if (!workspace || !actor) return;
+
+  const payload = {
+    workspaceId,
+    workspaceName: workspace.name,
+    workspaceSlug: workspace.slug,
+    actor,
+  };
+
+  await prisma.notification.create({
+    data: { userId: addedUserId, type: 'member_added', payload: payload as object },
+  });
+
+  const addedUser = await prisma.user.findUnique({
+    where: { id: addedUserId },
+    select: { email: true, emailNotifications: true },
+  });
+  if (addedUser?.emailNotifications) {
+    void sendNotificationEmail(
+      addedUser.email,
+      sanitizeEmailHeader(`Вас добавили в воркспейс ${workspace.name}`),
+      `<p><b>${escapeHtml(actor.name)}</b> добавил(а) вас в воркспейс <b>${escapeHtml(workspace.name)}</b></p>`,
+      `${actor.name} добавил(а) вас в воркспейс ${workspace.name}`,
+    ).catch((err) => logger.warn('notification_email_failed', { type: 'member_added', error: String(err) }));
+  }
 }

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
-import { emitMentionNotifications } from '../notifications/notifications.service.js';
+import { emitMentionNotifications, emitTaskAssignedNotification } from '../notifications/notifications.service.js';
 import type { CreateTaskDto, UpdateTaskDto, TaskFiltersDto, MyTasksFiltersDto } from './tasks.dto.js';
 import type { Prisma } from '@prisma/client';
 
@@ -232,6 +232,10 @@ export async function createTask(boardId: string, userId: string, dto: CreateTas
     }, userId);
   }
 
+  if (dto.assigneeId && dto.assigneeId !== userId) {
+    emitTaskAssignedNotification(task.id, dto.assigneeId, userId).catch(() => {});
+  }
+
   return task;
 }
 
@@ -372,6 +376,12 @@ export async function updateTask(taskId: string, userId: string, dto: UpdateTask
       mentionedBy: author,
       context: 'task',
     }, userId);
+  }
+
+  // Notify new assignee if assignee changed
+  const newAssigneeId = dto.assigneeId;
+  if (newAssigneeId !== undefined && newAssigneeId !== current.assigneeId && newAssigneeId) {
+    emitTaskAssignedNotification(taskId, newAssigneeId, userId).catch(() => {});
   }
 
   return updated;

--- a/backend/src/modules/workspaces/workspaces.service.ts
+++ b/backend/src/modules/workspaces/workspaces.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { createDefaultWorkflow } from '../workflows/workflows.service.js';
+import { emitMemberAddedNotification } from '../notifications/notifications.service.js';
 import type { CreateWorkspaceDto, UpdateWorkspaceDto, AddMemberDto, UpdateMemberRoleDto, InviteByEmailDto } from './workspaces.dto.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -174,10 +175,12 @@ export async function addMember(workspaceId: string, requesterId: string, dto: A
   });
   if (existing) throw new AppError(409, 'User is already a member');
 
-  return prisma.workspaceMember.create({
+  const member = await prisma.workspaceMember.create({
     data: { workspaceId, userId: dto.userId, role: dto.role },
     include: { user: { select: { id: true, name: true, email: true, avatar: true } } },
   });
+  emitMemberAddedNotification(workspaceId, dto.userId, requesterId).catch(() => {});
+  return member;
 }
 
 export async function updateMemberRole(
@@ -219,6 +222,8 @@ export async function inviteByEmail(workspaceId: string, requesterId: string, dt
     data: { workspaceId, userId: targetUser.id, role: dto.role },
     include: { user: { select: { id: true, name: true, email: true, avatar: true } } },
   });
+
+  emitMemberAddedNotification(workspaceId, targetUser.id, requesterId).catch(() => {});
 
   await logEvent(workspaceId, requesterId, 'member_added', 'member', targetUser.id, {
     name: targetUser.name,

--- a/backend/src/prisma/migrations/20260506_add_email_notifications/migration.sql
+++ b/backend/src/prisma/migrations/20260506_add_email_notifications/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "email_notifications" BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -18,12 +18,13 @@ model User {
   keycloakId    String?   @unique                     // legacy — will be migrated to ssoSubjectId
   ssoSubjectId  String?   @unique @map("sso_subject_id") // provider sub claim: "<provider>:<sub>"
   authProvider  String    @default("local") @map("auth_provider") // "local" | "keycloak" | "avanpost"
-  ssoOnly       Boolean   @default(false) @map("sso_only") // local login disabled for this user
-  loginCount    Int       @default(0)
-  lastLoginAt   DateTime?
-  isSuperadmin  Boolean   @default(false)
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  ssoOnly              Boolean   @default(false) @map("sso_only") // local login disabled for this user
+  loginCount           Int       @default(0)
+  lastLoginAt          DateTime?
+  isSuperadmin         Boolean   @default(false)
+  emailNotifications   Boolean   @default(true) @map("email_notifications")
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
   refreshTokens        RefreshToken[]
   passwordResetTokens  PasswordResetToken[]

--- a/backend/src/shared/utils/email.ts
+++ b/backend/src/shared/utils/email.ts
@@ -49,3 +49,21 @@ export async function sendPasswordResetEmail(to: string, token: string): Promise
 
   logger.info('email_sent', { action: 'password_reset' });
 }
+
+export async function sendNotificationEmail(to: string, subject: string, html: string, text: string): Promise<void> {
+  if (!isConfigured()) {
+    logger.warn('email_not_configured', { action: 'notification', subject });
+    return;
+  }
+
+  const transport = createTransport();
+  await transport.sendMail({
+    from: `"FlowTask" <${config.SMTP_FROM}>`,
+    to,
+    subject,
+    text,
+    html,
+  });
+
+  logger.info('email_sent', { action: 'notification', subject });
+}

--- a/backend/src/shared/utils/sanitize.ts
+++ b/backend/src/shared/utils/sanitize.ts
@@ -13,3 +13,18 @@ export const stripHtml = (schema: z.ZodString) =>
   z.string()
     .transform(val => sanitizeHtml(val, PLAIN_TEXT_OPTIONS).trim())
     .pipe(schema);
+
+// Escape special HTML characters for safe interpolation into HTML strings.
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Strip newlines from strings that flow into email headers to prevent header injection.
+export function sanitizeEmailHeader(s: string): string {
+  return s.replace(/[\r\n]/g, ' ').trim();
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -16,7 +16,7 @@ export async function getMe(): Promise<User> {
   return data;
 }
 
-export async function updateProfile(data: { name?: string; email?: string }): Promise<User> {
+export async function updateProfile(data: { name?: string; email?: string; emailNotifications?: boolean }): Promise<User> {
   const { data: user } = await api.patch<User>('/auth/me', data);
   return user;
 }

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -11,11 +11,39 @@ export interface MentionPayload {
   body?: string;
 }
 
+export interface TaskAssignedPayload {
+  taskId: string;
+  taskTitle: string;
+  taskKey: string;
+  workspaceSlug: string;
+  boardSlug: string;
+  actor: { id: string; name: string };
+}
+
+export interface CommentAddedPayload {
+  taskId: string;
+  taskTitle: string;
+  taskKey: string;
+  workspaceSlug: string;
+  boardSlug: string;
+  actor: { id: string; name: string };
+}
+
+export interface MemberAddedPayload {
+  workspaceId: string;
+  workspaceName: string;
+  workspaceSlug: string;
+  actor: { id: string; name: string };
+}
+
+export type NotificationType = 'mention' | 'task_assigned' | 'comment_added' | 'member_added';
+export type NotificationPayload = MentionPayload | TaskAssignedPayload | CommentAddedPayload | MemberAddedPayload;
+
 export interface Notification {
   id: string;
   userId: string;
-  type: string;
-  payload: MentionPayload;
+  type: NotificationType;
+  payload: NotificationPayload;
   isRead: boolean;
   createdAt: string;
 }

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useThemeStore } from '../store/theme.store';
 import * as notificationsApi from '../api/notifications';
-import type { Notification } from '../api/notifications';
+import type { Notification, MentionPayload, TaskAssignedPayload, CommentAddedPayload, MemberAddedPayload } from '../api/notifications';
 
 const POLL_MS = 30_000;
 
@@ -12,6 +12,34 @@ function avatarInitials(name: string) { return name.split(/\s+/).map(w => w[0]).
 function bodyPreview(body?: string): string {
   if (!body) return '';
   return body.replace(/@\[([^\]]+)\]\([^)]+\)/g, '@$1').slice(0, 120);
+}
+
+function getActor(n: Notification): { id: string; name: string } {
+  if (n.type === 'mention') return (n.payload as MentionPayload).mentionedBy;
+  return (n.payload as TaskAssignedPayload | CommentAddedPayload | MemberAddedPayload).actor;
+}
+
+function getActionText(n: Notification): string {
+  switch (n.type) {
+    case 'mention': {
+      const p = n.payload as MentionPayload;
+      return p.context === 'comment' ? ' упомянул(а) вас в комментарии · ' : ' упомянул(а) вас в задаче · ';
+    }
+    case 'task_assigned': return ' назначил(а) вас на задачу · ';
+    case 'comment_added': return ' прокомментировал(а) задачу · ';
+    case 'member_added': return ' добавил(а) вас в воркспейс · ';
+    default: return ' · ';
+  }
+}
+
+function getTarget(n: Notification): string {
+  if (n.type === 'member_added') return (n.payload as MemberAddedPayload).workspaceName;
+  return (n.payload as MentionPayload | TaskAssignedPayload | CommentAddedPayload).taskKey;
+}
+
+function getSubtitle(n: Notification): string | null {
+  if (n.type === 'member_added') return null;
+  return (n.payload as MentionPayload | TaskAssignedPayload | CommentAddedPayload).taskTitle;
 }
 
 export default function NotificationBell() {
@@ -70,9 +98,11 @@ export default function NotificationBell() {
       setUnread(prev => Math.max(0, prev - 1));
     }
     setOpen(false);
-    const { workspaceSlug, boardSlug, taskId } = n.payload;
-    if (workspaceSlug && boardSlug) {
-      navigate(`/w/${workspaceSlug}/boards/${boardSlug}`, { state: { openTaskId: taskId } });
+    const p = n.payload as unknown as Record<string, unknown>;
+    if (p.workspaceSlug && p.boardSlug) {
+      navigate(`/w/${p.workspaceSlug}/boards/${p.boardSlug}`, { state: { openTaskId: p.taskId } });
+    } else if (p.workspaceSlug) {
+      navigate(`/w/${String(p.workspaceSlug)}`);
     }
   };
 
@@ -129,7 +159,10 @@ export default function NotificationBell() {
             {items.length === 0 ? (
               <div style={{ padding: '28px 16px', textAlign: 'center', fontSize: 13, color: muted }}>Нет уведомлений</div>
             ) : items.map(n => {
-              const preview = bodyPreview(n.payload.body);
+              const actor = getActor(n);
+              const preview = n.type === 'mention' ? bodyPreview((n.payload as MentionPayload).body) : null;
+              const subtitle = getSubtitle(n);
+              const isTaskLink = n.type !== 'member_added';
               return (
                 <div
                   key={n.id}
@@ -146,30 +179,30 @@ export default function NotificationBell() {
                     {/* Avatar */}
                     <div style={{
                       width: 30, height: 30, borderRadius: '50%', flexShrink: 0,
-                      background: avatarColor(n.payload.mentionedBy.name),
+                      background: avatarColor(actor.name),
                       display: 'flex', alignItems: 'center', justifyContent: 'center',
                     }}>
                       <span style={{ fontSize: 10, fontWeight: 700, color: '#fff' }}>
-                        {avatarInitials(n.payload.mentionedBy.name)}
+                        {avatarInitials(actor.name)}
                       </span>
                     </div>
 
                     <div style={{ flex: 1, minWidth: 0 }}>
-                      {/* Who + where */}
+                      {/* Who + action */}
                       <div style={{ fontSize: 13, color: text, lineHeight: '18px', marginBottom: 2 }}>
-                        <span style={{ fontWeight: 600 }}>{n.payload.mentionedBy.name}</span>
-                        <span style={{ color: subText }}>
-                          {n.payload.context === 'comment' ? ' упомянул(а) вас в комментарии · ' : ' упомянул(а) вас в задаче · '}
-                        </span>
-                        <span style={{ color: '#4F6EF7', fontWeight: 500 }}>{n.payload.taskKey}</span>
+                        <span style={{ fontWeight: 600 }}>{actor.name}</span>
+                        <span style={{ color: subText }}>{getActionText(n)}</span>
+                        <span style={{ color: '#4F6EF7', fontWeight: 500 }}>{getTarget(n)}</span>
                       </div>
 
-                      {/* Task title */}
-                      <div style={{ fontSize: 12, color: subText, marginBottom: preview ? 6 : 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {n.payload.taskTitle}
-                      </div>
+                      {/* Task title / subtitle */}
+                      {subtitle && (
+                        <div style={{ fontSize: 12, color: subText, marginBottom: preview ? 6 : 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {subtitle}
+                        </div>
+                      )}
 
-                      {/* Comment preview */}
+                      {/* Comment preview (mention only) */}
                       {preview && (
                         <div style={{
                           fontSize: 12, color: text, lineHeight: '17px',
@@ -182,13 +215,13 @@ export default function NotificationBell() {
                         </div>
                       )}
 
-                      {/* Footer: time + open button */}
+                      {/* Footer */}
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                         <span style={{ fontSize: 11, color: muted }}>
                           {new Date(n.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}
                         </span>
                         <span style={{ fontSize: 11, color: '#4F6EF7', fontWeight: 500 }}>
-                          Открыть задачу →
+                          {isTaskLink ? 'Открыть задачу →' : 'Открыть воркспейс →'}
                         </span>
                       </div>
                     </div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -262,17 +262,19 @@ export default function ProfilePage() {
 
   const [name, setName] = useState(user?.name ?? '');
   const [email, setEmail] = useState(user?.email ?? '');
+  const [emailNotifications, setEmailNotifications] = useState(user?.emailNotifications ?? true);
   const [saving, setSaving] = useState(false);
 
-  const hasChanges = name !== (user?.name ?? '') || email !== (user?.email ?? '');
+  const hasChanges = name !== (user?.name ?? '') || email !== (user?.email ?? '') || emailNotifications !== (user?.emailNotifications ?? true);
 
   const handleSave = async () => {
     if (!hasChanges) return;
     setSaving(true);
     try {
-      const data: { name?: string; email?: string } = {};
+      const data: { name?: string; email?: string; emailNotifications?: boolean } = {};
       if (name !== user?.name) data.name = name;
       if (email !== user?.email) data.email = email;
+      if (emailNotifications !== (user?.emailNotifications ?? true)) data.emailNotifications = emailNotifications;
       await updateProfile(data);
       message.success('Профиль обновлён');
     } catch (err: unknown) {
@@ -353,6 +355,34 @@ export default function ProfilePage() {
               lineHeight: '16px', outline: 'none', padding: '11px 14px', width: '100%',
             }}
           />
+        </div>
+
+        {/* Email notifications toggle */}
+        <div style={{ marginBottom: 28, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div>
+            <div style={{ color: c.label, fontFamily: INTER, fontSize: 12, fontWeight: 500, lineHeight: '16px', marginBottom: 2 }}>
+              Email-уведомления
+            </div>
+            <div style={{ color: c.muted, fontFamily: INTER, fontSize: 12, lineHeight: '16px' }}>
+              Назначение задач, комментарии, добавление в воркспейс
+            </div>
+          </div>
+          <button
+            onClick={() => setEmailNotifications(v => !v)}
+            style={{
+              width: 40, height: 22, borderRadius: 11, border: 'none',
+              background: emailNotifications ? c.accent : c.inputBorder,
+              position: 'relative', cursor: 'pointer', flexShrink: 0,
+              transition: 'background 0.2s',
+            }}
+            title={emailNotifications ? 'Выключить email-уведомления' : 'Включить email-уведомления'}
+          >
+            <span style={{
+              position: 'absolute', top: 3, left: emailNotifications ? 21 : 3,
+              width: 16, height: 16, borderRadius: '50%', background: '#fff',
+              transition: 'left 0.2s',
+            }} />
+          </button>
         </div>
 
         {/* Save button */}

--- a/frontend/src/store/auth.store.ts
+++ b/frontend/src/store/auth.store.ts
@@ -10,7 +10,7 @@ interface AuthState {
   register: (email: string, password: string, name: string) => Promise<string>;
   logout: () => Promise<void>;
   loadUser: () => Promise<void>;
-  updateProfile: (data: { name?: string; email?: string }) => Promise<void>;
+  updateProfile: (data: { name?: string; email?: string; emailNotifications?: boolean }) => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -24,6 +24,7 @@ export interface User {
   loginCount?: number;
   createdAt?: string;
   isSuperadmin?: boolean;
+  emailNotifications?: boolean;
 }
 
 // ─── Admin ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **4 new triggers**: task assigned, comment on assigned task, comment on created task, added to workspace
- **Email delivery**: `sendNotificationEmail` via existing SMTP config; HTML bodies with `escapeHtml` protection; subject lines sanitized against header injection with `sanitizeEmailHeader`
- **Opt-out**: `emailNotifications` boolean on User (defaults `true`); toggle in ProfilePage; PATCH /auth/me accepts the field
- **Prisma**: new `email_notifications` column + migration
- **NotificationBell**: handles all 4 types — correct action text, avatar, navigation (workspace link for `member_added`, board link for task types)
- **Security fixes applied**: HTML injection and email header injection addressed with `escapeHtml` / `sanitizeEmailHeader` in `sanitize.ts`; email send failures logged via `logger.warn` instead of silently swallowed

## Test plan

- [ ] Assign a task to another user → notification appears in Bell + email sent (if SMTP configured)
- [ ] Post a comment on a task assigned to someone else → assignee + creator each get notification
- [ ] Add a member to a workspace via invite or direct add → member gets `member_added` notification
- [ ] Toggle email notifications off in Profile → emails stop (notifications still created)
- [ ] Notification Bell renders correct text and navigates correctly for each type
- [ ] `tsc --noEmit` passes clean on both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)