### PR TITLE
fix: workspaceSlug + boardSlug в emitMentionNotifications

### DIFF
--- a/backend/src/__tests__/comments.test.ts
+++ b/backend/src/__tests__/comments.test.ts
@@ -59,8 +59,8 @@ describe('Comments', () => {
       await api.post(`/api/tasks/${taskId}/comments`).set(auth(ownerToken)).send({ body: 'Comment 1' });
       const res = await api.get(`/api/tasks/${taskId}/comments`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body)).toBe(true);
-      expect(res.body.length).toBeGreaterThan(0);
+      expect(Array.isArray(res.body.comments)).toBe(true);
+      expect(res.body.comments.length).toBeGreaterThan(0);
     });
 
     it('VIEWER can read comments', async () => {

--- a/backend/src/__tests__/workspaces.test.ts
+++ b/backend/src/__tests__/workspaces.test.ts
@@ -125,7 +125,7 @@ describe('Workspaces', () => {
     it('returns workspace event history for OWNER', async () => {
       const res = await api.get(`/api/workspaces/${workspaceId}/history`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body)).toBe(true);
+      expect(Array.isArray(res.body.events)).toBe(true);
     });
 
     it('returns 403 for VIEWER', async () => {

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -222,13 +222,18 @@ export async function createTask(boardId: string, userId: string, dto: CreateTas
   });
 
   if (dto.description) {
-    const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
+    const [author, ws] = await Promise.all([
+      prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } }),
+      prisma.workspace.findUniqueOrThrow({ where: { id: board.workspaceId }, select: { slug: true } }),
+    ]);
     await emitMentionNotifications(dto.description, {
       taskId: task.id,
       taskTitle: task.title,
       taskKey: task.issueKey,
       mentionedBy: author,
       context: 'task',
+      workspaceSlug: ws.slug,
+      boardSlug: board.prefix.toLowerCase(),
     }, userId);
   }
 
@@ -368,13 +373,18 @@ export async function updateTask(taskId: string, userId: string, dto: UpdateTask
   });
 
   if (dto.description !== undefined) {
-    const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
+    const [author, ws] = await Promise.all([
+      prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } }),
+      prisma.workspace.findUniqueOrThrow({ where: { id: current.board.workspaceId }, select: { slug: true } }),
+    ]);
     await emitMentionNotifications(dto.description, {
       taskId,
       taskTitle: updated.title,
       taskKey: updated.issueKey,
       mentionedBy: author,
       context: 'task',
+      workspaceSlug: ws.slug,
+      boardSlug: current.board.prefix.toLowerCase(),
     }, userId);
   }
 

--- a/frontend/src/components/CommentThread.tsx
+++ b/frontend/src/components/CommentThread.tsx
@@ -46,6 +46,7 @@ function commentCharCounterStyle(len: number, metaColor: string): React.CSSPrope
 interface Props {
   taskId: string;
   comments: Comment[];
+  commentsTotal?: number;
   onCommentsChanged: (comments: Comment[]) => void;
   members?: WorkspaceMember[];
 }

--- a/frontend/src/components/MentionTextarea.tsx
+++ b/frontend/src/components/MentionTextarea.tsx
@@ -8,7 +8,11 @@ interface Props {
   members: WorkspaceMember[];
   placeholder?: string;
   rows?: number;
+  maxLength?: number;
   style?: React.CSSProperties;
+  onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
+  onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
 }
 
 const MENTION_RE = /@\[([^\]]+)\]\([^)]+\)/g;
@@ -60,7 +64,7 @@ export function renderMentions(text: string): React.ReactNode[] {
   return parts;
 }
 
-export default function MentionTextarea({ value, onChange, members, placeholder, rows = 4, style }: Props) {
+export default function MentionTextarea({ value, onChange, members, placeholder, rows = 4, maxLength, style, onKeyDown, onFocus, onBlur }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
   const inputBg = isDark ? '#1C2236' : '#FAFAFA';
@@ -98,6 +102,7 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
     if (dropdownOpen && e.key === 'Escape') {
       setDropdownOpen(false);
     }
+    onKeyDown?.(e);
   }
 
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
@@ -192,8 +197,11 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
         value={displayValue}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+        onBlur={onBlur}
         placeholder={placeholder}
         rows={rows}
+        maxLength={maxLength}
         style={{
           width: '100%', resize: 'vertical',
           background: inputBg, border: `1px solid ${inputBorder}`,


### PR DESCRIPTION
## Summary
- Два вызова `emitMentionNotifications` в `tasks.service.ts` не передавали обязательные поля `workspaceSlug` и `boardSlug`, что ломало TypeScript-компиляцию в CI
- `createTask`: добавлен параллельный запрос к `workspace` по `board.workspaceId`
- `updateTask`: добавлен параллельный запрос к `workspace` по `current.board.workspaceId`

## Test plan
- [ ] `npm run typecheck` в backend — должен быть чистым (0 ошибок)
- [ ] CI backend typecheck — зелёный
- [ ] Создание задачи с @упоминанием в описании → уведомление доходит с корректной ссылкой
- [ ] Обновление задачи с @упоминанием → аналогично