### PR TITLE
fix(roadmap): milestone-ромб для задач только с dueDate

### DIFF
--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -145,11 +145,16 @@ export async function getRoadmapTasks(boardId: string, userId: string, from?: st
   const fromDate = from ? new Date(from) : new Date(new Date().getFullYear(), 0, 1);
   const toDate   = to   ? new Date(to)   : new Date(new Date().getFullYear() + 1, 0, 1);
 
+  const MAX_RANGE_DAYS = 730;
+  if ((toDate.getTime() - fromDate.getTime()) / 86_400_000 > MAX_RANGE_DAYS) {
+    throw new AppError(400, 'Date range too large (max 2 years)');
+  }
+
   const taskInclude = {
     status:        { select: { id: true, name: true, color: true, category: true } },
     assignee:      { select: { id: true, name: true, avatar: true } },
     _count:        { select: { children: true } },
-    statusHistory: { orderBy: { startedAt: 'asc' as const } },
+    statusHistory: { orderBy: { startedAt: 'asc' as const }, select: { id: true, statusId: true, startedAt: true, endedAt: true } },
   } as const;
 
   const dateInRange = {

--- a/frontend/src/components/RoadmapView.tsx
+++ b/frontend/src/components/RoadmapView.tsx
@@ -24,6 +24,11 @@ function isSameDay(a: Date, b: Date) {
     && a.getMonth() === b.getMonth()
     && a.getDate() === b.getDate();
 }
+const SAFE_COLOR_RE = /^#[0-9a-fA-F]{3,8}$|^rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$/;
+function safeColor(c: string | null | undefined, fallback = '#4F6EF7'): string {
+  return c && SAFE_COLOR_RE.test(c.trim()) ? c.trim() : fallback;
+}
+
 function parseDate(s?: string | null): Date | null {
   if (!s) return null;
   const d = new Date(s);
@@ -135,7 +140,7 @@ function BarTooltip({ tip, isDark, statuses }: {
           const ms     = Math.max(0, +segEnd - +new Date(seg.startedAt));
           const pct    = Math.round(ms / totalMs * 100);
           const st     = statusMap.get(seg.statusId);
-          return { name: st?.name ?? '?', color: st?.color ?? '#8B95B0', days: Math.round(ms / DAY_MS), pct, ongoing: !seg.endedAt };
+          return { name: st?.name ?? '?', color: safeColor(st?.color, '#8B95B0'), days: Math.round(ms / DAY_MS), pct, ongoing: !seg.endedAt };
         });
         // Хвост: запланированное оставшееся время
         const last = history[history.length - 1];
@@ -144,7 +149,7 @@ function BarTooltip({ tip, isDark, statuses }: {
           const tailMs  = +end - +today;
           const tailPct = Math.round(tailMs / totalMs * 100);
           const st      = statusMap.get(last.statusId);
-          tailSeg = { color: st?.color ?? '#8B95B0', pct: tailPct, days: Math.round(tailMs / DAY_MS) };
+          tailSeg = { color: safeColor(st?.color, '#8B95B0'), pct: tailPct, days: Math.round(tailMs / DAY_MS) };
         }
         return { segs, tailSeg };
       })()
@@ -191,12 +196,18 @@ function BarTooltip({ tip, isDark, statuses }: {
 
       {/* Даты */}
       {!start && end ? (
-        <div style={{ display:'flex', alignItems:'center', gap:5, color:muted, fontSize:11.5, marginBottom:5 }}>
-          <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-            <path d="M2 6l2.5 2.5L10 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-          Дедлайн: {fmtShort(end)}
-        </div>
+        <>
+          <div style={{ display:'flex', alignItems:'center', gap:5, color:muted, fontSize:11.5, marginBottom:5 }}>
+            {/* milestone diamond icon — matches the visual marker on the timeline */}
+            <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+              <rect x="3" y="3" width="6" height="6" transform="rotate(45 6 6)" stroke="currentColor" strokeWidth="1.3"/>
+            </svg>
+            Дедлайн: {fmtShort(end)}
+          </div>
+          <div style={{ fontSize:10.5, color:dimmed, fontStyle:'italic', marginBottom:5 }}>
+            Добавьте дату начала — задача появится как диапазон
+          </div>
+        </>
       ) : start && end ? (
         <div style={{ display:'flex', alignItems:'center', gap:5, color:muted, fontSize:11.5, marginBottom:5 }}>
           <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
@@ -398,7 +409,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
 
   // ── Status bar color ───────────────────────────────────────────────────────
   function barColor(task: Task): { bg: string; border: string } {
-    const color = task.status?.color ?? '#4F6EF7';
+    const color = safeColor(task.status?.color);
     const cat   = task.status?.category ?? 'OPEN';
     const alpha = cat === 'DONE' ? '.62' : cat === 'IN_PROGRESS' ? '.68' : '.55';
     return {
@@ -822,7 +833,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
                   return (
                     <div key={task.id} style={rowStyle}>
                       <span style={{
-                        position: 'absolute', right: 10, top: '50%',
+                        position: 'absolute', left: 10, top: '50%',
                         transform: 'translateY(-50%)', fontSize: 11, color: c.dimmed, fontStyle: 'italic',
                       }}>нет дат</span>
                     </div>
@@ -832,38 +843,58 @@ export default function RoadmapView({ boardId, statuses }: Props) {
                 // Milestone: only dueDate set, no startDate → render diamond marker
                 if (isMilestone) {
                   const mx = xOf(end!);
-                  const mSize = isChild ? 12 : 16;
+                  // minimum 14px so child diamonds stay legible
+                  const mSize = isChild ? 14 : 16;
+                  // hitbox is larger than the visual for easy mouse targeting
+                  const hitbox = mSize + 16;
                   const overdue = isOverdue(task);
+                  // clamp visual center so the diamond is never partially off-screen
+                  const clampedMx = Math.max(mSize / 2, Math.min(TL_W - mSize / 2, mx));
+                  const inView = mx >= -hitbox && mx <= TL_W + hitbox;
                   const mileMouseProps = {
                     onMouseEnter: (e: React.MouseEvent) => {
-                      (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-50%) rotate(45deg) scale(1.2)';
+                      const inner = (e.currentTarget as HTMLDivElement).querySelector<HTMLDivElement>('[data-mile-inner]');
+                      if (inner) inner.style.transform = 'rotate(45deg) scale(1.25)';
                       setTip({ task, x: e.clientX, y: e.clientY });
                     },
                     onMouseMove: (e: React.MouseEvent) =>
                       setTip(prev => prev ? { ...prev, x: e.clientX, y: e.clientY } : null),
                     onMouseLeave: (e: React.MouseEvent) => {
-                      (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-50%) rotate(45deg) scale(1)';
+                      const inner = (e.currentTarget as HTMLDivElement).querySelector<HTMLDivElement>('[data-mile-inner]');
+                      if (inner) inner.style.transform = 'rotate(45deg) scale(1)';
                       setTip(null);
                     },
                   };
                   return (
                     <div key={task.id} style={rowStyle}>
-                      {mx >= -mSize && mx <= TL_W + mSize && (
+                      {inView && (
+                        // Outer div: positioning only (top/left). Inner div: visual rotation + scale animation.
+                        // Separating transforms prevents scale mutations from corrupting translateY(-50%).
                         <div
                           title={`${task.issueKey} · ${task.title} · ${statusLabel(task)} · дедлайн ${fmtShort(end!)}`}
                           style={{
                             position: 'absolute',
-                            top: '50%', left: mx - mSize / 2,
-                            transform: 'translateY(-50%) rotate(45deg)',
-                            width: mSize, height: mSize,
-                            background: overdue ? 'rgba(239,68,68,.75)' : bg,
-                            border: `2px solid ${overdue ? '#EF4444' : border}`,
+                            top: '50%', left: clampedMx - hitbox / 2,
+                            transform: 'translateY(-50%)',
+                            width: hitbox, height: hitbox,
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
                             zIndex: 2, cursor: 'default',
-                            transition: 'transform .12s',
-                            animation: overdue && task.priority === 'HIGH' ? 'ov-pulse 2s ease-in-out infinite' : 'none',
                           }}
                           {...mileMouseProps}
-                        />
+                        >
+                          <div
+                            data-mile-inner=""
+                            style={{
+                              width: mSize, height: mSize,
+                              transform: 'rotate(45deg)',
+                              background: overdue ? 'rgba(239,68,68,.8)' : bg,
+                              border: `2px solid ${overdue ? '#EF4444' : border}`,
+                              transition: 'transform .12s',
+                              animation: overdue ? 'ov-pulse 2s ease-in-out infinite' : 'none',
+                              flexShrink: 0,
+                            }}
+                          />
+                        </div>
                       )}
                     </div>
                   );
@@ -926,7 +957,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
                               const segL     = Math.max(0, xOf(clampS) - cx);
                               const segW     = Math.max(2, xOf(clampE) - xOf(clampS));
                               const st       = statusMap.get(seg.statusId);
-                              const color    = st?.color ?? '#8B95B0';
+                              const color    = safeColor(st?.color, '#8B95B0');
                               const alpha    = st?.category === 'DONE'
                                 ? 'A0' : st?.category === 'IN_PROGRESS' ? 'B0' : '70';
                               return (
@@ -950,8 +981,8 @@ export default function RoadmapView({ boardId, statuses }: Props) {
                                 <div style={{
                                   position: 'absolute', top: 0, bottom: 0,
                                   left: tailL, width: tailW,
-                                  background: `${st?.color ?? '#8B95B0'}28`,
-                                  borderLeft: `1px dashed ${st?.color ?? '#8B95B0'}55`,
+                                  background: `${safeColor(st?.color, '#8B95B0')}28`,
+                                  borderLeft: `1px dashed ${safeColor(st?.color, '#8B95B0')}55`,
                                 }} />
                               );
                             })()}
@@ -1011,7 +1042,7 @@ export default function RoadmapView({ boardId, statuses }: Props) {
         </div>
       </div>
 
-      <style>{`@keyframes ov-pulse{0%,100%{opacity:1}50%{opacity:.55}}`}</style>
+      <style>{`@keyframes ov-pulse{0%,100%{opacity:1}50%{opacity:.55}}@media(prefers-reduced-motion:reduce){*{animation:none!important}}`}</style>
 
       {tip && <BarTooltip tip={tip} isDark={isDark} statuses={statuses} />}
     </div>

--- a/frontend/src/components/RoadmapView.tsx
+++ b/frontend/src/components/RoadmapView.tsx
@@ -190,7 +190,14 @@ function BarTooltip({ tip, isDark, statuses }: {
       </div>
 
       {/* Даты */}
-      {start && end && (
+      {!start && end ? (
+        <div style={{ display:'flex', alignItems:'center', gap:5, color:muted, fontSize:11.5, marginBottom:5 }}>
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+            <path d="M2 6l2.5 2.5L10 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          Дедлайн: {fmtShort(end)}
+        </div>
+      ) : start && end ? (
         <div style={{ display:'flex', alignItems:'center', gap:5, color:muted, fontSize:11.5, marginBottom:5 }}>
           <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
             <rect x="1" y="2" width="10" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.1"/>
@@ -199,7 +206,7 @@ function BarTooltip({ tip, isDark, statuses }: {
           {fmtShort(start)} → {fmtShort(end)}
           <span style={{ color:dimmed }}>({dur} дн.)</span>
         </div>
-      )}
+      ) : null}
 
       {/* Приоритет */}
       {task.priority && (
@@ -795,8 +802,11 @@ export default function RoadmapView({ boardId, statuses }: Props) {
                 const isChild = !!task.parentId;
                 const rh      = isChild ? CROW_H : ROW_H;
                 const yOffset = rows.slice(0, idx).reduce((acc, t) => acc + (t.parentId ? CROW_H : ROW_H), 0);
-                const start   = parseDate(task.startDate) ?? parseDate(task.dueDate);
-                const end     = parseDate(task.dueDate)   ?? parseDate(task.startDate);
+                const rawStart = parseDate(task.startDate);
+                const rawEnd   = parseDate(task.dueDate);
+                const isMilestone = !rawStart && !!rawEnd;
+                const start = rawStart ?? rawEnd;
+                const end   = rawEnd   ?? rawStart;
                 const { bg, border } = barColor(task);
                 const barH    = isChild ? 22 : 30;
                 const barR    = isChild ? 5  : 7;
@@ -815,6 +825,46 @@ export default function RoadmapView({ boardId, statuses }: Props) {
                         position: 'absolute', right: 10, top: '50%',
                         transform: 'translateY(-50%)', fontSize: 11, color: c.dimmed, fontStyle: 'italic',
                       }}>нет дат</span>
+                    </div>
+                  );
+                }
+
+                // Milestone: only dueDate set, no startDate → render diamond marker
+                if (isMilestone) {
+                  const mx = xOf(end!);
+                  const mSize = isChild ? 12 : 16;
+                  const overdue = isOverdue(task);
+                  const mileMouseProps = {
+                    onMouseEnter: (e: React.MouseEvent) => {
+                      (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-50%) rotate(45deg) scale(1.2)';
+                      setTip({ task, x: e.clientX, y: e.clientY });
+                    },
+                    onMouseMove: (e: React.MouseEvent) =>
+                      setTip(prev => prev ? { ...prev, x: e.clientX, y: e.clientY } : null),
+                    onMouseLeave: (e: React.MouseEvent) => {
+                      (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-50%) rotate(45deg) scale(1)';
+                      setTip(null);
+                    },
+                  };
+                  return (
+                    <div key={task.id} style={rowStyle}>
+                      {mx >= -mSize && mx <= TL_W + mSize && (
+                        <div
+                          title={`${task.issueKey} · ${task.title} · ${statusLabel(task)} · дедлайн ${fmtShort(end!)}`}
+                          style={{
+                            position: 'absolute',
+                            top: '50%', left: mx - mSize / 2,
+                            transform: 'translateY(-50%) rotate(45deg)',
+                            width: mSize, height: mSize,
+                            background: overdue ? 'rgba(239,68,68,.75)' : bg,
+                            border: `2px solid ${overdue ? '#EF4444' : border}`,
+                            zIndex: 2, cursor: 'default',
+                            transition: 'transform .12s',
+                            animation: overdue && task.priority === 'HIGH' ? 'ov-pulse 2s ease-in-out infinite' : 'none',
+                          }}
+                          {...mileMouseProps}
+                        />
+                      )}
                     </div>
                   );
                 }

--- a/specs/roadmap-milestone.md
+++ b/specs/roadmap-milestone.md
@@ -1,0 +1,143 @@
+# Spec: Roadmap — Milestone-маркеры для задач только с дедлайном
+
+**Статус:** Реализовано (частично) + открытые задачи  
+**Ветка:** `fix/roadmap-milestone-bars`  
+**Дата:** 2026-05-08
+
+---
+
+## Проблема
+
+Задачи с только `dueDate` (без `startDate`) отрисовывались как 6px вертикальная черта вместо нормального элемента на временно́й шкале. Причина: `start = end = dueDate` → `diffDays = 0` → `Math.max(6, 0 * dayPx) = 6px`.
+
+---
+
+## Решение (реализовано)
+
+Задачи без `startDate` рендерятся как **ромб-маркер (milestone diamond)** в позиции `dueDate`.
+
+### Визуальный язык таймлайна
+
+| Элемент | Условие | Внешний вид |
+|---------|---------|-------------|
+| Бар | `startDate` + `dueDate` | Цветной прямоугольник от start до end |
+| Milestone-ромб | только `dueDate` | Ромб ◇ в позиции дедлайна |
+| Просроченный бар | `dueDate < сегодня` + статус ≠ DONE | Красный пунктирный хвост |
+| Просроченный ромб | `dueDate < сегодня` + статус ≠ DONE | Красный ромб, пульсация |
+| Нет дат | нет ни одной даты | Italic-текст «нет дат» |
+
+### Параметры milestone-ромба
+
+```
+mSize:  16px (родительская задача), 14px (дочерняя)
+hitbox: mSize + 16 = 32px (невидимая область для hover, облегчает попадание мышью)
+clamp:  left зажат в [mSize/2, TL_W - mSize/2] — ромб не выходит за края
+```
+
+### Структура DOM (разделение transform)
+
+```html
+<!-- позиционирующий wrapper: translateY(-50%) — никогда не мутируется -->
+<div style="position:absolute; top:50%; left:{clampedMx - hitbox/2}; transform:translateY(-50%); width:{hitbox}; height:{hitbox}">
+  <!-- визуальный ромб: rotate(45deg) scale(1) — scale мутируется при hover -->
+  <div data-mile-inner style="transform:rotate(45deg); transition:transform .12s; ...">
+  </div>
+</div>
+```
+
+Разделение не даёт hover-анимации (`scale`) испортить позиционирующий `translateY(-50%)`.
+
+---
+
+## Фиксы, вошедшие в PR #158
+
+### Frontend (`RoadmapView.tsx`)
+
+| # | Проблема | Severity | Статус |
+|---|---------|----------|--------|
+| F1 | `start=end=dueDate` → 6px черта | CRITICAL | ✅ Milestone-ромб |
+| F2 | Transform isolation: scale ломал translateY | HIGH | ✅ Wrapper + inner div |
+| F3 | `«нет дат»` виден только в конце скролла (`right:10`) | LOW | ✅ Перенесён на `left:10` |
+| F4 | Иконка галочки в тултипе milestone — семантически неверна | HIGH | ✅ Заменена на ромб SVG |
+| F5 | Child-ромб 12px — нечитаем | HIGH | ✅ Минимум 14px |
+| F6 | Hitbox milestone = визуальный размер — сложно попасть | HIGH | ✅ Hitbox 32px |
+| F7 | Нет подсказки как получить бар вместо ромба | MEDIUM | ✅ Hint в тултипе |
+| F8 | `status.color` интерполируется в CSS без валидации (CSS injection) | MEDIUM | ✅ `safeColor()` |
+| F9 | Все места с `st?.color` в строках стилей | MEDIUM | ✅ Обёрнуты `safeColor()` |
+| F10 | `prefers-reduced-motion` не учитывался | MEDIUM | ✅ `@media` в `<style>` |
+| F11 | Clamp: ромб мог вылезти за левый/правый край | CRITICAL | ✅ `clampedMx` |
+
+### Backend (`boards.service.ts`)
+
+| # | Проблема | Severity | Статус |
+|---|---------|----------|--------|
+| B1 | `statusHistory` возвращал все поля модели | LOW | ✅ Добавлен `select` (id, statusId, startedAt, endedAt) |
+| B2 | Нет ограничения на диапазон дат → DB scan за годы | LOW | ✅ `MAX_RANGE_DAYS = 730` |
+
+---
+
+## Открытые задачи (backlog)
+
+### UX / UI
+
+| ID | Проблема | Severity | Описание |
+|----|---------|----------|----------|
+| U1 | Нет легенды таймлайна | CRITICAL | Пользователь не знает: ромб = дедлайн, бар = диапазон, красный хвост = просрочка. Нужна кнопка «Легенда» в toolbar с popover |
+| U2 | Tooltip недоступен на touch/mobile | HIGH | `onMouseEnter` не работает на тачскринах. Нужен `onTouchStart` → показ tooltip на 2с, или `onClick` → мобильный drawer |
+| U3 | 1400px без scroll affordance на мобильном | HIGH | Нет fade-градиента по правому краю, нет `scroll-snap`. Пользователь не знает что можно скроллить |
+| U4 | Collision detection overlapping milestones | MEDIUM | При нескольких milestone в одну неделю ромбы перекрываются. Нужен вертикальный offset (±8px) или badge-счётчик |
+| U5 | Бар без текста при `cw < 38` — немой цветной блок | MEDIUM | Нужен label над/под баром или `···` при hover |
+| U6 | Keyboard navigation по строкам задач | LOW | Нет `tabIndex`, `role="button"`, `onKeyDown` |
+| U7 | Keyboard shortcuts W/M/Q для zoom | LOW | Стандарт Jira/Linear |
+| U8 | Loading skeleton для area баров | LOW | Сейчас при загрузке правая панель выглядит сломанной |
+| U9 | Overdue tail не виден для задач с dueDate до range.start | LOW | Нужен отдельный badge просрочки по левому краю |
+
+### Code quality
+
+| ID | Проблема | Severity | Описание |
+|----|---------|----------|----------|
+| C1 | `getToday()` вызывается N раз при рендере (per row) | MEDIUM | Вычислять один раз в начале рендера и передавать в замыкание |
+| C2 | `onMouseMove → setTip → re-render` на 60fps | MEDIUM | Throttle через `requestAnimationFrame`. Захватить `clientX/Y` до rAF callback |
+| C3 | `isMilestone` — asymmetry: startDate-only → 6px слайвер | LOW | Задача только с startDate (без dueDate) всё ещё рендерится как 6px черта. Задокументировать или вынести в отдельный milestone-ромб |
+| C4 | `isMilestone` дублируется в `BarTooltip` как `!start && end` | LOW | Передавать как prop `isMilestone: boolean` или вынести в утилиту |
+
+### Security (hardening, не критично)
+
+| ID | Проблема | Severity | Описание |
+|----|---------|----------|----------|
+| S1 | `task.title` в `title` атрибуте — длина не ограничена | LOW | Truncate до 200 символов (UX, не XSS — React escapes all) |
+
+---
+
+## Тест-план
+
+### Smoke tests (вручную)
+
+- [ ] Создать задачу только с `dueDate` → открыть roadmap → ромб в позиции дедлайна
+- [ ] Создать задачу с `startDate` + `dueDate` → бар от start до end (без изменений)
+- [ ] Создать задачу без дат → «нет дат» слева в строке
+- [ ] Hover на ромб → scale 1.25 + tooltip «Дедлайн: X» + hint про startDate
+- [ ] Milestone на краю видимого диапазона → ромб не вылезает за границы
+- [ ] Milestone с `dueDate < сегодня` → красный ромб
+- [ ] Проверить все zoom: неделя / месяц / квартал → ромб виден на каждом
+- [ ] Светлая тема → ромб виден (не сливается с фоном)
+- [ ] Тёмная тема → ромб виден
+
+### Регрессия
+
+- [ ] Существующие бары с `startDate + dueDate` — без изменений
+- [ ] Segmented bars (история статусов) — работают корректно
+- [ ] Overdue tail у баров — отображается
+
+---
+
+## Дизайн-решения и rationale
+
+**Почему ромб, а не бар от createdAt?**  
+Использование `createdAt` как start создаёт вводящие в заблуждение бары: задача, созданная 3 месяца назад с дедлайном завтра, показала бы трёхмесячный бар. Ромб-маркер честно отражает что у задачи есть только дедлайн — это стандарт Gantt-диаграмм (Jira, Linear, MS Project, Monday.com).
+
+**Почему hitbox 32px при визуале 16px?**  
+Стандарт touch/pointer targets — минимум 44px (Apple HIG), минимум 48px (Material Design). 32px — компромисс для desktop (не перекрывает соседние ромбы в плотных списках).
+
+**Почему clamp ромба, а не скрытие?**  
+Если задача в диапазоне по дате но ромб выходит за пиксельный край — лучше показать его прижатым к краю, чем скрыть. Пользователь видит «здесь что-то есть» и может проскроллить.


### PR DESCRIPTION
## Проблема

Задачи с только `dueDate` (без `startDate`) отображались как 6px вертикальные черточки: `start = end = dueDate` → `Math.max(6, 0 * dayPx) = 6px`.

## Решение

Задачи только с дедлайном → **ромб-маркер (milestone diamond)** в позиции `dueDate`. Стандарт Gantt-диаграмм (Jira, Linear, MS Project).

## Изменения (после code/security/ux ревью)

### Frontend `RoadmapView.tsx`
| Fix | Severity |
|-----|----------|
| Разделение positioning и scale transforms — hover не ломает `translateY(-50%)` | HIGH |
| Clamp ромба: не вылезает за левый/правый край | CRITICAL |
| Hitbox 32px вместо 16px — легче попасть мышью | HIGH |
| Child-ромб минимум 14px вместо 12 | HIGH |
| Иконка в тултипе — ромб SVG вместо галочки | HIGH |
| Hint «Добавьте дату начала» в тултипе milestone | MEDIUM |
| `safeColor()` — валидация `status.color` перед inline CSS | MEDIUM (security) |
| `prefers-reduced-motion` `@media` | MEDIUM |
| «нет дат» перенесено на `left:10` (было `right:10` — не видно без скролла) | LOW |

### Backend `boards.service.ts`
| Fix | Severity |
|-----|----------|
| `statusHistory select` — только нужные поля (id, statusId, startedAt, endedAt) | LOW (security) |
| `MAX_RANGE_DAYS=730` — защита от слишком широкого диапазона дат | LOW (security) |

### Спека
- `specs/roadmap-milestone.md` — полная спека с backlog открытых задач (U1–U9, C1–C4, S1)

## Тест план
- [ ] Задача только с `dueDate` → ромб в позиции дедлайна
- [ ] Задача с `startDate` + `dueDate` → обычный бар (без изменений)
- [ ] Задача без дат → «нет дат» слева в строке
- [ ] Hover на ромб → scale 1.25 + tooltip «Дедлайн: X» + hint
- [ ] Milestone на краю диапазона → не вылезает за границу
- [ ] Просроченный milestone → красный ромб
- [ ] Все зумы (неделя / месяц / квартал) → ромб виден
- [ ] Светлая и тёмная темы → ромб читаем
- [ ] Existing бары с `startDate + dueDate` — без регрессий