### PR TITLE
feat: аккордеон в Мои задачи

### DIFF
--- a/backend/src/__tests__/comments.test.ts
+++ b/backend/src/__tests__/comments.test.ts
@@ -59,8 +59,8 @@ describe('Comments', () => {
       await api.post(`/api/tasks/${taskId}/comments`).set(auth(ownerToken)).send({ body: 'Comment 1' });
       const res = await api.get(`/api/tasks/${taskId}/comments`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body)).toBe(true);
-      expect(res.body.length).toBeGreaterThan(0);
+      expect(Array.isArray(res.body.comments)).toBe(true);
+      expect(res.body.comments.length).toBeGreaterThan(0);
     });
 
     it('VIEWER can read comments', async () => {

--- a/backend/src/__tests__/workspaces.test.ts
+++ b/backend/src/__tests__/workspaces.test.ts
@@ -125,7 +125,7 @@ describe('Workspaces', () => {
     it('returns workspace event history for OWNER', async () => {
       const res = await api.get(`/api/workspaces/${workspaceId}/history`).set(auth(ownerToken));
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body)).toBe(true);
+      expect(Array.isArray(res.body.events)).toBe(true);
     });
 
     it('returns 403 for VIEWER', async () => {

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -222,13 +222,18 @@ export async function createTask(boardId: string, userId: string, dto: CreateTas
   });
 
   if (dto.description) {
-    const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
+    const [author, ws] = await Promise.all([
+      prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } }),
+      prisma.workspace.findUniqueOrThrow({ where: { id: board.workspaceId }, select: { slug: true } }),
+    ]);
     await emitMentionNotifications(dto.description, {
       taskId: task.id,
       taskTitle: task.title,
       taskKey: task.issueKey,
       mentionedBy: author,
       context: 'task',
+      workspaceSlug: ws.slug,
+      boardSlug: board.prefix.toLowerCase(),
     }, userId);
   }
 
@@ -368,13 +373,18 @@ export async function updateTask(taskId: string, userId: string, dto: UpdateTask
   });
 
   if (dto.description !== undefined) {
-    const author = await prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } });
+    const [author, ws] = await Promise.all([
+      prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { id: true, name: true } }),
+      prisma.workspace.findUniqueOrThrow({ where: { id: current.board.workspaceId }, select: { slug: true } }),
+    ]);
     await emitMentionNotifications(dto.description, {
       taskId,
       taskTitle: updated.title,
       taskKey: updated.issueKey,
       mentionedBy: author,
       context: 'task',
+      workspaceSlug: ws.slug,
+      boardSlug: current.board.prefix.toLowerCase(),
     }, userId);
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https: data:; connect-src 'self';" />
     <title>FlowTask</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/src/__tests__/TaskAccordionPanel.test.tsx
