### PR TITLE
feat: Gap-10 — bulk operations (select, update, delete)

### DIFF
--- a/backend/src/__tests__/tasks-bulk.test.ts
+++ b/backend/src/__tests__/tasks-bulk.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { auth, registerUser, createWorkspace, createBoard, createTask, cleanupTestData, api } from './helpers.js';
+import { prisma } from '../prisma/client.js';
+
+describe('Bulk task operations', () => {
+  let ownerToken: string;
+  let memberToken: string;
+  let viewerToken: string;
+  let outsiderToken: string;
+  let boardId: string;
+  let otherBoardId: string;
+  let workspaceId: string;
+  let memberId: string;
+  let statuses: Array<{ id: string; name: string; category: string }>;
+
+  beforeAll(async () => {
+    const owner   = await registerUser();
+    const member  = await registerUser();
+    const viewer  = await registerUser();
+    const outsider = await registerUser();
+    ownerToken    = owner.token;
+    memberToken   = member.token;
+    viewerToken   = viewer.token;
+    outsiderToken = outsider.token;
+    memberId      = member.userId;
+
+    const ws = await createWorkspace(ownerToken);
+    workspaceId = ws.id;
+
+    await api.post(`/api/workspaces/${workspaceId}/members`).set(auth(ownerToken))
+      .send({ userId: memberId, role: 'MEMBER' });
+    await api.post(`/api/workspaces/${workspaceId}/members`).set(auth(ownerToken))
+      .send({ userId: viewer.userId, role: 'VIEWER' });
+
+    const board = await createBoard(ownerToken, workspaceId);
+    boardId = board.id;
+    const otherBoard = await createBoard(ownerToken, workspaceId);
+    otherBoardId = otherBoard.id;
+
+    const boardDetail = await api.get(`/api/boards/${boardId}`).set(auth(ownerToken));
+    statuses = boardDetail.body.workflow.statuses;
+  });
+
+  afterAll(cleanupTestData);
+
+  // ── PATCH /bulk ──────────────────────────────────────────────────────────────
+
+  describe('PATCH /api/boards/:bid/tasks/bulk', () => {
+    it('bulk-updates priority for multiple tasks', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+      const t2 = await createTask(ownerToken, boardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id, t2.id], patch: { priority: 'HIGH' } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.updated).toBe(2);
+
+      const check = await api.get(`/api/tasks/${t1.id}`).set(auth(ownerToken));
+      expect(check.body.priority).toBe('HIGH');
+    });
+
+    it('bulk-updates status and moves tasks to new column', async () => {
+      const t1 = await createTask(ownerToken, boardId, { statusId: statuses[0].id });
+      const secondStatus = statuses[1];
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id], patch: { statusId: secondStatus.id } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.updated).toBe(1);
+
+      const check = await api.get(`/api/tasks/${t1.id}`).set(auth(ownerToken));
+      expect(check.body.statusId).toBe(secondStatus.id);
+    });
+
+    it('bulk-updates assignee', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id], patch: { assigneeId: memberId } });
+
+      expect(res.status).toBe(200);
+      const check = await api.get(`/api/tasks/${t1.id}`).set(auth(ownerToken));
+      expect(check.body.assignee?.id).toBe(memberId);
+    });
+
+    it('writes taskHistory records for changed fields', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id], patch: { priority: 'LOW' } });
+
+      const history = await prisma.taskHistory.findMany({ where: { taskId: t1.id } });
+      expect(history.some(h => h.field === 'priority' && h.newValue === 'LOW')).toBe(true);
+    });
+
+    it('writes taskStatusHistory on bulk status change', async () => {
+      const t1 = await createTask(ownerToken, boardId, { statusId: statuses[0].id });
+      const secondStatus = statuses[1];
+
+      // Ensure there's an open status history entry
+      await prisma.taskStatusHistory.create({ data: { taskId: t1.id, statusId: statuses[0].id } });
+
+      await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id], patch: { statusId: secondStatus.id } });
+
+      const closedEntry = await prisma.taskStatusHistory.findFirst({
+        where: { taskId: t1.id, statusId: statuses[0].id, endedAt: { not: null } },
+      });
+      const newEntry = await prisma.taskStatusHistory.findFirst({
+        where: { taskId: t1.id, statusId: secondStatus.id, endedAt: null },
+      });
+      expect(closedEntry).not.toBeNull();
+      expect(newEntry).not.toBeNull();
+    });
+
+    it('silently ignores IDs from a different board (returns updated: 0)', async () => {
+      const otherTask = await createTask(ownerToken, otherBoardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [otherTask.id], patch: { priority: 'HIGH' } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.updated).toBe(0);
+
+      // Original task must be unchanged
+      const check = await api.get(`/api/tasks/${otherTask.id}`).set(auth(ownerToken));
+      expect(check.body.priority).not.toBe('HIGH');
+    });
+
+    it('returns 400 for statusId not in board workflow', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+      // Create an isolated workspace+board so its statuses share no workflow with boardId
+      const isolatedWs = await createWorkspace(ownerToken);
+      const isolatedBoard = await createBoard(ownerToken, isolatedWs.id);
+      const isolatedDetail = await api.get(`/api/boards/${isolatedBoard.id}`).set(auth(ownerToken));
+      const foreignStatusId = isolatedDetail.body.workflow.statuses[0].id;
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id], patch: { statusId: foreignStatusId } });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for assigneeId not in workspace', async () => {
+      const outsiderDetail = await api.get('/api/auth/me').set(auth(outsiderToken));
+      const outsiderId = outsiderDetail.body.id;
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id], patch: { assigneeId: outsiderId } });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when ids array exceeds 100', async () => {
+      const ids = Array.from({ length: 101 }, () => '00000000-0000-0000-0000-000000000001');
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids, patch: { priority: 'LOW' } });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when patch object is empty', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id], patch: {} });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('VIEWER gets 403', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(viewerToken))
+        .send({ ids: [t1.id], patch: { priority: 'LOW' } });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('non-member gets 404', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .set(auth(outsiderToken))
+        .send({ ids: [t1.id], patch: { priority: 'LOW' } });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('unauthenticated gets 401', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.patch(`/api/boards/${boardId}/tasks/bulk`)
+        .send({ ids: [t1.id], patch: { priority: 'LOW' } });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── POST /bulk-delete ────────────────────────────────────────────────────────
+
+  describe('POST /api/boards/:bid/tasks/bulk-delete', () => {
+    it('deletes multiple tasks', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+      const t2 = await createTask(ownerToken, boardId);
+
+      const res = await api.post(`/api/boards/${boardId}/tasks/bulk-delete`)
+        .set(auth(ownerToken))
+        .send({ ids: [t1.id, t2.id] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(2);
+
+      const check = await api.get(`/api/tasks/${t1.id}`).set(auth(ownerToken));
+      expect(check.status).toBe(404);
+    });
+
+    it('cascades to subtasks', async () => {
+      const parent = await createTask(ownerToken, boardId);
+      const child = await api.post(`/api/boards/${boardId}/tasks`)
+        .set(auth(ownerToken))
+        .send({ title: 'Subtask', parentId: parent.id });
+      const childId = child.body.id;
+
+      await api.post(`/api/boards/${boardId}/tasks/bulk-delete`)
+        .set(auth(ownerToken))
+        .send({ ids: [parent.id] });
+
+      const checkChild = await api.get(`/api/tasks/${childId}`).set(auth(ownerToken));
+      expect(checkChild.status).toBe(404);
+    });
+
+    it('silently ignores IDs from a different board (returns deleted: 0)', async () => {
+      const otherTask = await createTask(ownerToken, otherBoardId);
+
+      const res = await api.post(`/api/boards/${boardId}/tasks/bulk-delete`)
+        .set(auth(ownerToken))
+        .send({ ids: [otherTask.id] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(0);
+
+      const check = await api.get(`/api/tasks/${otherTask.id}`).set(auth(ownerToken));
+      expect(check.status).toBe(200);
+    });
+
+    it('returns 400 when ids array exceeds 100', async () => {
+      const ids = Array.from({ length: 101 }, () => '00000000-0000-0000-0000-000000000001');
+
+      const res = await api.post(`/api/boards/${boardId}/tasks/bulk-delete`)
+        .set(auth(ownerToken))
+        .send({ ids });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('VIEWER gets 403', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.post(`/api/boards/${boardId}/tasks/bulk-delete`)
+        .set(auth(viewerToken))
+        .send({ ids: [t1.id] });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('non-member gets 404', async () => {
+      const t1 = await createTask(ownerToken, boardId);
+
+      const res = await api.post(`/api/boards/${boardId}/tasks/bulk-delete`)
+        .set(auth(outsiderToken))
+        .send({ ids: [t1.id] });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('unauthenticated gets 401', async () => {
+      const res = await api.post(`/api/boards/${boardId}/tasks/bulk-delete`)
+        .send({ ids: ['00000000-0000-0000-0000-000000000001'] });
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/backend/src/modules/tasks/tasks.dto.ts
+++ b/backend/src/modules/tasks/tasks.dto.ts
@@ -25,6 +25,22 @@ export const moveTaskDto = z.object({
   statusId: z.string().uuid(),
 });
 
+export const bulkUpdateDto = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(100),
+  patch: z.object({
+    statusId: z.string().uuid().optional(),
+    assigneeId: z.string().uuid().nullable().optional(),
+    priority: z.enum(['HIGH', 'MEDIUM', 'LOW']).nullable().optional(),
+  }).refine(
+    d => d.statusId !== undefined || d.assigneeId !== undefined || d.priority !== undefined,
+    'At least one field must be provided',
+  ),
+});
+
+export const bulkDeleteDto = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(100),
+});
+
 export const reorderTasksDto = z.object({
   updates: z.array(
     z.object({
@@ -59,5 +75,6 @@ export const myTasksFiltersDto = z.object({
 
 export type CreateTaskDto = z.infer<typeof createTaskDto>;
 export type UpdateTaskDto = z.infer<typeof updateTaskDto>;
+export type BulkUpdateDto = z.infer<typeof bulkUpdateDto>;
 export type TaskFiltersDto = z.infer<typeof taskFiltersDto>;
 export type MyTasksFiltersDto = z.infer<typeof myTasksFiltersDto>;

--- a/backend/src/modules/tasks/tasks.router.ts
+++ b/backend/src/modules/tasks/tasks.router.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { validate } from '../../shared/middleware/validate.js';
+import { rateLimit } from '../../shared/middleware/rate-limit.js';
 import {
   createTaskDto,
   updateTaskDto,
@@ -8,9 +9,20 @@ import {
   reorderTasksDto,
   taskFiltersDto,
   myTasksFiltersDto,
+  bulkUpdateDto,
+  bulkDeleteDto,
+  type BulkUpdateDto,
 } from './tasks.dto.js';
 import * as tasks from './tasks.service.js';
 import { authHandler } from '../../shared/utils/async-handler.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+
+const bulkLimit = rateLimit({
+  scope: 'bulk-tasks',
+  limit: 30,
+  windowMs: 60_000,
+  keyFn: (req) => (req as AuthRequest).user?.userId ?? req.ip ?? 'anon',
+});
 
 // ─── /boards/:bid/tasks ───────────────────────────────────────────────────────
 export const boardTasksRouter = Router({ mergeParams: true });
@@ -27,6 +39,16 @@ boardTasksRouter.post('/', validate(createTaskDto), authHandler(async (req, res)
 boardTasksRouter.patch('/reorder', validate(reorderTasksDto), authHandler(async (req, res) => {
   await tasks.reorderTasks(String(req.params.bid), req.user!.userId, req.body.updates);
   res.json({ message: 'Reordered' });
+}));
+
+boardTasksRouter.patch('/bulk', bulkLimit, validate(bulkUpdateDto), authHandler(async (req, res) => {
+  const { ids, patch } = req.body as BulkUpdateDto;
+  res.json(await tasks.bulkUpdateTasks(String(req.params.bid), req.user!.userId, ids, patch));
+}));
+
+boardTasksRouter.post('/bulk-delete', bulkLimit, validate(bulkDeleteDto), authHandler(async (req, res) => {
+  const { ids } = req.body as { ids: string[] };
+  res.json(await tasks.bulkDeleteTasks(String(req.params.bid), req.user!.userId, ids));
 }));
 
 // ─── /tasks/:id ───────────────────────────────────────────────────────────────

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -513,16 +513,56 @@ export async function bulkUpdateTasks(
     if (!isMember) throw new AppError(400, 'Assignee is not a member of this workspace');
   }
 
-  const result = await prisma.task.updateMany({
+  // Fetch current state to compute history and status transitions
+  const current = await prisma.task.findMany({
     where: { id: { in: ids }, boardId },
-    data: {
-      ...(patch.statusId !== undefined && { statusId: patch.statusId }),
-      ...(patch.assigneeId !== undefined && { assigneeId: patch.assigneeId }),
-      ...(patch.priority !== undefined && { priority: patch.priority }),
-    },
+    select: { id: true, statusId: true, assigneeId: true, priority: true },
+  });
+  if (current.length === 0) return { updated: 0 };
+
+  const validIds = current.map(t => t.id);
+  const historyEntries: HistoryRecord[] = [];
+  const statusChangedIds: string[] = [];
+
+  for (const t of current) {
+    if (patch.statusId !== undefined && patch.statusId !== t.statusId) {
+      historyEntries.push({ taskId: t.id, userId, field: 'statusId', oldValue: t.statusId, newValue: patch.statusId });
+      statusChangedIds.push(t.id);
+    }
+    if (patch.assigneeId !== undefined && patch.assigneeId !== t.assigneeId) {
+      historyEntries.push({ taskId: t.id, userId, field: 'assigneeId', oldValue: t.assigneeId, newValue: patch.assigneeId });
+    }
+    if (patch.priority !== undefined && patch.priority !== t.priority) {
+      historyEntries.push({ taskId: t.id, userId, field: 'priority', oldValue: t.priority ?? null, newValue: patch.priority ?? null });
+    }
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.task.updateMany({
+      where: { id: { in: validIds }, boardId },
+      data: {
+        ...(patch.statusId !== undefined && { statusId: patch.statusId }),
+        ...(patch.assigneeId !== undefined && { assigneeId: patch.assigneeId }),
+        ...(patch.priority !== undefined && { priority: patch.priority }),
+      },
+    });
+
+    if (historyEntries.length > 0) {
+      await tx.taskHistory.createMany({ data: historyEntries });
+    }
+
+    if (statusChangedIds.length > 0) {
+      await tx.taskStatusHistory.updateMany({
+        where: { taskId: { in: statusChangedIds }, endedAt: null },
+        data: { endedAt: new Date() },
+      });
+      await tx.taskStatusHistory.createMany({
+        data: statusChangedIds.map(id => ({ taskId: id, statusId: patch.statusId! })),
+      });
+    }
   });
 
-  return { updated: result.count };
+  return { updated: validIds.length };
 }
 
 // ─── Bulk delete tasks ────────────────────────────────────────────────────────

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -490,6 +490,69 @@ export async function deleteTask(taskId: string, userId: string) {
   ]);
 }
 
+// ─── Bulk update tasks ────────────────────────────────────────────────────────
+
+export async function bulkUpdateTasks(
+  boardId: string,
+  userId: string,
+  ids: string[],
+  patch: { statusId?: string; assigneeId?: string | null; priority?: 'HIGH' | 'MEDIUM' | 'LOW' | null },
+) {
+  const { board, member } = await getBoardWithAccess(boardId, userId);
+  if (member.role === 'VIEWER') throw new AppError(403, 'Viewers cannot update tasks');
+
+  if (patch.statusId) {
+    const valid = board.workflow.statuses.find(s => s.id === patch.statusId);
+    if (!valid) throw new AppError(400, 'Status does not belong to this board workflow');
+  }
+
+  if (patch.assigneeId) {
+    const isMember = await prisma.workspaceMember.findUnique({
+      where: { workspaceId_userId: { workspaceId: board.workspaceId, userId: patch.assigneeId } },
+    });
+    if (!isMember) throw new AppError(400, 'Assignee is not a member of this workspace');
+  }
+
+  const result = await prisma.task.updateMany({
+    where: { id: { in: ids }, boardId },
+    data: {
+      ...(patch.statusId !== undefined && { statusId: patch.statusId }),
+      ...(patch.assigneeId !== undefined && { assigneeId: patch.assigneeId }),
+      ...(patch.priority !== undefined && { priority: patch.priority }),
+    },
+  });
+
+  return { updated: result.count };
+}
+
+// ─── Bulk delete tasks ────────────────────────────────────────────────────────
+
+export async function bulkDeleteTasks(boardId: string, userId: string, ids: string[]) {
+  const { member } = await getBoardWithAccess(boardId, userId);
+  if (member.role === 'VIEWER') throw new AppError(403, 'Viewers cannot delete tasks');
+
+  const tasksToDelete = await prisma.task.findMany({
+    where: { id: { in: ids }, boardId },
+    select: { id: true, path: true },
+  });
+  if (tasksToDelete.length === 0) return { deleted: 0 };
+
+  const validIds = tasksToDelete.map(t => t.id);
+
+  await prisma.$transaction(async (tx) => {
+    // Delete descendants before the selected tasks (materialized path cascade)
+    await tx.task.deleteMany({
+      where: {
+        boardId,
+        OR: tasksToDelete.map(t => ({ path: { startsWith: `${t.path}${t.id}/` } })),
+      },
+    });
+    await tx.task.deleteMany({ where: { id: { in: validIds } } });
+  });
+
+  return { deleted: validIds.length };
+}
+
 // ─── My Tasks (cross-workspace) ───────────────────────────────────────────────
 
 export async function listMyTasks(userId: string, filters: MyTasksFiltersDto) {
@@ -545,7 +608,8 @@ export async function reorderTasks(
   userId: string,
   updates: { id: string; statusId: string; orderIndex: number }[],
 ) {
-  const { board } = await getBoardWithAccess(boardId, userId);
+  const { board, member } = await getBoardWithAccess(boardId, userId);
+  if (member.role === 'VIEWER') throw new AppError(403, 'Viewers cannot reorder tasks');
   const validStatusIds = new Set(board.workflow.statuses.map((s) => s.id));
 
   for (const u of updates) {

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -72,6 +72,25 @@ export async function getTaskHistory(taskId: string): Promise<TaskHistory[]> {
   return data;
 }
 
+export interface BulkUpdatePayload {
+  ids: string[];
+  patch: {
+    statusId?: string;
+    assigneeId?: string | null;
+    priority?: 'HIGH' | 'MEDIUM' | 'LOW' | null;
+  };
+}
+
+export async function bulkUpdateTasks(boardId: string, payload: BulkUpdatePayload): Promise<{ updated: number }> {
+  const { data } = await api.patch<{ updated: number }>(`/boards/${boardId}/tasks/bulk`, payload);
+  return data;
+}
+
+export async function bulkDeleteTasks(boardId: string, ids: string[]): Promise<{ deleted: number }> {
+  const { data } = await api.post<{ deleted: number }>(`/boards/${boardId}/tasks/bulk-delete`, { ids });
+  return data;
+}
+
 export async function listMyTasks(params?: {
   priority?: string;
   duePreset?: string;

--- a/frontend/src/components/BoardListView.tsx
+++ b/frontend/src/components/BoardListView.tsx
@@ -61,7 +61,7 @@ function avatarColor(name: string): string { return AVATAR_PALETTE[(name?.charCo
 function avatarInitials(name: string): string { return name.split(/\s+/).map(w => w[0]).slice(0, 2).join('').toUpperCase() || '?'; }
 
 // ── Column widths ──────────────────────────────────────────────────────────────
-const W = { key: 120, status: 140, priority: 100, assignee: 140, due: 100, labels: 160 };
+const W = { checkbox: 36, key: 120, status: 140, priority: 100, assignee: 140, due: 100, labels: 160 };
 
 // ── Props ──────────────────────────────────────────────────────────────────────
 interface Props {
@@ -74,12 +74,16 @@ interface Props {
   onQuickAddStart: (statusId: string) => void;
   onQuickAddChange: (title: string) => void;
   onQuickAddSubmit: (statusId: string) => void;
+  selectedTaskIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
+  onSelectAll?: (ids: string[]) => void;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 export default function BoardListView({
   statuses, tasks, onTaskClick, onTaskUpdated,
   quickAddStatusId, quickAddTitle, onQuickAddStart, onQuickAddChange, onQuickAddSubmit,
+  selectedTaskIds, onToggleSelect, onSelectAll,
 }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
@@ -113,6 +117,32 @@ export default function BoardListView({
         color: c.headerText, letterSpacing: '0.04em', textTransform: 'uppercase',
         position: 'sticky', top: 0, zIndex: 10,
       }}>
+        {onToggleSelect && (
+          <div style={{ width: W.checkbox, flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+            {onSelectAll && (() => {
+              const allIds = tasks.map(t => t.id);
+              const allSelected = allIds.length > 0 && allIds.every(id => selectedTaskIds?.has(id));
+              return (
+                <div
+                  onClick={() => onSelectAll(allSelected ? [] : allIds)}
+                  style={{
+                    width: 14, height: 14, borderRadius: 3,
+                    border: `1.5px solid ${allSelected ? '#4F6EF7' : c.headerText}`,
+                    background: allSelected ? '#4F6EF7' : 'transparent',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    cursor: 'pointer', transition: 'all 0.12s',
+                  }}
+                >
+                  {allSelected && (
+                    <svg width="8" height="6" viewBox="0 0 8 6" fill="none">
+                      <path d="M1 3l2 2 4-4" stroke="#fff" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  )}
+                </div>
+              );
+            })()}
+          </div>
+        )}
         <div style={{ width: W.key, flexShrink: 0 }}>Ключ</div>
         <div style={{ flex: 1 }}>Задача</div>
         <div style={{ width: W.status, flexShrink: 0 }}>Статус</div>
@@ -188,24 +218,50 @@ export default function BoardListView({
                   const prio = prioKey ? (PRIO[prioKey] ?? null) : null;
                   const prioCfg = prio ? prio[isDark ? 0 : 1] : null;
 
+                  const isRowSelected = selectedTaskIds?.has(task.id) ?? false;
                   return (
                     <div
                       key={task.id}
                       style={{
                         display: 'flex', alignItems: 'center',
-                        background: isActive ? c.rowActiveBg : c.rowBg,
+                        background: isRowSelected
+                          ? (isDark ? '#111A30' : '#F0F1FF')
+                          : (isActive ? c.rowActiveBg : c.rowBg),
                         borderBottom: `1px solid ${c.rowBorder}`,
-                        borderLeft: (!isDark && isActive) ? '3px solid #4F6EF7' : 'none',
+                        borderLeft: isRowSelected
+                          ? '3px solid #4F6EF7'
+                          : (!isDark && isActive) ? '3px solid #4F6EF7' : 'none',
                         padding: '12px 24px',
                         opacity: isDoneRow ? 0.65 : 1,
                         transition: 'background 0.1s',
                       }}
-                      onMouseEnter={e => { if (!isActive) (e.currentTarget as HTMLDivElement).style.background = isDark ? '#0D1017' : '#F7F5FD'; }}
-                      onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = isActive ? c.rowActiveBg : c.rowBg; }}
+                      onMouseEnter={e => { if (!isActive && !isRowSelected) (e.currentTarget as HTMLDivElement).style.background = isDark ? '#0D1017' : '#F7F5FD'; }}
+                      onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.background = isRowSelected ? (isDark ? '#111A30' : '#F0F1FF') : (isActive ? c.rowActiveBg : c.rowBg); }}
                     >
+                      {/* Checkbox */}
+                      {onToggleSelect && (
+                        <div style={{ width: W.checkbox, flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+                          <div
+                            onClick={e => { e.stopPropagation(); onToggleSelect(task.id); }}
+                            style={{
+                              width: 14, height: 14, borderRadius: 3,
+                              border: `1.5px solid ${isRowSelected ? '#4F6EF7' : c.keyText}`,
+                              background: isRowSelected ? '#4F6EF7' : 'transparent',
+                              display: 'flex', alignItems: 'center', justifyContent: 'center',
+                              cursor: 'pointer', transition: 'all 0.12s', flexShrink: 0,
+                            }}
+                          >
+                            {isRowSelected && (
+                              <svg width="8" height="6" viewBox="0 0 8 6" fill="none">
+                                <path d="M1 3l2 2 4-4" stroke="#fff" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                              </svg>
+                            )}
+                          </div>
+                        </div>
+                      )}
                       {/* Key */}
                       <div style={{
-                        width: W.key - ((!isDark && isActive) ? 3 : 0),
+                        width: W.key - (isRowSelected || (!isDark && isActive) ? 3 : 0),
                         flexShrink: 0,
                         fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 600,
                         color: isActive ? c.keyActiveText : c.keyText,

--- a/frontend/src/components/BulkActionBar.tsx
+++ b/frontend/src/components/BulkActionBar.tsx
@@ -1,0 +1,216 @@
+import { useState } from 'react';
+import { useThemeStore } from '../store/theme.store';
+import type { WorkflowStatus, WorkspaceMember } from '../types';
+
+interface BulkPatch {
+  statusId?: string;
+  assigneeId?: string | null;
+  priority?: 'HIGH' | 'MEDIUM' | 'LOW' | null;
+}
+
+interface Props {
+  count: number;
+  statuses: WorkflowStatus[];
+  members: WorkspaceMember[];
+  onBulkUpdate: (patch: BulkPatch) => Promise<void>;
+  onBulkDelete: () => Promise<void>;
+  onClose: () => void;
+}
+
+export default function BulkActionBar({ count, statuses, members, onBulkUpdate, onBulkDelete, onClose }: Props) {
+  const mode = useThemeStore(s => s.mode);
+  const isDark = mode === 'dark';
+
+  const bg = isDark ? '#0F1320' : '#FFFFFF';
+  const border = isDark ? '#1C2236' : '#E8E5F0';
+  const text = isDark ? '#E2E8F8' : '#1A1A2E';
+  const muted = isDark ? '#8B95B0' : '#9B96B8';
+  const inputBg = isDark ? '#07091A' : '#F5F3FF';
+  const inputBorder = isDark ? '#2A3250' : '#DDD9F0';
+
+  const [loading, setLoading] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const handle = async (fn: () => Promise<void>) => {
+    if (loading) return;
+    setLoading(true);
+    try { await fn(); } finally { setLoading(false); }
+  };
+
+  const CLEAR = '__clear__';
+
+  const handleStatus = (statusId: string) => {
+    if (!statusId) return;
+    handle(() => onBulkUpdate({ statusId }));
+  };
+
+  const handlePriority = (val: string) => {
+    if (!val) return;
+    const priority = val === CLEAR ? null : val as 'HIGH' | 'MEDIUM' | 'LOW';
+    handle(() => onBulkUpdate({ priority }));
+  };
+
+  const handleAssignee = (val: string) => {
+    if (!val) return;
+    const assigneeId = val === CLEAR ? null : val;
+    handle(() => onBulkUpdate({ assigneeId }));
+  };
+
+  const handleDelete = async () => {
+    setConfirmDelete(false);
+    handle(onBulkDelete);
+  };
+
+  const selectStyle: React.CSSProperties = {
+    background: inputBg,
+    border: `1px solid ${inputBorder}`,
+    borderRadius: 7,
+    padding: '5px 8px',
+    fontFamily: '"Inter",system-ui,sans-serif',
+    fontSize: 12,
+    color: text,
+    cursor: 'pointer',
+    outline: 'none',
+    height: 30,
+    appearance: 'none',
+    WebkitAppearance: 'none',
+    paddingRight: 24,
+    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='${isDark ? '%238B95B0' : '%239B96B8'}' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`,
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'right 8px center',
+    minWidth: 120,
+  };
+
+  return (
+    <div style={{
+      position: 'fixed', bottom: 24, left: '50%', transform: 'translateX(-50%)',
+      zIndex: 500,
+      display: 'flex', alignItems: 'center', gap: 8,
+      background: bg,
+      border: `1px solid ${border}`,
+      borderRadius: 12,
+      padding: '8px 12px',
+      boxShadow: isDark
+        ? '0 8px 32px rgba(0,0,0,0.5), 0 0 0 1px rgba(79,110,247,0.15)'
+        : '0 8px 32px rgba(0,0,0,0.12), 0 0 0 1px rgba(79,110,247,0.1)',
+      backdropFilter: 'blur(8px)',
+      WebkitBackdropFilter: 'blur(8px)',
+      whiteSpace: 'nowrap',
+      opacity: loading ? 0.6 : 1,
+      transition: 'opacity 0.15s',
+    }}>
+      {/* Count + close */}
+      <button
+        onClick={onClose}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          background: 'none', border: 'none', cursor: 'pointer', padding: '0 4px',
+        }}
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M3 3l8 8M11 3l-8 8" stroke={muted} strokeWidth="1.4" strokeLinecap="round"/>
+        </svg>
+        <span style={{
+          fontFamily: '"Inter",system-ui,sans-serif', fontSize: 13, fontWeight: 600,
+          color: '#4F6EF7',
+        }}>
+          {count} {count === 1 ? 'задача' : count < 5 ? 'задачи' : 'задач'}
+        </span>
+      </button>
+
+      <div style={{ width: 1, height: 20, background: border }} />
+
+      {/* Status */}
+      <select
+        value=""
+        onChange={e => handleStatus(e.target.value)}
+        disabled={loading}
+        style={selectStyle}
+      >
+        <option value="">Статус...</option>
+        {statuses.map(s => (
+          <option key={s.id} value={s.id}>{s.name}</option>
+        ))}
+      </select>
+
+      {/* Priority */}
+      <select
+        value=""
+        onChange={e => handlePriority(e.target.value)}
+        disabled={loading}
+        style={selectStyle}
+      >
+        <option value="">Приоритет...</option>
+        <option value="HIGH">HIGH</option>
+        <option value="MEDIUM">MEDIUM</option>
+        <option value="LOW">LOW</option>
+        <option value={CLEAR}>— Очистить</option>
+      </select>
+
+      {/* Assignee */}
+      <select
+        value=""
+        onChange={e => handleAssignee(e.target.value)}
+        disabled={loading}
+        style={{ ...selectStyle, minWidth: 140 }}
+      >
+        <option value="">Исполнитель...</option>
+        {members.map(m => (
+          <option key={m.userId} value={m.userId}>{m.user.name}</option>
+        ))}
+        <option value={CLEAR}>— Очистить</option>
+      </select>
+
+      <div style={{ width: 1, height: 20, background: border }} />
+
+      {/* Delete */}
+      {confirmDelete ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: '#EF4444' }}>
+            Удалить {count}?
+          </span>
+          <button
+            onClick={handleDelete}
+            style={{
+              background: '#EF4444', color: '#fff', border: 'none',
+              borderRadius: 6, padding: '4px 10px', cursor: 'pointer',
+              fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 600,
+            }}
+          >
+            Да
+          </button>
+          <button
+            onClick={() => setConfirmDelete(false)}
+            style={{
+              background: inputBg, color: muted,
+              border: `1px solid ${inputBorder}`,
+              borderRadius: 6, padding: '4px 10px', cursor: 'pointer',
+              fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12,
+            }}
+          >
+            Нет
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setConfirmDelete(true)}
+          disabled={loading}
+          title="Удалить выбранные задачи"
+          style={{
+            display: 'flex', alignItems: 'center', gap: 5,
+            background: 'rgba(239,68,68,0.1)', color: '#EF4444',
+            border: '1px solid rgba(239,68,68,0.25)',
+            borderRadius: 7, padding: '5px 10px', cursor: 'pointer',
+            fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, fontWeight: 500,
+            height: 30,
+          }}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M1.5 3h9M4.5 3V2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5v1m1 0-.5 7a.5.5 0 0 1-.5.5h-5a.5.5 0 0 1-.5-.5L2.5 3" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          Удалить
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -28,9 +28,14 @@ function avatarInitials(name: string): string {
   return name.split(/\s+/).map(w => w[0]).slice(0, 2).join('').toUpperCase() || '?';
 }
 
-interface Props { task: Task; onClick?: () => void }
+interface Props {
+  task: Task;
+  onClick?: () => void;
+  isSelected?: boolean;
+  onSelect?: (id: string) => void;
+}
 
-export default function TaskCard({ task, onClick }: Props) {
+export default function TaskCard({ task, onClick, isSelected = false, onSelect }: Props) {
   const mode = useThemeStore(s => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
 
@@ -45,18 +50,40 @@ export default function TaskCard({ task, onClick }: Props) {
     <div
       onClick={onClick}
       style={{
-        background: c.bg, border: `1px solid ${c.border}`,
+        background: c.bg,
+        border: `1px solid ${isSelected ? '#4F6EF7' : c.border}`,
         borderRadius: 10, padding: '12px 14px',
         cursor: 'pointer', userSelect: 'none', transition: 'border-color 0.15s',
+        outline: isSelected ? '2px solid rgba(79,110,247,0.25)' : 'none',
       }}
-      onMouseEnter={e => (e.currentTarget.style.borderColor = c.borderHover)}
-      onMouseLeave={e => (e.currentTarget.style.borderColor = c.border)}
+      onMouseEnter={e => { (e.currentTarget.style.borderColor = isSelected ? '#4F6EF7' : c.borderHover); }}
+      onMouseLeave={e => { (e.currentTarget.style.borderColor = isSelected ? '#4F6EF7' : c.border); }}
     >
       {/* Key + priority badge */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
-        <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.key, letterSpacing: '0.02em' }}>
-          {task.issueKey}
-        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          {onSelect && (
+            <div
+              onClick={e => { e.stopPropagation(); onSelect(task.id); }}
+              style={{
+                width: 14, height: 14, borderRadius: 3, flexShrink: 0,
+                border: `1.5px solid ${isSelected ? '#4F6EF7' : c.key}`,
+                background: isSelected ? '#4F6EF7' : 'transparent',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                cursor: 'pointer', transition: 'all 0.12s',
+              }}
+            >
+              {isSelected && (
+                <svg width="8" height="6" viewBox="0 0 8 6" fill="none">
+                  <path d="M1 3l2 2 4-4" stroke="#fff" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              )}
+            </div>
+          )}
+          <span style={{ fontFamily: '"Inter",system-ui,sans-serif', fontSize: 11, color: c.key, letterSpacing: '0.02em' }}>
+            {task.issueKey}
+          </span>
+        </div>
         {prio && (
           <span style={{
             fontFamily: '"Inter",system-ui,sans-serif', fontSize: 10, fontWeight: 600,

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -21,6 +21,7 @@ import BoardListView from '../components/BoardListView';
 import BoardCalendarView from '../components/BoardCalendarView';
 import RoadmapView from '../components/RoadmapView';
 import FilterBar from '../components/FilterBar';
+import BulkActionBar from '../components/BulkActionBar';
 
 type ViewMode = 'board' | 'list' | 'calendar' | 'roadmap';
 type Columns = Record<string, Task[]>;
@@ -204,6 +205,7 @@ export default function BoardPage() {
   const [labels, setLabels] = useState<Label[]>([]);
   const [wfEditorOpen, setWfEditorOpen] = useState(false);
   const [draggingFromStatusId, setDraggingFromStatusId] = useState<string | null>(null);
+  const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
   const [columnOffsets, setColumnOffsets] = useState<Record<string, number>>({});
   const [columnTotals, setColumnTotals] = useState<Record<string, number>>({});
   const [loadingMoreCols, setLoadingMoreCols] = useState<Set<string>>(new Set());
@@ -433,6 +435,81 @@ export default function BoardPage() {
       }
       return newCols;
     });
+  };
+
+  // ── Selection ─────────────────────────────────────────────────────────────
+  const toggleSelect = (id: string) => {
+    setSelectedTaskIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const selectAll = (ids: string[]) => {
+    setSelectedTaskIds(ids.length === 0 ? new Set() : new Set(ids));
+  };
+
+  // ── Bulk operations ───────────────────────────────────────────────────────
+  const handleBulkUpdate = async (patch: { statusId?: string; assigneeId?: string | null; priority?: 'HIGH' | 'MEDIUM' | 'LOW' | null }) => {
+    if (!board || selectedTaskIds.size === 0) return;
+    const ids = [...selectedTaskIds];
+    try {
+      await tasksApi.bulkUpdateTasks(board.id, { ids, patch });
+
+      setColumns(prev => {
+        const idSet = new Set(ids);
+        // Apply patch to all selected tasks
+        const allUpdated: Task[] = [];
+        for (const tasks of Object.values(prev)) {
+          for (const t of tasks) {
+            if (!idSet.has(t.id)) {
+              allUpdated.push(t);
+            } else {
+              const updated = { ...t };
+              if (patch.statusId !== undefined) updated.statusId = patch.statusId!;
+              if (patch.priority !== undefined) updated.priority = patch.priority ?? undefined;
+              if (patch.assigneeId !== undefined) {
+                if (patch.assigneeId === null) {
+                  updated.assignee = undefined;
+                } else {
+                  const m = members.find(mb => mb.userId === patch.assigneeId);
+                  updated.assignee = m ? { id: m.userId, name: m.user.name, avatar: m.user.avatar } : undefined;
+                }
+              }
+              allUpdated.push(updated);
+            }
+          }
+        }
+        // Redistribute into columns by current statusId
+        const newCols: Columns = {};
+        for (const sid of Object.keys(prev)) newCols[sid] = [];
+        for (const t of allUpdated) {
+          if (!newCols[t.statusId]) newCols[t.statusId] = [];
+          newCols[t.statusId].push(t);
+        }
+        return newCols;
+      });
+
+      setSelectedTaskIds(new Set());
+      message.success(`Обновлено ${ids.length} задач`);
+    } catch {
+      message.error('Не удалось обновить задачи');
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    if (!board || selectedTaskIds.size === 0) return;
+    const ids = [...selectedTaskIds];
+    try {
+      await tasksApi.bulkDeleteTasks(board.id, ids);
+      setSelectedTaskIds(new Set());
+      message.success(`Удалено ${ids.length} задач`);
+      // Reload to remove deleted subtasks that aren't in selection
+      loadBoard();
+    } catch {
+      message.error('Не удалось удалить задачи');
+    }
   };
 
   // ── Filtered data ─────────────────────────────────────────────────────────
@@ -698,7 +775,12 @@ export default function BoardPage() {
                                     {...drag.dragHandleProps}
                                     style={{ marginBottom: 8, opacity: snap.isDragging ? 0.85 : 1, ...drag.draggableProps.style }}
                                   >
-                                    <TaskCard task={task} onClick={() => setSelectedTaskId(task.id)} />
+                                    <TaskCard
+                                      task={task}
+                                      onClick={() => setSelectedTaskId(task.id)}
+                                      isSelected={selectedTaskIds.has(task.id)}
+                                      onSelect={toggleSelect}
+                                    />
                                   </div>
                                 )}
                               </Draggable>
@@ -743,6 +825,9 @@ export default function BoardPage() {
             onQuickAddStart={sid => { setAddingTo(sid); setAddTitle(''); }}
             onQuickAddChange={setAddTitle}
             onQuickAddSubmit={submitAdd}
+            selectedTaskIds={selectedTaskIds}
+            onToggleSelect={toggleSelect}
+            onSelectAll={selectAll}
           />
         )}
 
@@ -763,6 +848,18 @@ export default function BoardPage() {
           />
         )}
       </div>
+
+      {/* Bulk action bar */}
+      {selectedTaskIds.size > 0 && (
+        <BulkActionBar
+          count={selectedTaskIds.size}
+          statuses={statuses}
+          members={members}
+          onBulkUpdate={handleBulkUpdate}
+          onBulkDelete={handleBulkDelete}
+          onClose={() => setSelectedTaskIds(new Set())}
+        />
+      )}
 
       {/* Task drawer */}
       <TaskDrawer


### PR DESCRIPTION
## Summary

- **PATCH** `/api/boards/:bid/tasks/bulk` — bulk update status/priority/assignee for up to 100 tasks
- **POST** `/api/boards/:bid/tasks/bulk-delete` — bulk delete with full subtree cascade (materialized path)
- Frontend: checkbox selection in Kanban cards and List view, floating `BulkActionBar` at page bottom

## Security & auth
- Rate limit: 30 req/min per user on both endpoints
- VIEWER role blocked (403) on both endpoints + `reorderTasks` (pre-existing gap fixed)
- `assigneeId` validated against workspace membership before write
- Changed from `DELETE` body (infra-unreliable) to `POST /bulk-delete`

## Code review issues fixed
- try/catch on all bulk API calls in BoardPage
- Optimistic column redistribution rewritten to correctly move cards to new status column
- `loadBoard()` after bulk delete to remove orphaned subtasks from UI
- `__clear__` sentinel in BulkActionBar selects to distinguish "clear" from placeholder
- `onSelect` signature aligned to `(id: string) => void`
- `validate()` middleware result used directly — no double-parse

## Test plan
- [ ] Select tasks in kanban → BulkActionBar appears at bottom
- [ ] Select tasks in list view via checkboxes → BulkActionBar appears
- [ ] "Select all" in list view header selects/deselects all visible tasks
- [ ] Change status → cards move to correct column instantly
- [ ] Change priority → badges update instantly
- [ ] Change assignee → avatars update instantly
- [ ] Delete → inline confirm → tasks removed, loadBoard() refreshes subtrees
- [ ] VIEWER account → bulk update/delete returns 403
- [ ] 101 IDs → 400 from Zod `.max(100)` validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)