### PR TITLE
test: fix E2E timeout failures on CI

### DIFF
--- a/frontend/e2e/flows/task-drawer.spec.ts
+++ b/frontend/e2e/flows/task-drawer.spec.ts
@@ -348,6 +348,7 @@ test.describe('TaskDrawer — редактирование задачи', () => 
     // getByRole('button') чтобы не попасть на span 'Метки' в сайдбаре
     await page.getByRole('button', { name: 'Метки' }).click();
     // .first() т.к. labelName может матчиться в picker list И в sidebar labels
+    await expect(page.getByText(labelName).first()).toBeVisible({ timeout: 10000 });
     await page.getByText(labelName).first().click();
     // Метка назначена — picker ещё открыт (Escape закрыл бы drawer целиком)
     // Проверяем что метка видна — .first() избегает strict mode

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -56,12 +56,12 @@ test('CIO demo smoke: full user journey', async ({ page }) => {
   // ── 7. Open task drawer ──────────────────────────────────────────────────────
   await page.locator(`text=${taskTitle}`).first().click();
   // Task drawer opens — wait for the comments tab to be available
-  await expect(page.locator('text=Комментарии')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('text=Комментарии')).toBeVisible({ timeout: 10000 });
 
   // ── 8. Add a comment (click Comments tab first) ───────────────────────────────
   await page.locator('text=Комментарии').click();
   const commentInput = page.locator('textarea[placeholder="Написать комментарий..."]');
-  await commentInput.waitFor({ timeout: 5000 });
+  await commentInput.waitFor({ timeout: 10000 });
   await commentInput.fill('Hello from e2e smoke test');
   await page.locator('button:has-text("Отправить")').click();
   await expect(page.locator('text=Hello from e2e smoke test')).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
## Summary
- `smoke.spec.ts`: увеличен таймаут ожидания открытия drawer (`text=Комментарии`) и textarea комментария с 5s до 10s
- `task-drawer.spec.ts`: добавлен explicit `waitFor` 10s перед кликом по метке в picker (тест «назначение существующей метки на задачу»)

## Why
E2E тесты впервые попали в CI после мержа gap-05 (#135) — до этого CI блокировался на TypeScript-ошибках. На CI среда медленнее: 5s таймаутов не хватает для открытия drawer и рендера label picker после `page.reload()`.

## Test plan
- [ ] CI E2E job проходит зелёным
- [ ] `smoke.spec.ts` — «CIO demo smoke: full user journey» проходит
- [ ] `task-drawer.spec.ts` — «назначение существующей метки на задачу» проходит