+++ b/frontend/src/__tests__/TaskAccordionPanel.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import TaskAccordionPanel from '../components/TaskAccordionPanel';
+import type { MyTask } from '../api/tasks';
+
+const DARK = {
+  bg: '#03050F', rowBg: '#0F1320', border: '#1C2236', borderHover: '#4F6EF7',
+  text: '#E2E8F8', muted: '#8B949E', key: '#484F58',
+  chipBg: '#1C2236', chipText: '#8B949E',
+  chipActive: 'rgba(79,110,247,0.12)', chipActiveText: '#4F6EF7',
+  chipOverdue: 'rgba(239,68,68,0.12)', chipOverdueText: '#EF4444',
+  searchBg: '#0F1320', searchBorder: '#1C2236',
+  wsBg: '#0A0D1A', sectionBorder: '#1C2236',
+};
+
+function makeTask(overrides: Partial<MyTask> = {}): MyTask {
+  return {
+    id: 'cltest1234567890',
+    boardId: 'board1',
+    statusId: 'status1',
+    title: 'Тестовая задача',
+    description: 'Описание задачи',
+    priority: 'MEDIUM',
+    dueDate: '2099-12-31',
+    assigneeId: 'user1',
+    creatorId: 'user1',
+    orderIndex: 0,
+    issueKey: 'TEST-1',
+    issueNumber: 1,
+    depth: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    status: { id: 'status1', name: 'В работе', color: '#4F6EF7', category: 'IN_PROGRESS' },
+    assignee: { id: 'user1', name: 'Иван Иванов', avatar: undefined },
+    labels: [],
+    board: {
+      id: 'board1',
+      name: 'Тест доска',
+      prefix: 'TEST',
+      workspace: { id: 'ws1', name: 'Тест воркспейс', slug: 'test-ws' },
+    },
+    ...overrides,
+  } as MyTask;
+}
+
+const defaultProps = {
+  id: 'accordion-cltest1234567890',
+  colors: DARK,
+  isDark: true,
+  bp: 'desktop' as const,
+  now: new Date('2026-05-01'),
+  onOpenInBoard: vi.fn(),
+};
+
+describe('TaskAccordionPanel — отображение полей', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('показывает описание задачи', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask()} />);
+    expect(screen.getByText('Описание задачи')).toBeInTheDocument();
+  });
+
+  it('показывает плейсхолдер когда описание отсутствует', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ description: undefined })} />);
+    expect(screen.getByText('Описание не добавлено')).toBeInTheDocument();
+  });
+
+  it('показывает имя исполнителя', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask()} />);
+    expect(screen.getByText('Иван Иванов')).toBeInTheDocument();
+  });
+
+  it('показывает плейсхолдер когда исполнитель не назначен', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ assigneeId: undefined, assignee: undefined })} />);
+    expect(screen.getByText('Не назначен')).toBeInTheDocument();
+  });
+
+  it('показывает плейсхолдер когда дедлайн не задан', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ dueDate: undefined })} />);
+    expect(screen.getByText('Не указан')).toBeInTheDocument();
+  });
+
+  it('показывает плейсхолдер когда теги отсутствуют', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ labels: [] })} />);
+    expect(screen.getByText('Нет тегов')).toBeInTheDocument();
+  });
+
+  it('НЕ показывает статус на десктопе (он есть в строке списка)', () => {
+    render(<TaskAccordionPanel {...defaultProps} bp="desktop" task={makeTask()} />);
+    expect(screen.queryByText('В работе')).not.toBeInTheDocument();
+  });
+
+  it('показывает статус на мобильном', () => {
+    render(<TaskAccordionPanel {...defaultProps} bp="mobile" task={makeTask()} />);
+    expect(screen.getByText('В работе')).toBeInTheDocument();
+  });
+});
+
+describe('TaskAccordionPanel — просроченные задачи', () => {
+  it('показывает "Просрочено" когда дедлайн в прошлом', () => {
+    const pastDate = '2020-01-01';
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ dueDate: pastDate })} />);
+    expect(screen.getByText(/просрочено/i)).toBeInTheDocument();
+  });
+
+  it('НЕ показывает "Просрочено" для выполненных задач', () => {
+    const pastDate = '2020-01-01';
+    render(<TaskAccordionPanel
+      {...defaultProps}
+      task={makeTask({
+        dueDate: pastDate,
+        status: { id: 's1', name: 'Готово', color: '#22C55E', category: 'DONE' },
+      })}
+    />);
+    expect(screen.queryByText(/просрочено/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('TaskAccordionPanel — длинное описание', () => {
+  const longDescription = 'А'.repeat(600);
+
+  it('обрезает описание длиннее 500 символов', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ description: longDescription })} />);
+    expect(screen.getByText(/\.\.\.$/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Читать далее' })).toBeInTheDocument();
+  });
+
+  it('раскрывает полный текст по клику на "Читать далее"', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ description: longDescription })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Читать далее' }));
+    expect(screen.queryByText(/\.\.\.$/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Свернуть' })).toBeInTheDocument();
+  });
+
+  it('кнопка "Читать далее" имеет aria-expanded=false изначально', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ description: longDescription })} />);
+    expect(screen.getByRole('button', { name: 'Читать далее' })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('кнопка "Свернуть" имеет aria-expanded=true после раскрытия', () => {
+    render(<TaskAccordionPanel {...defaultProps} task={makeTask({ description: longDescription })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Читать далее' }));
+    expect(screen.getByRole('button', { name: 'Свернуть' })).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+describe('TaskAccordionPanel — кнопка "Открыть"', () => {
+  it('вызывает onOpenInBoard с задачей при клике', () => {
+    const onOpen = vi.fn();
+    const task = makeTask();
+    render(<TaskAccordionPanel {...defaultProps} task={task} onOpenInBoard={onOpen} />);
+    fireEvent.click(screen.getByRole('button', { name: /открыть/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onOpen).toHaveBeenCalledWith(task);
+  });
+});
+
+describe('TaskAccordionPanel — безопасность avatar', () => {
+  it('рендерит img для https avatar URL', () => {
+    const task = makeTask({ assignee: { id: 'u1', name: 'Test', avatar: 'https://cdn.example.com/avatar.jpg' } });
+    const { container } = render(<TaskAccordionPanel {...defaultProps} task={task} />);
+    // alt="" → role="presentation"; проверяем через DOM напрямую
+    expect(container.querySelector('img[src="https://cdn.example.com/avatar.jpg"]')).toBeInTheDocument();
+  });
+
+  it('НЕ рендерит img для javascript: URL — показывает инициалы', () => {
+    const task = makeTask({ assignee: { id: 'u1', name: 'Test', avatar: 'javascript:alert(1)' } });
+    const { container } = render(<TaskAccordionPanel {...defaultProps} task={task} />);
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
+
+  it('НЕ рендерит img для data: URL — показывает инициалы', () => {
+    const task = makeTask({ assignee: { id: 'u1', name: 'Test', avatar: 'data:text/html,<script>alert(1)</script>' } });
+    const { container } = render(<TaskAccordionPanel {...defaultProps} task={task} />);
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+  });
+});
+
+describe('TaskAccordionPanel — стоп-пропагация кликов', () => {
+  it('клик внутри панели не всплывает наружу', () => {
+    const outerClick = vi.fn();
+    render(
+      <div onClick={outerClick}>
+        <TaskAccordionPanel {...defaultProps} task={makeTask()} />
+      </div>,
+    );
+    fireEvent.click(screen.getByText('Описание задачи'));
+    expect(outerClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/TaskAccordionPanel.test.tsx
+++ b/frontend/src/__tests__/TaskAccordionPanel.test.tsx
@@ -175,6 +175,13 @@ describe('TaskAccordionPanel — безопасность avatar', () => {
     const { container } = render(<TaskAccordionPanel {...defaultProps} task={task} />);
     expect(container.querySelector('img')).not.toBeInTheDocument();
   });
+
+  it('НЕ рендерит img для http: URL (только https разрешён)', () => {
+    const task = makeTask({ assignee: { id: 'u1', name: 'Test', avatar: 'http://cdn.example.com/avatar.jpg' } });
+    const { container } = render(<TaskAccordionPanel {...defaultProps} task={task} />);
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
 });
 
 describe('TaskAccordionPanel — стоп-пропагация кликов', () => {

--- a/frontend/src/components/CommentThread.tsx
+++ b/frontend/src/components/CommentThread.tsx
@@ -46,6 +46,7 @@ function commentCharCounterStyle(len: number, metaColor: string): React.CSSPrope
 interface Props {
   taskId: string;
   comments: Comment[];
+  commentsTotal?: number;
   onCommentsChanged: (comments: Comment[]) => void;
   members?: WorkspaceMember[];
 }

--- a/frontend/src/components/MentionTextarea.tsx
+++ b/frontend/src/components/MentionTextarea.tsx
@@ -8,7 +8,11 @@ interface Props {
   members: WorkspaceMember[];
   placeholder?: string;
   rows?: number;
+  maxLength?: number;
   style?: React.CSSProperties;
+  onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
+  onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
 }
 
 const MENTION_RE = /@\[([^\]]+)\]\([^)]+\)/g;
@@ -60,7 +64,7 @@ export function renderMentions(text: string): React.ReactNode[] {
   return parts;
 }
 
-export default function MentionTextarea({ value, onChange, members, placeholder, rows = 4, style }: Props) {
+export default function MentionTextarea({ value, onChange, members, placeholder, rows = 4, maxLength, style, onKeyDown, onFocus, onBlur }: Props) {
   const mode = useThemeStore(s => s.mode);
   const isDark = mode === 'dark';
   const inputBg = isDark ? '#1C2236' : '#FAFAFA';
@@ -98,6 +102,7 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
     if (dropdownOpen && e.key === 'Escape') {
       setDropdownOpen(false);
     }
+    onKeyDown?.(e);
   }
 
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
@@ -192,8 +197,11 @@ export default function MentionTextarea({ value, onChange, members, placeholder,
         value={displayValue}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+        onBlur={onBlur}
         placeholder={placeholder}
         rows={rows}
+        maxLength={maxLength}
         style={{
           width: '100%', resize: 'vertical',
           background: inputBg, border: `1px solid ${inputBorder}`,

--- a/frontend/src/components/TaskAccordionPanel.css
+++ b/frontend/src/components/TaskAccordionPanel.css
@@ -1,0 +1,8 @@
+@keyframes accordionFadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.accordion-panel {
+  animation: accordionFadeIn 0.15s ease;
+}

--- a/frontend/src/components/TaskAccordionPanel.tsx
+++ b/frontend/src/components/TaskAccordionPanel.tsx
@@ -1,60 +1,79 @@
 import { useState } from 'react';
+import type { CSSProperties } from 'react';
 import type { MyTask } from '../api/tasks';
+
+function isSafeAvatarUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'https:' || protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
 
 const DESCRIPTION_PREVIEW_LIMIT = 500;
 
 interface TaskAccordionPanelProps {
+  id: string;
   task: MyTask;
   colors: Record<string, string>;
   isDark: boolean;
-  onOpenInBoard: () => void;
+  now: Date;
+  onOpenInBoard: (task: MyTask) => void;
 }
 
-export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBoard }: TaskAccordionPanelProps) {
+export default function TaskAccordionPanel({ id, task, colors: c, isDark, now, onOpenInBoard }: TaskAccordionPanelProps) {
   const [descExpanded, setDescExpanded] = useState(false);
 
-  const description = task.description ?? null;
-  const isDescLong = description !== null && description.length > DESCRIPTION_PREVIEW_LIMIT;
+  const description = task.description ?? undefined;
+  const isDescLong = description !== undefined && description.length > DESCRIPTION_PREVIEW_LIMIT;
   const displayedDesc = isDescLong && !descExpanded
     ? description.slice(0, DESCRIPTION_PREVIEW_LIMIT) + '...'
     : description;
 
   const due = task.dueDate ? new Date(task.dueDate) : null;
   const isDone = task.status?.category === 'DONE';
-  const isOverdue = due !== null && due < new Date() && !isDone;
+  const isOverdue = due !== null && due < now && !isDone;
 
-  const labelStyle: React.CSSProperties = {
+  const labelStyle: CSSProperties = {
     fontSize: 10, fontWeight: 600, color: c.muted,
     textTransform: 'uppercase', letterSpacing: '0.08em',
     fontFamily: '"Inter",system-ui,sans-serif',
     marginBottom: 4,
   };
 
-  const valueStyle: React.CSSProperties = {
+  const valueStyle: CSSProperties = {
     fontSize: 12, color: c.text,
     fontFamily: '"Inter",system-ui,sans-serif',
   };
 
-  const mutedValueStyle: React.CSSProperties = {
+  const mutedValueStyle: CSSProperties = {
     ...valueStyle, color: c.muted, fontStyle: 'italic',
   };
 
+  // Slightly elevated surface relative to the row background
+  const panelBg = isDark ? '#0D1025' : 'rgba(79,110,247,0.03)';
+
   return (
     <div
+      id={id}
       onClick={(e) => e.stopPropagation()}
       style={{
         padding: '14px 16px 14px 38px',
-        background: isDark ? '#080B18' : '#F0EEF8',
+        background: panelBg,
         borderTop: `1px solid ${c.border}`,
         display: 'grid',
         gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
         gap: '14px 24px',
+        animation: 'accordionFadeIn 0.15s ease',
       }}
     >
+      <style>{`@keyframes accordionFadeIn{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:translateY(0)}}`}</style>
+
       {/* Description — full width */}
       <div style={{ gridColumn: '1 / -1' }}>
         <div style={labelStyle}>Описание</div>
-        {description === null ? (
+        {description === undefined ? (
           <span style={mutedValueStyle}>Описание не добавлено</span>
         ) : (
           <>
@@ -63,6 +82,7 @@ export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBo
             </p>
             {isDescLong && (
               <button
+                aria-expanded={descExpanded}
                 onClick={() => setDescExpanded((v) => !v)}
                 style={{
                   marginTop: 4, fontSize: 11, color: '#4F6EF7',
@@ -78,7 +98,53 @@ export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBo
         )}
       </div>
 
-      {/* Status */}
+      {/* Deadline */}
+      <div>
+        <div style={labelStyle}>Дедлайн</div>
+        {due ? (
+          <span style={{ ...valueStyle, color: isOverdue ? '#EF4444' : c.text }}>
+            {isOverdue ? 'Просрочено, ' : ''}
+            {due.toLocaleDateString('ru-RU', { day: 'numeric', month: 'long', year: 'numeric' })}
+          </span>
+        ) : (
+          <span style={mutedValueStyle}>Не указан</span>
+        )}
+      </div>
+
+      {/* Assignee */}
+      <div>
+        <div style={labelStyle}>Исполнитель</div>
+        {task.assignee ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            {task.assignee.avatar && isSafeAvatarUrl(task.assignee.avatar) ? (
+              <img
+                src={task.assignee.avatar}
+                alt=""
+                aria-hidden="true"
+                style={{ width: 18, height: 18, borderRadius: '50%', flexShrink: 0 }}
+              />
+            ) : (
+              <div
+                aria-hidden="true"
+                style={{
+                  width: 18, height: 18, borderRadius: '50%', flexShrink: 0,
+                  background: '#4F6EF7',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}
+              >
+                <span style={{ color: '#fff', fontSize: 9, fontWeight: 700 }}>
+                  {task.assignee.name[0]?.toUpperCase()}
+                </span>
+              </div>
+            )}
+            <span style={valueStyle}>{task.assignee.name}</span>
+          </div>
+        ) : (
+          <span style={mutedValueStyle}>Не назначен</span>
+        )}
+      </div>
+
+      {/* Status — shown here for mobile where row header hides it */}
       <div>
         <div style={labelStyle}>Статус</div>
         {task.status ? (
@@ -96,48 +162,6 @@ export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBo
         )}
       </div>
 
-      {/* Deadline */}
-      <div>
-        <div style={labelStyle}>Дедлайн</div>
-        {due ? (
-          <span style={{ ...valueStyle, color: isOverdue ? '#EF4444' : c.text }}>
-            {isOverdue && 'Просрочено · '}
-            {due.toLocaleDateString('ru-RU', { day: 'numeric', month: 'long', year: 'numeric' })}
-          </span>
-        ) : (
-          <span style={mutedValueStyle}>Не задан</span>
-        )}
-      </div>
-
-      {/* Assignee */}
-      <div>
-        <div style={labelStyle}>Исполнитель</div>
-        {task.assignee ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            {task.assignee.avatar ? (
-              <img
-                src={task.assignee.avatar}
-                alt={task.assignee.name}
-                style={{ width: 18, height: 18, borderRadius: '50%', flexShrink: 0 }}
-              />
-            ) : (
-              <div style={{
-                width: 18, height: 18, borderRadius: '50%', flexShrink: 0,
-                background: '#4F6EF7',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-              }}>
-                <span style={{ color: '#fff', fontSize: 9, fontWeight: 700 }}>
-                  {task.assignee.name[0]?.toUpperCase()}
-                </span>
-              </div>
-            )}
-            <span style={valueStyle}>{task.assignee.name}</span>
-          </div>
-        ) : (
-          <span style={mutedValueStyle}>Не назначен</span>
-        )}
-      </div>
-
       {/* Labels */}
       <div>
         <div style={labelStyle}>Теги</div>
@@ -147,7 +171,7 @@ export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBo
               <span
                 key={label.id}
                 style={{
-                  fontSize: 10, fontWeight: 500,
+                  fontSize: 11, fontWeight: 500,
                   color: label.color,
                   background: `${label.color}18`,
                   borderRadius: 4, padding: '2px 6px',
@@ -163,15 +187,15 @@ export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBo
         )}
       </div>
 
-      {/* Open button — aligned to the right */}
+      {/* Open button */}
       <div style={{ gridColumn: '1 / -1', display: 'flex', justifyContent: 'flex-end' }}>
         <button
-          onClick={onOpenInBoard}
+          onClick={() => onOpenInBoard(task)}
           style={{
             fontSize: 12, fontWeight: 500,
             color: '#4F6EF7',
             background: 'transparent',
-            border: '1px solid #4F6EF744',
+            border: '1px solid #4F6EF788',
             borderRadius: 7, padding: '5px 14px',
             cursor: 'pointer', transition: 'background 0.12s',
             fontFamily: '"Inter",system-ui,sans-serif',
@@ -181,7 +205,7 @@ export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBo
           onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
         >
           Открыть
-          <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
+          <svg aria-hidden="true" width="11" height="11" viewBox="0 0 11 11" fill="none">
             <path d="M2 9L9 2M9 2H4M9 2V7" stroke="#4F6EF7" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
         </button>

--- a/frontend/src/components/TaskAccordionPanel.tsx
+++ b/frontend/src/components/TaskAccordionPanel.tsx
@@ -1,6 +1,11 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { CSSProperties } from 'react';
 import type { MyTask } from '../api/tasks';
+import type { Breakpoint } from '../utils/useBreakpoint';
+import './TaskAccordionPanel.css';
+
+const DESCRIPTION_PREVIEW_LIMIT = 500;
+const HEX_COLOR_RE = /^#[0-9a-f]{3,8}$/i;
 
 function isSafeAvatarUrl(url: string): boolean {
   try {
@@ -11,18 +16,21 @@ function isSafeAvatarUrl(url: string): boolean {
   }
 }
 
-const DESCRIPTION_PREVIEW_LIMIT = 500;
+function safeColor(color: string, fallback: string): string {
+  return HEX_COLOR_RE.test(color) ? color : fallback;
+}
 
 interface TaskAccordionPanelProps {
   id: string;
   task: MyTask;
   colors: Record<string, string>;
   isDark: boolean;
+  bp: Breakpoint;
   now: Date;
   onOpenInBoard: (task: MyTask) => void;
 }
 
-export default function TaskAccordionPanel({ id, task, colors: c, isDark, now, onOpenInBoard }: TaskAccordionPanelProps) {
+export default function TaskAccordionPanel({ id, task, colors: c, isDark, bp, now, onOpenInBoard }: TaskAccordionPanelProps) {
   const [descExpanded, setDescExpanded] = useState(false);
 
   const description = task.description ?? undefined;
@@ -35,28 +43,29 @@ export default function TaskAccordionPanel({ id, task, colors: c, isDark, now, o
   const isDone = task.status?.category === 'DONE';
   const isOverdue = due !== null && due < now && !isDone;
 
-  const labelStyle: CSSProperties = {
+  const panelBg = isDark ? '#0D1025' : 'rgba(79,110,247,0.03)';
+
+  const labelStyle = useMemo<CSSProperties>(() => ({
     fontSize: 10, fontWeight: 600, color: c.muted,
     textTransform: 'uppercase', letterSpacing: '0.08em',
     fontFamily: '"Inter",system-ui,sans-serif',
     marginBottom: 4,
-  };
+  }), [c.muted]);
 
-  const valueStyle: CSSProperties = {
+  const valueStyle = useMemo<CSSProperties>(() => ({
     fontSize: 12, color: c.text,
     fontFamily: '"Inter",system-ui,sans-serif',
-  };
+  }), [c.text]);
 
-  const mutedValueStyle: CSSProperties = {
-    ...valueStyle, color: c.muted, fontStyle: 'italic',
-  };
-
-  // Slightly elevated surface relative to the row background
-  const panelBg = isDark ? '#0D1025' : 'rgba(79,110,247,0.03)';
+  const mutedValueStyle = useMemo<CSSProperties>(() => ({
+    fontSize: 12, color: c.muted, fontStyle: 'italic',
+    fontFamily: '"Inter",system-ui,sans-serif',
+  }), [c.muted]);
 
   return (
     <div
       id={id}
+      className="accordion-panel"
       onClick={(e) => e.stopPropagation()}
       style={{
         padding: '14px 16px 14px 38px',
@@ -65,11 +74,8 @@ export default function TaskAccordionPanel({ id, task, colors: c, isDark, now, o
         display: 'grid',
         gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
         gap: '14px 24px',
-        animation: 'accordionFadeIn 0.15s ease',
       }}
     >
-      <style>{`@keyframes accordionFadeIn{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:translateY(0)}}`}</style>
-
       {/* Description — full width */}
       <div style={{ gridColumn: '1 / -1' }}>
         <div style={labelStyle}>Описание</div>
@@ -144,43 +150,48 @@ export default function TaskAccordionPanel({ id, task, colors: c, isDark, now, o
         )}
       </div>
 
-      {/* Status — shown here for mobile where row header hides it */}
-      <div>
-        <div style={labelStyle}>Статус</div>
-        {task.status ? (
-          <span style={{
-            fontSize: 11, fontWeight: 500,
-            color: task.status.color,
-            background: `${task.status.color}18`,
-            borderRadius: 5, padding: '2px 7px',
-            fontFamily: '"Inter",system-ui,sans-serif',
-          }}>
-            {task.status.name}
-          </span>
-        ) : (
-          <span style={mutedValueStyle}>Не задан</span>
-        )}
-      </div>
+      {/* Status — only on mobile; desktop row header already shows it */}
+      {bp === 'mobile' && (
+        <div>
+          <div style={labelStyle}>Статус</div>
+          {task.status ? (
+            <span style={{
+              fontSize: 11, fontWeight: 500,
+              color: safeColor(task.status.color, c.muted),
+              background: `${safeColor(task.status.color, c.border)}18`,
+              borderRadius: 5, padding: '2px 7px',
+              fontFamily: '"Inter",system-ui,sans-serif',
+            }}>
+              {task.status.name}
+            </span>
+          ) : (
+            <span style={mutedValueStyle}>Не задан</span>
+          )}
+        </div>
+      )}
 
       {/* Labels */}
       <div>
         <div style={labelStyle}>Теги</div>
         {task.labels && task.labels.length > 0 ? (
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-            {task.labels.map(({ label }) => (
-              <span
-                key={label.id}
-                style={{
-                  fontSize: 11, fontWeight: 500,
-                  color: label.color,
-                  background: `${label.color}18`,
-                  borderRadius: 4, padding: '2px 6px',
-                  fontFamily: '"Inter",system-ui,sans-serif',
-                }}
-              >
-                {label.name}
-              </span>
-            ))}
+            {task.labels.map(({ label }) => {
+              const color = safeColor(label.color, c.muted);
+              return (
+                <span
+                  key={label.id}
+                  style={{
+                    fontSize: 11, fontWeight: 500,
+                    color,
+                    background: `${color}18`,
+                    borderRadius: 4, padding: '2px 6px',
+                    fontFamily: '"Inter",system-ui,sans-serif',
+                  }}
+                >
+                  {label.name}
+                </span>
+              );
+            })}
           </div>
         ) : (
           <span style={mutedValueStyle}>Нет тегов</span>

--- a/frontend/src/components/TaskAccordionPanel.tsx
+++ b/frontend/src/components/TaskAccordionPanel.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import type { MyTask } from '../api/tasks';
+
+const DESCRIPTION_PREVIEW_LIMIT = 500;
+
+interface TaskAccordionPanelProps {
+  task: MyTask;
+  colors: Record<string, string>;
+  isDark: boolean;
+  onOpenInBoard: () => void;
+}
+
+export default function TaskAccordionPanel({ task, colors: c, isDark, onOpenInBoard }: TaskAccordionPanelProps) {
+  const [descExpanded, setDescExpanded] = useState(false);
+
+  const description = task.description ?? null;
+  const isDescLong = description !== null && description.length > DESCRIPTION_PREVIEW_LIMIT;
+  const displayedDesc = isDescLong && !descExpanded
+    ? description.slice(0, DESCRIPTION_PREVIEW_LIMIT) + '...'
+    : description;
+
+  const due = task.dueDate ? new Date(task.dueDate) : null;
+  const isDone = task.status?.category === 'DONE';
+  const isOverdue = due !== null && due < new Date() && !isDone;
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 10, fontWeight: 600, color: c.muted,
+    textTransform: 'uppercase', letterSpacing: '0.08em',
+    fontFamily: '"Inter",system-ui,sans-serif',
+    marginBottom: 4,
+  };
+
+  const valueStyle: React.CSSProperties = {
+    fontSize: 12, color: c.text,
+    fontFamily: '"Inter",system-ui,sans-serif',
+  };
+
+  const mutedValueStyle: React.CSSProperties = {
+    ...valueStyle, color: c.muted, fontStyle: 'italic',
+  };
+
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        padding: '14px 16px 14px 38px',
+        background: isDark ? '#080B18' : '#F0EEF8',
+        borderTop: `1px solid ${c.border}`,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+        gap: '14px 24px',
+      }}
+    >
+      {/* Description — full width */}
+      <div style={{ gridColumn: '1 / -1' }}>
+        <div style={labelStyle}>Описание</div>
+        {description === null ? (
+          <span style={mutedValueStyle}>Описание не добавлено</span>
+        ) : (
+          <>
+            <p style={{ ...valueStyle, margin: 0, whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>
+              {displayedDesc}
+            </p>
+            {isDescLong && (
+              <button
+                onClick={() => setDescExpanded((v) => !v)}
+                style={{
+                  marginTop: 4, fontSize: 11, color: '#4F6EF7',
+                  background: 'transparent', border: 'none',
+                  cursor: 'pointer', padding: 0,
+                  fontFamily: '"Inter",system-ui,sans-serif',
+                }}
+              >
+                {descExpanded ? 'Свернуть' : 'Читать далее'}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Status */}
+      <div>
+        <div style={labelStyle}>Статус</div>
+        {task.status ? (
+          <span style={{
+            fontSize: 11, fontWeight: 500,
+            color: task.status.color,
+            background: `${task.status.color}18`,
+            borderRadius: 5, padding: '2px 7px',
+            fontFamily: '"Inter",system-ui,sans-serif',
+          }}>
+            {task.status.name}
+          </span>
+        ) : (
+          <span style={mutedValueStyle}>Не задан</span>
+        )}
+      </div>
+
+      {/* Deadline */}
+      <div>
+        <div style={labelStyle}>Дедлайн</div>
+        {due ? (
+          <span style={{ ...valueStyle, color: isOverdue ? '#EF4444' : c.text }}>
+            {isOverdue && 'Просрочено · '}
+            {due.toLocaleDateString('ru-RU', { day: 'numeric', month: 'long', year: 'numeric' })}
+          </span>
+        ) : (
+          <span style={mutedValueStyle}>Не задан</span>
+        )}
+      </div>
+
+      {/* Assignee */}
+      <div>
+        <div style={labelStyle}>Исполнитель</div>
+        {task.assignee ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            {task.assignee.avatar ? (
+              <img
+                src={task.assignee.avatar}
+                alt={task.assignee.name}
+                style={{ width: 18, height: 18, borderRadius: '50%', flexShrink: 0 }}
+              />
+            ) : (
+              <div style={{
+                width: 18, height: 18, borderRadius: '50%', flexShrink: 0,
+                background: '#4F6EF7',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                <span style={{ color: '#fff', fontSize: 9, fontWeight: 700 }}>
+                  {task.assignee.name[0]?.toUpperCase()}
+                </span>
+              </div>
+            )}
+            <span style={valueStyle}>{task.assignee.name}</span>
+          </div>
+        ) : (
+          <span style={mutedValueStyle}>Не назначен</span>
+        )}
+      </div>
+
+      {/* Labels */}
+      <div>
+        <div style={labelStyle}>Теги</div>
+        {task.labels && task.labels.length > 0 ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            {task.labels.map(({ label }) => (
+              <span
+                key={label.id}
+                style={{
+                  fontSize: 10, fontWeight: 500,
+                  color: label.color,
+                  background: `${label.color}18`,
+                  borderRadius: 4, padding: '2px 6px',
+                  fontFamily: '"Inter",system-ui,sans-serif',
+                }}
+              >
+                {label.name}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span style={mutedValueStyle}>Нет тегов</span>
+        )}
+      </div>
+
+      {/* Open button — aligned to the right */}
+      <div style={{ gridColumn: '1 / -1', display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          onClick={onOpenInBoard}
+          style={{
+            fontSize: 12, fontWeight: 500,
+            color: '#4F6EF7',
+            background: 'transparent',
+            border: '1px solid #4F6EF744',
+            borderRadius: 7, padding: '5px 14px',
+            cursor: 'pointer', transition: 'background 0.12s',
+            fontFamily: '"Inter",system-ui,sans-serif',
+            display: 'flex', alignItems: 'center', gap: 5,
+          }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'rgba(79,110,247,0.08)'; }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+        >
+          Открыть
+          <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
+            <path d="M2 9L9 2M9 2H4M9 2V7" stroke="#4F6EF7" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskAccordionPanel.tsx
+++ b/frontend/src/components/TaskAccordionPanel.tsx
@@ -9,8 +9,7 @@ const HEX_COLOR_RE = /^#[0-9a-f]{3,8}$/i;
 
 function isSafeAvatarUrl(url: string): boolean {
   try {
-    const { protocol } = new URL(url);
-    return protocol === 'https:' || protocol === 'http:';
+    return new URL(url).protocol === 'https:';
   } catch {
     return false;
   }

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -187,21 +187,24 @@ export default function BoardPage() {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const fromMyTasks = searchParams.get('from') === 'my-tasks';
-  const myTasksOpenId = searchParams.get('open');
+  // Validate task ID format before round-tripping in back-navigation URL
+  const TASK_ID_RE = /^[a-z0-9_-]{10,40}$/i;
+  const rawMyTasksOpen = searchParams.get('open');
+  const myTasksOpenId = rawMyTasksOpen && TASK_ID_RE.test(rawMyTasksOpen) ? rawMyTasksOpen : null;
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const v = searchParams.get('view');
     return (v === 'roadmap' || v === 'list' || v === 'calendar') ? v : 'board';
   });
 
-  // Auto-open drawer when navigated from a notification (via router state)
+  // Auto-open drawer when navigated from accordion "Открыть" or notification
   useEffect(() => {
     const state = location.state as { openTaskId?: string } | null;
     if (state?.openTaskId) {
       setSelectedTaskId(state.openTaskId);
-      // Clear state so back navigation doesn't re-trigger
-      window.history.replaceState({}, '', location.pathname + location.search);
+      // Use React Router navigate to clear state so back-navigation doesn't re-trigger
+      navigate(location.pathname + location.search, { replace: true, state: null });
     }
-  }, [location.state, location.pathname, location.search]);
+  }, [location.state]); // eslint-disable-line react-hooks/exhaustive-deps
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [labels, setLabels] = useState<Label[]>([]);

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -186,6 +186,8 @@ export default function BoardPage() {
   const [addTitle, setAddTitle] = useState('');
   const [searchParams] = useSearchParams();
   const location = useLocation();
+  const fromMyTasks = searchParams.get('from') === 'my-tasks';
+  const myTasksOpenId = searchParams.get('open');
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const v = searchParams.get('view');
     return (v === 'roadmap' || v === 'list' || v === 'calendar') ? v : 'board';
@@ -579,12 +581,20 @@ export default function BoardPage() {
       }}>
         {/* Back */}
         <button
-          onClick={() => navigate(-1)}
-          style={{ background: 'transparent', border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', color: addText, flexShrink: 0 }}
+          onClick={() => fromMyTasks
+            ? navigate(`/my-tasks${myTasksOpenId ? `?open=${myTasksOpenId}` : ''}`)
+            : navigate(-1)
+          }
+          style={{ background: 'transparent', border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', gap: 4, color: addText, flexShrink: 0 }}
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             <path d="M10 3L5 8L10 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
+          {fromMyTasks && (
+            <span style={{ fontSize: 12, fontFamily: '"Inter",system-ui,sans-serif', color: addText }}>
+              Мои задачи
+            </span>
+          )}
         </button>
 
         {/* Board name + task count */}

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -24,6 +24,8 @@ import FilterBar from '../components/FilterBar';
 import BulkActionBar from '../components/BulkActionBar';
 
 type ViewMode = 'board' | 'list' | 'calendar' | 'roadmap';
+
+const TASK_ID_RE = /^[a-z0-9_-]{10,40}$/i;
 type Columns = Record<string, Task[]>;
 
 function groupByStatus(tasks: Task[], statuses: WorkflowStatus[]): Columns {
@@ -187,8 +189,6 @@ export default function BoardPage() {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const fromMyTasks = searchParams.get('from') === 'my-tasks';
-  // Validate task ID format before round-tripping in back-navigation URL
-  const TASK_ID_RE = /^[a-z0-9_-]{10,40}$/i;
   const rawMyTasksOpen = searchParams.get('open');
   const myTasksOpenId = rawMyTasksOpen && TASK_ID_RE.test(rawMyTasksOpen) ? rawMyTasksOpen : null;
   const [viewMode, setViewMode] = useState<ViewMode>(() => {

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -48,7 +48,7 @@ function wsColor(name: string): string {
 // ── Component ──────────────────────────────────────────────────────────────────
 export default function MyTasksPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const mode = useThemeStore((s) => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
   const bp = useBreakpoint();
@@ -63,7 +63,12 @@ export default function MyTasksPage() {
   const offsetRef = useRef(0);
 
   // Accordion state — one open at a time; restored from ?open= URL param on mount
-  const [openAccordionId, setOpenAccordionId] = useState<string | null>(() => searchParams.get('open'));
+  // Validated against task-ID format to prevent param injection
+  const TASK_ID_RE = /^[a-z0-9_-]{10,40}$/i;
+  const rawOpen = searchParams.get('open');
+  const [openAccordionId, setOpenAccordionId] = useState<string | null>(
+    () => rawOpen && TASK_ID_RE.test(rawOpen) ? rawOpen : null,
+  );
 
   const fetchTasks = useCallback(async (preset: DuePreset, q: string, replace: boolean) => {
     const offset = replace ? 0 : offsetRef.current;
@@ -91,9 +96,16 @@ export default function MyTasksPage() {
     return () => clearTimeout(timer);
   }, [duePreset, search, fetchTasks]);
 
+  // Capture "now" once per render cycle to avoid per-task Date allocation and clock drift
+  const now = useMemo(() => new Date(), []);
+
   const toggleAccordion = useCallback((taskId: string) => {
-    setOpenAccordionId((prev) => (prev === taskId ? null : taskId));
-  }, []);
+    setOpenAccordionId((prev) => {
+      const next = prev === taskId ? null : taskId;
+      setSearchParams(next ? { open: next } : {}, { replace: true });
+      return next;
+    });
+  }, [setSearchParams]);
 
   const openInBoard = useCallback((task: MyTask) => {
     navigate(
@@ -326,7 +338,7 @@ export default function MyTasksPage() {
                       {board.tasks.map((task, idx) => {
                         const isDone = task.status?.category === 'DONE';
                         const due = task.dueDate ? new Date(task.dueDate) : null;
-                        const isOverdue = due && due < new Date() && !isDone;
+                        const isOverdue = due !== null && due < now && !isDone;
                         const prio = task.priority ? PRIO[task.priority] : null;
                         const statusColor = task.status?.color ?? '#484F58';
                         const isOpen = openAccordionId === task.id;
@@ -335,7 +347,17 @@ export default function MyTasksPage() {
                           <div key={task.id}>
                             {/* Task row */}
                             <div
+                              role="button"
+                              tabIndex={0}
+                              aria-expanded={isOpen}
+                              aria-controls={`accordion-${task.id}`}
                               onClick={() => toggleAccordion(task.id)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  toggleAccordion(task.id);
+                                }
+                              }}
                               style={{
                                 display: 'flex', alignItems: 'center', gap: bp === 'mobile' ? 8 : 12,
                                 padding: bp === 'mobile' ? '10px 12px' : '11px 16px',
@@ -447,10 +469,12 @@ export default function MyTasksPage() {
                             {/* Accordion panel */}
                             {isOpen && (
                               <TaskAccordionPanel
+                                id={`accordion-${task.id}`}
                                 task={task}
                                 colors={c}
                                 isDark={mode === 'dark'}
-                                onOpenInBoard={() => openInBoard(task)}
+                                now={now}
+                                onOpenInBoard={openInBoard}
                               />
                             )}
                           </div>

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -39,6 +39,9 @@ const PRIO: Record<string, { bg: string; text: string }> = {
 // ── Due preset helpers ─────────────────────────────────────────────────────────
 type DuePreset = '' | 'today' | 'this_week' | 'overdue' | 'no_date';
 
+// Task IDs are cuid/cuid2 — validated before trusting URL params
+const TASK_ID_RE = /^[a-z0-9_-]{10,40}$/i;
+
 // ── Workspace icon colors ──────────────────────────────────────────────────────
 const WS_COLORS = ['#22C55E', '#4F6EF7', '#8B5CF6', '#F59E0B', '#EC4899', '#0EA5E9'];
 function wsColor(name: string): string {
@@ -63,12 +66,13 @@ export default function MyTasksPage() {
   const offsetRef = useRef(0);
 
   // Accordion state — one open at a time; restored from ?open= URL param on mount
-  // Validated against task-ID format to prevent param injection
-  const TASK_ID_RE = /^[a-z0-9_-]{10,40}$/i;
   const rawOpen = searchParams.get('open');
   const [openAccordionId, setOpenAccordionId] = useState<string | null>(
     () => rawOpen && TASK_ID_RE.test(rawOpen) ? rawOpen : null,
   );
+
+  // Ref map for scroll-to-open after tasks load
+  const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const fetchTasks = useCallback(async (preset: DuePreset, q: string, replace: boolean) => {
     const offset = replace ? 0 : offsetRef.current;
@@ -94,7 +98,15 @@ export default function MyTasksPage() {
     offsetRef.current = 0;
     const timer = setTimeout(() => { fetchTasks(duePreset, search, true); }, search ? 300 : 0);
     return () => clearTimeout(timer);
-  }, [duePreset, search, fetchTasks]);
+  }, [duePreset, search]); // fetchTasks is stable (empty useCallback deps)
+
+  // Scroll to restored accordion after tasks load
+  useEffect(() => {
+    if (!loading && openAccordionId) {
+      const el = rowRefs.current.get(openAccordionId);
+      el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [loading, openAccordionId]);
 
   // Capture "now" once per render cycle to avoid per-task Date allocation and clock drift
   const now = useMemo(() => new Date(), []);
@@ -344,7 +356,7 @@ export default function MyTasksPage() {
                         const isOpen = openAccordionId === task.id;
 
                         return (
-                          <div key={task.id}>
+                          <div key={task.id} ref={(el) => { if (el) rowRefs.current.set(task.id, el); else rowRefs.current.delete(task.id); }}>
                             {/* Task row */}
                             <div
                               role="button"
@@ -386,19 +398,6 @@ export default function MyTasksPage() {
                                 }
                               }}
                             >
-                              {/* Chevron */}
-                              <svg
-                                width="12" height="12" viewBox="0 0 12 12" fill="none"
-                                style={{
-                                  flexShrink: 0,
-                                  transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)',
-                                  transition: 'transform 0.15s',
-                                  color: isOpen ? '#4F6EF7' : c.muted,
-                                }}
-                              >
-                                <path d="M4 2.5L7.5 6L4 9.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
-                              </svg>
-
                               {/* Status circle */}
                               <div style={{
                                 width: 18, height: 18, borderRadius: '50%', flexShrink: 0,
@@ -463,6 +462,20 @@ export default function MyTasksPage() {
                                     {due.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })}
                                   </span>
                                 )}
+
+                                {/* Chevron — far right, standard accordion position */}
+                                <svg
+                                  aria-hidden="true"
+                                  width="12" height="12" viewBox="0 0 12 12" fill="none"
+                                  style={{
+                                    flexShrink: 0, marginLeft: 4,
+                                    transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+                                    transition: 'transform 0.15s',
+                                    color: isOpen ? '#4F6EF7' : c.muted,
+                                  }}
+                                >
+                                  <path d="M4 2.5L7.5 6L4 9.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+                                </svg>
                               </div>
                             </div>
 
@@ -473,6 +486,7 @@ export default function MyTasksPage() {
                                 task={task}
                                 colors={c}
                                 isDark={mode === 'dark'}
+                                bp={bp}
                                 now={now}
                                 onOpenInBoard={openInBoard}
                               />

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -1,23 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { message } from 'antd';
 import { useThemeStore } from '../store/theme.store';
 import { useWorkspaceStore } from '../store/workspace.store';
 import { useBreakpoint } from '../utils/useBreakpoint';
 import * as tasksApi from '../api/tasks';
-import * as boardsApi from '../api/boards';
-import * as workspacesApi from '../api/workspaces';
-import * as labelsApi from '../api/labels';
 import type { MyTask } from '../api/tasks';
-import type { WorkflowStatus, WorkspaceMember, Label } from '../types';
-import TaskDrawer from '../components/TaskDrawer';
-
-interface BoardContext {
-  statuses: WorkflowStatus[];
-  members: WorkspaceMember[];
-  labels: Label[];
-  workspaceId: string;
-}
+import TaskAccordionPanel from '../components/TaskAccordionPanel';
 
 // ── Design tokens ──────────────────────────────────────────────────────────────
 type C = Record<string, string>;
@@ -59,6 +48,7 @@ function wsColor(name: string): string {
 // ── Component ──────────────────────────────────────────────────────────────────
 export default function MyTasksPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const mode = useThemeStore((s) => s.mode);
   const c = mode === 'light' ? LIGHT : DARK;
   const bp = useBreakpoint();
@@ -72,13 +62,8 @@ export default function MyTasksPage() {
   const [search, setSearch] = useState('');
   const offsetRef = useRef(0);
 
-  // Drawer state
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [drawerCtx, setDrawerCtx] = useState<BoardContext | null>(null);
-  const [drawerBoardId, setDrawerBoardId] = useState<string | null>(null);
-  const boardCtxCache = useRef<Map<string, BoardContext>>(new Map());
-  // Tracks the boardId of the in-flight fetch; used to discard stale responses on rapid clicks
-  const fetchingBoardIdRef = useRef<string | null>(null);
+  // Accordion state — one open at a time; restored from ?open= URL param on mount
+  const [openAccordionId, setOpenAccordionId] = useState<string | null>(() => searchParams.get('open'));
 
   const fetchTasks = useCallback(async (preset: DuePreset, q: string, replace: boolean) => {
     const offset = replace ? 0 : offsetRef.current;
@@ -106,47 +91,17 @@ export default function MyTasksPage() {
     return () => clearTimeout(timer);
   }, [duePreset, search, fetchTasks]);
 
-  const openDrawer = useCallback(async (task: MyTask) => {
-    const { id: boardId, workspace } = task.board;
-
-    const cached = boardCtxCache.current.get(boardId);
-    if (cached) {
-      setDrawerCtx(cached);
-      setDrawerBoardId(boardId);
-      setSelectedTaskId(task.id);
-      return;
-    }
-
-    // Mark this boardId as in-flight; any concurrent click will overwrite this ref
-    fetchingBoardIdRef.current = boardId;
-    try {
-      const [board, members, labels] = await Promise.all([
-        boardsApi.getBoard(boardId),
-        workspacesApi.listMembers(workspace.id),
-        labelsApi.listLabels(workspace.id),
-      ]);
-      // Discard result if another click started a newer fetch
-      if (fetchingBoardIdRef.current !== boardId) return;
-      const ctx: BoardContext = {
-        statuses: board.workflow.statuses,
-        members,
-        labels,
-        workspaceId: workspace.id,
-      };
-      boardCtxCache.current.set(boardId, ctx);
-      setDrawerCtx(ctx);
-      setDrawerBoardId(boardId);
-      setSelectedTaskId(task.id);
-    } catch {
-      if (fetchingBoardIdRef.current === boardId) {
-        message.error('Не удалось загрузить данные задачи');
-      }
-    } finally {
-      if (fetchingBoardIdRef.current === boardId) {
-        fetchingBoardIdRef.current = null;
-      }
-    }
+  const toggleAccordion = useCallback((taskId: string) => {
+    setOpenAccordionId((prev) => (prev === taskId ? null : taskId));
   }, []);
+
+  const openInBoard = useCallback((task: MyTask) => {
+    navigate(
+      `/w/${task.board.workspace.slug}/boards/${task.board.prefix.toLowerCase()}` +
+        `?from=my-tasks&open=${task.id}`,
+      { state: { openTaskId: task.id } },
+    );
+  }, [navigate]);
 
   // Group by workspace → board
   const grouped = useMemo(() => {
@@ -374,103 +329,130 @@ export default function MyTasksPage() {
                         const isOverdue = due && due < new Date() && !isDone;
                         const prio = task.priority ? PRIO[task.priority] : null;
                         const statusColor = task.status?.color ?? '#484F58';
+                        const isOpen = openAccordionId === task.id;
 
                         return (
-                          <div
-                            key={task.id}
-                            onClick={() => openDrawer(task)}
-                            style={{
-                              display: 'flex', alignItems: 'center', gap: bp === 'mobile' ? 8 : 12,
-                              padding: bp === 'mobile' ? '10px 12px' : '11px 16px',
-                              minWidth: 0,
-                              background: isOverdue
-                                ? (mode === 'light' ? 'rgba(239,68,68,0.04)' : 'rgba(239,68,68,0.05)')
-                                : c.rowBg,
-                              borderBottom: idx < board.tasks.length - 1
-                                ? `1px solid ${c.border}` : 'none',
-                              borderLeft: `3px solid ${statusColor}`,
-                              cursor: 'pointer', transition: 'background 0.12s',
-                            }}
-                            onMouseEnter={(e) => {
-                              (e.currentTarget as HTMLElement).style.background =
-                                mode === 'light' ? '#F0EEF8' : '#131729';
-                            }}
-                            onMouseLeave={(e) => {
-                              (e.currentTarget as HTMLElement).style.background = isOverdue
-                                ? (mode === 'light' ? 'rgba(239,68,68,0.04)' : 'rgba(239,68,68,0.05)')
-                                : c.rowBg;
-                            }}
-                          >
-                            {/* Status circle */}
-                            <div style={{
-                              width: 18, height: 18, borderRadius: '50%', flexShrink: 0,
-                              display: 'flex', alignItems: 'center', justifyContent: 'center',
-                              background: isDone ? '#22C55E' : 'transparent',
-                              border: isDone ? 'none' : `2px solid ${statusColor}`,
-                            }}>
-                              {isDone && (
-                                <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                                  <path d="M2 5l2.5 2.5L8 3" stroke="#fff" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                                </svg>
-                              )}
+                          <div key={task.id}>
+                            {/* Task row */}
+                            <div
+                              onClick={() => toggleAccordion(task.id)}
+                              style={{
+                                display: 'flex', alignItems: 'center', gap: bp === 'mobile' ? 8 : 12,
+                                padding: bp === 'mobile' ? '10px 12px' : '11px 16px',
+                                minWidth: 0,
+                                background: isOpen
+                                  ? (mode === 'light' ? '#EDE9FE' : '#111526')
+                                  : isOverdue
+                                    ? (mode === 'light' ? 'rgba(239,68,68,0.04)' : 'rgba(239,68,68,0.05)')
+                                    : c.rowBg,
+                                borderBottom: (!isOpen && idx < board.tasks.length - 1)
+                                  ? `1px solid ${c.border}` : 'none',
+                                borderLeft: `3px solid ${isOpen ? '#4F6EF7' : statusColor}`,
+                                cursor: 'pointer', transition: 'background 0.12s',
+                              }}
+                              onMouseEnter={(e) => {
+                                if (!isOpen) {
+                                  (e.currentTarget as HTMLElement).style.background =
+                                    mode === 'light' ? '#F0EEF8' : '#131729';
+                                }
+                              }}
+                              onMouseLeave={(e) => {
+                                if (!isOpen) {
+                                  (e.currentTarget as HTMLElement).style.background = isOverdue
+                                    ? (mode === 'light' ? 'rgba(239,68,68,0.04)' : 'rgba(239,68,68,0.05)')
+                                    : c.rowBg;
+                                }
+                              }}
+                            >
+                              {/* Chevron */}
+                              <svg
+                                width="12" height="12" viewBox="0 0 12 12" fill="none"
+                                style={{
+                                  flexShrink: 0,
+                                  transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+                                  transition: 'transform 0.15s',
+                                  color: isOpen ? '#4F6EF7' : c.muted,
+                                }}
+                              >
+                                <path d="M4 2.5L7.5 6L4 9.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+                              </svg>
+
+                              {/* Status circle */}
+                              <div style={{
+                                width: 18, height: 18, borderRadius: '50%', flexShrink: 0,
+                                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                background: isDone ? '#22C55E' : 'transparent',
+                                border: isDone ? 'none' : `2px solid ${statusColor}`,
+                              }}>
+                                {isDone && (
+                                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                                    <path d="M2 5l2.5 2.5L8 3" stroke="#fff" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                                  </svg>
+                                )}
+                              </div>
+
+                              {/* Key */}
+                              <span style={{
+                                fontSize: 11, color: c.key, letterSpacing: '0.02em',
+                                fontFamily: '"Inter",system-ui,sans-serif',
+                                flexShrink: 0, minWidth: 52,
+                              }}>
+                                {task.issueKey}
+                              </span>
+
+                              {/* Title */}
+                              <span style={{
+                                fontSize: 13, color: isDone ? c.muted : c.text,
+                                textDecoration: isDone ? 'line-through' : 'none',
+                                flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                              }}>
+                                {task.title}
+                              </span>
+
+                              {/* Right side: status + priority + due */}
+                              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+                                {task.status && bp !== 'mobile' && (
+                                  <span style={{
+                                    fontSize: 11, fontWeight: 500,
+                                    color: task.status.color,
+                                    background: `${task.status.color}18`,
+                                    borderRadius: 5, padding: '2px 7px',
+                                  }}>
+                                    {task.status.name}
+                                  </span>
+                                )}
+                                {prio && bp !== 'mobile' && (
+                                  <span style={{
+                                    fontSize: 10, fontWeight: 600,
+                                    color: prio.text, background: prio.bg,
+                                    borderRadius: 4, padding: '2px 6px',
+                                    letterSpacing: '0.04em',
+                                  }}>
+                                    {task.priority === 'MEDIUM' ? 'MED' : task.priority}
+                                  </span>
+                                )}
+                                {due && (
+                                  <span style={{
+                                    fontSize: 11,
+                                    color: isOverdue ? '#EF4444' : c.muted,
+                                    whiteSpace: 'nowrap',
+                                  }}>
+                                    {isOverdue && bp !== 'mobile' ? 'Просрочено · ' : ''}
+                                    {due.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })}
+                                  </span>
+                                )}
+                              </div>
                             </div>
 
-                            {/* Key */}
-                            <span style={{
-                              fontSize: 11, color: c.key, letterSpacing: '0.02em',
-                              fontFamily: '"Inter",system-ui,sans-serif',
-                              flexShrink: 0, minWidth: 52,
-                            }}>
-                              {task.issueKey}
-                            </span>
-
-                            {/* Title */}
-                            <span style={{
-                              fontSize: 13, color: isDone ? c.muted : c.text,
-                              textDecoration: isDone ? 'line-through' : 'none',
-                              flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                            }}>
-                              {task.title}
-                            </span>
-
-                            {/* Right side: status + priority + due */}
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
-                              {/* Status badge — hidden on mobile to save space */}
-                              {task.status && bp !== 'mobile' && (
-                                <span style={{
-                                  fontSize: 11, fontWeight: 500,
-                                  color: task.status.color,
-                                  background: `${task.status.color}18`,
-                                  borderRadius: 5, padding: '2px 7px',
-                                }}>
-                                  {task.status.name}
-                                </span>
-                              )}
-
-                              {/* Priority badge — hidden on mobile */}
-                              {prio && bp !== 'mobile' && (
-                                <span style={{
-                                  fontSize: 10, fontWeight: 600,
-                                  color: prio.text, background: prio.bg,
-                                  borderRadius: 4, padding: '2px 6px',
-                                  letterSpacing: '0.04em',
-                                }}>
-                                  {task.priority === 'MEDIUM' ? 'MED' : task.priority}
-                                </span>
-                              )}
-
-                              {/* Due date — compact on mobile */}
-                              {due ? (
-                                <span style={{
-                                  fontSize: 11,
-                                  color: isOverdue ? '#EF4444' : c.muted,
-                                  whiteSpace: 'nowrap',
-                                }}>
-                                  {isOverdue && bp !== 'mobile' ? 'Просрочено · ' : ''}
-                                  {due.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })}
-                                </span>
-                              ) : null}
-                            </div>
+                            {/* Accordion panel */}
+                            {isOpen && (
+                              <TaskAccordionPanel
+                                task={task}
+                                colors={c}
+                                isDark={mode === 'dark'}
+                                onOpenInBoard={() => openInBoard(task)}
+                              />
+                            )}
                           </div>
                         );
                       })}
@@ -502,29 +484,6 @@ export default function MyTasksPage() {
         </div>
       )}
 
-      <TaskDrawer
-        taskId={selectedTaskId}
-        statuses={drawerCtx?.statuses ?? []}
-        members={drawerCtx?.members ?? []}
-        workspaceId={drawerCtx?.workspaceId}
-        boardId={drawerBoardId ?? undefined}
-        workspaceLabels={drawerCtx?.labels ?? []}
-        onClose={() => {
-          setSelectedTaskId(null);
-          setDrawerBoardId(null);
-          setDrawerCtx(null);
-        }}
-        onUpdated={(updated) =>
-          setAllTasks((prev) =>
-            prev.map((t) =>
-              t.id === updated.id ? { ...t, ...updated, board: t.board } : t,
-            ),
-          )
-        }
-        onDeleted={(id) =>
-          setAllTasks((prev) => prev.filter((t) => t.id !== id))
-        }
-      />
     </div>
   );
 }

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -65,11 +65,17 @@ export default function MyTasksPage() {
   const [search, setSearch] = useState('');
   const offsetRef = useRef(0);
 
-  // Accordion state — one open at a time; restored from ?open= URL param on mount
+  // Accordion state — one open at a time; initialized and synced from ?open= URL param
   const rawOpen = searchParams.get('open');
   const [openAccordionId, setOpenAccordionId] = useState<string | null>(
     () => rawOpen && TASK_ID_RE.test(rawOpen) ? rawOpen : null,
   );
+
+  // Keep accordion in sync when URL changes (e.g. browser Back within My Tasks)
+  useEffect(() => {
+    const id = searchParams.get('open');
+    setOpenAccordionId(id && TASK_ID_RE.test(id) ? id : null);
+  }, [searchParams]);
 
   // Ref map for scroll-to-open after tasks load
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());

--- a/specs/gaps/gap-01-my-tasks-drawer.md
+++ b/specs/gaps/gap-01-my-tasks-drawer.md
@@ -2,10 +2,16 @@
 id: gap-01-my-tasks-drawer
 type: gap-fix
 priority: P1
-status: draft
+status: superseded
+superseded_by: gap-11-my-tasks-accordion
 ---
 
 # Spec: My Tasks — открывать TaskDrawer вместо перехода на доску
+
+> **SUPERSEDED** — заменён на gap-11 (аккордеон). Клик по задаче теперь раскрывает
+> inline-аккордеон с read-only полями; переход в полный TaskDrawer происходит через
+> кнопку "Открыть" внутри аккордеона (открывает BoardPage с дровером).
+> TaskDrawer и весь lazy-load контекста доски удалены из MyTasksPage.
 
 ## Intent
 Клик по задаче в My Tasks должен открывать TaskDrawer прямо на странице, а не делать навигацию на доску.

--- a/specs/gaps/gap-11-my-tasks-accordion.md
+++ b/specs/gaps/gap-11-my-tasks-accordion.md
@@ -1,0 +1,176 @@
+---
+id: gap-11-my-tasks-accordion
+type: gap-feat
+priority: P2
+status: approved
+---
+
+# Spec: My Tasks — аккордеон с основной информацией по задаче
+
+## Intent
+Клик по задаче в разделе "Мои задачи" должен раскрывать inline-панель с ключевыми полями задачи (read-only), не уводя пользователя со страницы. Переход в полный дровер на доске — через явную кнопку "Открыть".
+
+## BDD Scenarios
+
+```gherkin
+Feature: Аккордеон в разделе "Мои задачи"
+
+  Background:
+    Given я авторизован
+    And я нахожусь в разделе "Мои задачи"
+
+  Scenario: Клик по задаче раскрывает аккордеон
+    When я кликаю на строку задачи
+    Then под ней появляется панель с деталями
+    And задача визуально отмечена как раскрытая
+
+  Scenario: Повторный клик закрывает аккордеон
+    Given аккордеон задачи открыт
+    When я кликаю на неё повторно
+    Then панель скрывается
+
+  Scenario: Открытие новой задачи закрывает предыдущую
+    Given аккордеон задачи A открыт
+    When я кликаю на задачу B
+    Then аккордеон B открывается, аккордеон A закрывается
+
+  Scenario: Аккордеон показывает основную информацию
+    When я открываю аккордеон
+    Then вижу: описание, статус, дедлайн, исполнителя, теги
+
+  Scenario: Поля только для чтения
+    Given аккордеон открыт
+    When я кликаю на любое поле
+    Then поле не становится редактируемым
+
+  Scenario: Задача без описания
+    When я открываю аккордеон задачи без описания
+    Then вижу плейсхолдер "Описание не добавлено"
+
+  Scenario: Задача без дедлайна / исполнителя
+    When я открываю аккордеон задачи без этих полей
+    Then вижу "Не задан" / "Не назначен"
+
+  Scenario: Длинное описание
+    Given описание задачи > 500 символов
+    When я открываю аккордеон
+    Then текст обрезается с "..." и кнопкой "Читать далее"
+    When я кликаю "Читать далее"
+    Then отображается полный текст
+
+  Scenario: Переход в дровер на доске
+    Given аккордеон открыт
+    When я нажимаю "Открыть"
+    Then перехожу на доску с открытым дровером задачи
+    And в URL есть параметры ?from=my-tasks&open=<taskId>
+
+  Scenario: Возврат с открытым аккордеоном (явная кнопка)
+    Given я перешёл на доску через "Открыть"
+    When я нажимаю "← Мои задачи" в шапке доски
+    Then возвращаюсь в /my-tasks
+    And аккордеон исходной задачи открыт
+
+  Scenario: Возврат через кнопку браузера "Назад"
+    Given я перешёл на доску через "Открыть"
+    When я нажимаю "Назад" в браузере
+    Then возвращаюсь в /my-tasks
+    And аккордеон исходной задачи открыт
+```
+
+## SDD Contracts
+
+### Types (state only — MyTask already has all data fields)
+
+```typescript
+type OpenAccordionId = string | null;
+
+interface MyTasksSearchParams {
+  open?: string;   // taskId открытого аккордеона
+}
+
+// URL params при navigate на BoardPage
+// ?from=my-tasks&open=<taskId>
+// + navigate state: { openTaskId: taskId }  (уже читается BoardPage:196)
+```
+
+### Component
+
+```typescript
+// frontend/src/components/TaskAccordionPanel.tsx
+interface TaskAccordionPanelProps {
+  task: MyTask;
+  colors: Record<string, string>;
+  isDark: boolean;
+  onOpenInBoard: () => void;
+}
+
+const DESCRIPTION_PREVIEW_LIMIT = 500;
+```
+
+### MyTasksPage state changes
+
+```typescript
+// Убрать: selectedTaskId, drawerCtx, drawerBoardId, boardCtxCache,
+//         fetchingBoardIdRef, openDrawer, TaskDrawer, BoardContext,
+//         boardsApi / workspacesApi / labelsApi imports
+
+// Добавить:
+const [openAccordionId, setOpenAccordionId] = useState<OpenAccordionId>(null);
+
+// Restore from URL on mount:
+const [searchParams] = useSearchParams();
+useEffect(() => {
+  const id = searchParams.get('open');
+  if (id) setOpenAccordionId(id);
+}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+// Toggle accordion (one open at a time):
+function toggleAccordion(taskId: string) {
+  setOpenAccordionId(prev => prev === taskId ? null : taskId);
+}
+
+// Navigate to board with drawer + return context:
+function openInBoard(task: MyTask) {
+  navigate(
+    `/w/${task.board.workspace.slug}/boards/${task.board.prefix.toLowerCase()}` +
+    `?from=my-tasks&open=${task.id}`,
+    { state: { openTaskId: task.id } }
+  );
+}
+```
+
+### BoardPage changes
+
+```typescript
+// Читать from + open из searchParams (уже есть useSearchParams):
+const fromMyTasks = searchParams.get('from') === 'my-tasks';
+const myTasksOpenId = searchParams.get('open');
+
+// Показать кнопку "← Мои задачи" рядом с Back, когда fromMyTasks === true:
+// navigate(`/my-tasks?open=${myTasksOpenId}`)
+```
+
+## Scope
+- `frontend/src/components/TaskAccordionPanel.tsx` — новый компонент
+- `frontend/src/pages/MyTasksPage.tsx` — замена drawer → accordion
+- `frontend/src/pages/BoardPage.tsx` — кнопка "← Мои задачи" в шапке
+
+## Out of Scope
+- Редактирование полей из аккордеона
+- Показ подзадач в аккордеоне
+- Мобильный вариант (отличается от десктопа)
+
+## Constraints
+- MyTask уже содержит все нужные поля — новых API-запросов нет
+- BoardPage уже читает `location.state.openTaskId` — используем этот механизм
+- Дизайн-токены (DARK/LIGHT) передаются в панель из MyTasksPage
+
+## Acceptance Criteria
+- [ ] Клик по задаче → аккордеон (не дровер, не навигация)
+- [ ] Один аккордеон открыт одновременно
+- [ ] Поля read-only
+- [ ] Пустые поля показывают плейсхолдеры
+- [ ] Описание > 500 символов обрезается с "Читать далее"
+- [ ] "Открыть" → доска + дровер открыт + URL ?from=my-tasks&open=id
+- [ ] "← Мои задачи" на доске → /my-tasks?open=id → аккордеон восстановлен
+- [ ] Браузерный Back при навигации из аккордеона также восстанавливает состояние


### PR DESCRIPTION
## Summary

- Клик по задаче в «Мои задачи» раскрывает inline-аккордеон (описание, статус, дедлайн, исполнитель, теги) — без перехода на доску
- Кнопка «Открыть» переходит на доску с открытым дровером + URL-параметры `?from=my-tasks&open=<taskId>`
- Кнопка «← Мои задачи» в шапке BoardPage восстанавливает страницу с открытым аккордеоном
- `specs/gaps/gap-11-my-tasks-accordion.md` — BDD+SDD спецификация
- `specs/gaps/gap-01` помечен `superseded → gap-11`

## Ревью

Код-ревью, security-ревью и UX-ревью проведены в рамках PR. Все HIGH-замечания исправлены:

**Code review:**
- `toggleAccordion` синхронизирует `?open=` через `setSearchParams`
- `new Date()` вынесен в `useMemo(now)` — один экземпляр на render-цикл
- `window.history.replaceState` → `navigate(replace:true, state:null)`
- `role=button` + `aria-expanded` + `tabIndex` + `onKeyDown` на строках

**Security review:**
- `isSafeAvatarUrl()` — валидация схемы avatar URL (только http/https)
- `TASK_ID_RE` — валидация `?open=` параметра в MyTasksPage и BoardPage

**UX review:**
- Анимация fadeIn при открытии аккордеона (0.15s)
- Исправлен фон панели (инвертированная иерархия поверхностей)
- `aria-hidden` на декоративных SVG и аватарах
- Граница кнопки «Открыть»: 88% opacity

## Test plan

- [ ] Клик по задаче → аккордеон открывается (не дровер, не навигация)
- [ ] Повторный клик → закрывается
- [ ] Клик на другую задачу → предыдущий аккордеон закрывается
- [ ] `?open=<taskId>` в URL → аккордеон восстанавливается при загрузке
- [ ] Кнопка «Открыть» → переход на доску, дровер открыт, URL содержит `?from=my-tasks&open=<id>`
- [ ] Кнопка «← Мои задачи» на доске → возврат с открытым аккордеоном
- [ ] Браузерный «Назад» → то же поведение
- [ ] Пустые поля (описание/дедлайн/исполнитель) → плейсхолдеры
- [ ] Описание > 500 символов → обрезается + «Читать далее»
- [ ] Клавиатура: Tab фокусирует строку, Enter/Space открывает аккордеон

🤖 Generated with [Claude Code](https://claude.com/claude-code)