### PR TITLE
feat: gap-22 + gap-23 — настройки пространства везде + superadmin badge

### DIFF
--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -33,8 +33,11 @@ export async function listUsers() {
     orderBy: { createdAt: 'desc' },
   });
 
+  const superadminEmail = config.SUPERADMIN_EMAIL;
+
   return users.map(({ createdWorkspaces, _count, ...u }) => ({
     ...u,
+    isSuperadmin: u.isSuperadmin || u.email === superadminEmail,
     stats: {
       workspaces: _count.createdWorkspaces,
       boards: createdWorkspaces.reduce((s, ws) => s + ws._count.boards, 0),

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -50,6 +50,14 @@ export async function listUsers() {
 export async function setUserSuperadmin(actorId: string, userId: string, isSuperadmin: boolean) {
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user) throw new AppError(404, 'Пользователь не найден');
+
+  if (!isSuperadmin && user.email === config.SUPERADMIN_EMAIL) {
+    throw new AppError(403, 'Нельзя снять роль суперадминистратора с резервного аккаунта');
+  }
+  if (!isSuperadmin && actorId === userId) {
+    throw new AppError(403, 'Нельзя снять роль суперадминистратора с самого себя');
+  }
+
   const updated = await prisma.user.update({
     where: { id: userId },
     data: { isSuperadmin },

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -38,6 +38,7 @@ export async function listUsers() {
   return users.map(({ createdWorkspaces, _count, ...u }) => ({
     ...u,
     isSuperadmin: u.isSuperadmin || u.email === superadminEmail,
+    isSuperadminLocked: u.email === superadminEmail,
     stats: {
       workspaces: _count.createdWorkspaces,
       boards: createdWorkspaces.reduce((s, ws) => s + ws._count.boards, 0),

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -117,7 +117,8 @@ export async function login(dto: LoginDto, clientMeta?: ClientMeta) {
   }
 
   // Block local login for SSO-only users (except superadmins who always retain local access)
-  if (user.ssoOnly && !user.isSuperadmin) {
+  const isSuperadminEffective = user.isSuperadmin || user.email === config.SUPERADMIN_EMAIL;
+  if (user.ssoOnly && !isSuperadminEffective) {
     throw new AppError(403, 'Вход по паролю недоступен. Используйте SSO.');
   }
 

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -28,23 +28,36 @@ function GridIcon() {
 }
 
 // ─── User dropdown menu ───────────────────────────────────────────────────────
-function UserMenu({ user, onLogout, onProfile, onSettings, hasSettings, onAdminUsers, isSuperadmin, navBg, border, textPrimary, textMuted, onClose }: {
+function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, onAdminUsers, isSuperadmin, navBg, border, textPrimary, textMuted, onClose }: {
   user: { name: string; email?: string };
   onLogout: () => void;
   onProfile: () => void;
-  onSettings: () => void;
-  hasSettings: boolean;
+  onSettings: (slug: string) => void;
+  workspaces: Array<{ id: string; name: string; slug: string }>;
+  current: { id: string; name: string; slug: string } | null;
   onAdminUsers: () => void;
   isSuperadmin: boolean;
   navBg: string; border: string; textPrimary: string; textMuted: string;
   onClose: () => void;
 }) {
+  const [pickerOpen, setPickerOpen] = useState(false);
   const menuBg = navBg === '#0A0D1A' ? '#0F1320' : '#FFFFFF';
+  const hasWorkspaces = workspaces.length > 0;
+
+  function handleSettingsClick() {
+    if (current) {
+      onSettings(current.slug);
+      onClose();
+    } else {
+      setPickerOpen(v => !v);
+    }
+  }
+
   return (
     <div
       style={{
         backgroundColor: menuBg, border: `1px solid ${border}`, borderRadius: 10,
-        boxShadow: '0 8px 32px rgba(0,0,0,0.3)', minWidth: 200,
+        boxShadow: '0 8px 32px rgba(0,0,0,0.3)', minWidth: 220,
         padding: '6px 0', position: 'absolute', right: 0, top: 'calc(100% + 8px)', zIndex: 200,
       }}
       onClick={e => e.stopPropagation()}
@@ -77,14 +90,60 @@ function UserMenu({ user, onLogout, onProfile, onSettings, hasSettings, onAdminU
           Пользователи
         </button>
       )}
-      {hasSettings && (
-        <button onClick={() => { onSettings(); onClose(); }} style={{
-          background: 'none', border: 'none', borderRadius: 6, color: textMuted,
-          cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
-          fontSize: 13, padding: '8px 16px', textAlign: 'left', width: '100%',
-        }}>
-          Настройки workspace
-        </button>
+      {hasWorkspaces && (
+        <>
+          <button onClick={handleSettingsClick} style={{
+            alignItems: 'center', background: 'none', border: 'none', borderRadius: 6,
+            color: textMuted, cursor: 'pointer', display: 'flex', justifyContent: 'space-between',
+            fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13,
+            padding: '8px 16px', textAlign: 'left', width: '100%',
+          }}>
+            <span>Настройки пространства</span>
+            {!current && (
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={{ flexShrink: 0, transform: pickerOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>
+                <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            )}
+          </button>
+          {/* Inline picker — shown when no active workspace, or when user wants to switch */}
+          {pickerOpen && !current && (
+            <div style={{ borderTop: `1px solid ${border}`, paddingBottom: 4 }}>
+              {workspaces.map(ws => (
+                <button key={ws.id} onClick={() => { onSettings(ws.slug); onClose(); }} style={{
+                  background: 'none', border: 'none', borderRadius: 6, color: textMuted,
+                  cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
+                  fontSize: 12, padding: '6px 16px 6px 28px', textAlign: 'left', width: '100%',
+                }}>
+                  {ws.name}
+                </button>
+              ))}
+            </div>
+          )}
+          {/* When in a workspace — offer switching to another space's settings */}
+          {current && (
+            <button onClick={() => setPickerOpen(v => !v)} style={{
+              background: 'none', border: 'none', borderRadius: 6,
+              color: textMuted, cursor: 'pointer', display: 'block',
+              fontFamily: '"Inter", system-ui, sans-serif', fontSize: 11,
+              opacity: 0.6, padding: '2px 16px 6px', textAlign: 'left', width: '100%',
+            }}>
+              {pickerOpen ? 'Скрыть список ↑' : 'Другое пространство ›'}
+            </button>
+          )}
+          {pickerOpen && current && (
+            <div style={{ borderTop: `1px solid ${border}`, paddingBottom: 4 }}>
+              {workspaces.filter(ws => ws.id !== current.id).map(ws => (
+                <button key={ws.id} onClick={() => { onSettings(ws.slug); onClose(); }} style={{
+                  background: 'none', border: 'none', borderRadius: 6, color: textMuted,
+                  cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
+                  fontSize: 12, padding: '6px 16px 6px 28px', textAlign: 'left', width: '100%',
+                }}>
+                  {ws.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </>
       )}
       <div style={{ backgroundColor: border, height: 1, margin: '4px 0' }}/>
       <button onClick={() => { onLogout(); onClose(); }} style={{
@@ -436,8 +495,9 @@ export default function AppLayout({ children }: Props) {
               user={user}
               onLogout={handleLogout}
               onProfile={() => navigate('/profile')}
-              onSettings={() => current && navigate(`/w/${current.slug}/settings`)}
-              hasSettings={!!current}
+              onSettings={(slug) => navigate(`/w/${slug}/settings`)}
+              workspaces={workspaces}
+              current={current}
               onAdminUsers={() => navigate('/admin/users')}
               isSuperadmin={!!user.isSuperadmin}
               navBg={navBg} border={navBorder} textPrimary={wsSelectorText} textMuted={tabIdleText}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -57,6 +57,8 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
 
   return (
     <div
+      role="menu"
+      aria-label="Меню пользователя"
       style={{
         backgroundColor: menuBg, border: `1px solid ${border}`, borderRadius: 10,
         boxShadow: '0 8px 32px rgba(0,0,0,0.3)', minWidth: 220,
@@ -76,7 +78,7 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
         )}
       </div>
       <div style={{ backgroundColor: border, height: 1, margin: '4px 0' }}/>
-      <button onClick={() => { onProfile(); onClose(); }} style={{
+      <button role="menuitem" onClick={() => { onProfile(); onClose(); }} style={{
         background: 'none', border: 'none', borderRadius: 6, color: textMuted,
         cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
         fontSize: 13, padding: '8px 16px', textAlign: 'left', width: '100%',
@@ -84,7 +86,7 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
         Профиль
       </button>
       {isSuperadmin && (
-        <button onClick={() => { onAdminUsers(); onClose(); }} style={{
+        <button role="menuitem" onClick={() => { onAdminUsers(); onClose(); }} style={{
           background: 'none', border: 'none', borderRadius: 6, color: '#4F6EF7',
           cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
           fontSize: 13, padding: '8px 16px', textAlign: 'left', width: '100%', fontWeight: 500,
@@ -94,24 +96,30 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
       )}
       {hasWorkspaces && (
         <>
-          <button onClick={handleSettingsClick} style={{
-            alignItems: 'center', background: 'none', border: 'none', borderRadius: 6,
-            color: textMuted, cursor: 'pointer', display: 'flex', justifyContent: 'space-between',
-            fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13,
-            padding: '8px 16px', textAlign: 'left', width: '100%',
-          }}>
+          <button
+            role="menuitem"
+            aria-expanded={!current ? pickerOpen : undefined}
+            aria-haspopup={!current ? 'listbox' : undefined}
+            onClick={handleSettingsClick}
+            style={{
+              alignItems: 'center', background: 'none', border: 'none', borderRadius: 6,
+              color: textMuted, cursor: 'pointer', display: 'flex', justifyContent: 'space-between',
+              fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13,
+              padding: '8px 16px', textAlign: 'left', width: '100%',
+            }}
+          >
             <span>Настройки пространства</span>
             {!current && (
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={{ flexShrink: 0, transform: pickerOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" style={{ flexShrink: 0, transform: pickerOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>
                 <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
               </svg>
             )}
           </button>
-          {/* Inline picker — shown when no active workspace, or when user wants to switch */}
+          {/* Inline picker — shown when no active workspace */}
           {pickerOpen && !current && (
-            <div style={{ borderTop: `1px solid ${border}`, paddingBottom: 4 }}>
+            <div role="listbox" aria-label="Выберите пространство" style={{ borderTop: `1px solid ${border}`, maxHeight: 180, overflowY: 'auto', paddingBottom: 4 }}>
               {workspaces.map(ws => (
-                <button key={ws.id} onClick={() => { onSettings(ws.slug); onClose(); }} style={{
+                <button role="option" aria-selected={false} key={ws.id} onClick={() => { onSettings(ws.slug); onClose(); }} style={{
                   background: 'none', border: 'none', borderRadius: 6, color: textMuted,
                   cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
                   fontSize: 12, padding: '6px 16px 6px 28px', textAlign: 'left', width: '100%',
@@ -123,19 +131,27 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
           )}
           {/* When in a workspace — offer switching to another space's settings */}
           {current && (
-            <button onClick={() => setPickerOpen(v => !v)} style={{
-              background: 'none', border: 'none', borderRadius: 6,
-              color: textMuted, cursor: 'pointer', display: 'block',
-              fontFamily: '"Inter", system-ui, sans-serif', fontSize: 11,
-              opacity: 0.6, padding: '2px 16px 6px', textAlign: 'left', width: '100%',
-            }}>
-              {pickerOpen ? 'Скрыть список ↑' : 'Другое пространство ›'}
+            <button
+              role="menuitem"
+              aria-expanded={pickerOpen}
+              onClick={() => setPickerOpen(v => !v)}
+              style={{
+                alignItems: 'center', background: 'none', border: 'none', borderRadius: 6,
+                color: textMuted, cursor: 'pointer', display: 'flex', gap: 4,
+                fontFamily: '"Inter", system-ui, sans-serif', fontSize: 11,
+                opacity: 0.6, padding: '2px 16px 6px', textAlign: 'left', width: '100%',
+              }}
+            >
+              Другое пространство
+              <svg width="10" height="10" viewBox="0 0 12 12" fill="none" aria-hidden="true" style={{ flexShrink: 0, transform: pickerOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>
+                <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
             </button>
           )}
           {pickerOpen && current && (
-            <div style={{ borderTop: `1px solid ${border}`, paddingBottom: 4 }}>
+            <div role="listbox" aria-label="Выберите пространство" style={{ borderTop: `1px solid ${border}`, maxHeight: 180, overflowY: 'auto', paddingBottom: 4 }}>
               {workspaces.filter(ws => ws.id !== current.id).map(ws => (
-                <button key={ws.id} onClick={() => { onSettings(ws.slug); onClose(); }} style={{
+                <button role="option" aria-selected={false} key={ws.id} onClick={() => { onSettings(ws.slug); onClose(); }} style={{
                   background: 'none', border: 'none', borderRadius: 6, color: textMuted,
                   cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
                   fontSize: 12, padding: '6px 16px 6px 28px', textAlign: 'left', width: '100%',
@@ -148,7 +164,7 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
         </>
       )}
       <div style={{ backgroundColor: border, height: 1, margin: '4px 0' }}/>
-      <button onClick={() => { onLogout(); onClose(); }} style={{
+      <button role="menuitem" onClick={() => { onLogout(); onClose(); }} style={{
         background: 'none', border: 'none', borderRadius: 6, color: '#F87171',
         cursor: 'pointer', display: 'block', fontFamily: '"Inter", system-ui, sans-serif',
         fontSize: 13, padding: '8px 16px', textAlign: 'left', width: '100%',
@@ -290,6 +306,10 @@ export default function AppLayout({ children }: Props) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
         setSearchOpen(v => !v);
+      }
+      if (e.key === 'Escape') {
+        setUserMenuOpen(false);
+        setWsMenuOpen(false);
       }
     };
     window.addEventListener('keydown', handler);

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -44,6 +44,8 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
   const menuBg = navBg === '#0A0D1A' ? '#0F1320' : '#FFFFFF';
   const hasWorkspaces = workspaces.length > 0;
 
+  useEffect(() => { setPickerOpen(false); }, [current?.id]);
+
   function handleSettingsClick() {
     if (current) {
       onSettings(current.slug);

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -128,7 +128,7 @@ export default function AdminUsersPage() {
   const bp        = useBreakpoint();
   const isMobile  = bp === 'mobile';
   const [hoveredRow, setHoveredRow] = useState<string | null>(null);
-  const { user } = useAuthStore();
+  const { user, loading: authLoading } = useAuthStore();
   const navigate = useNavigate();
   const C = mode === 'dark' ? DARK : LIGHT;
 
@@ -153,10 +153,10 @@ export default function AdminUsersPage() {
   const [togglingId, setTogglingId] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!user?.isSuperadmin) {
+    if (!authLoading && !user?.isSuperadmin) {
       navigate('/workspaces');
     }
-  }, [user, navigate]);
+  }, [user, authLoading, navigate]);
 
   useEffect(() => {
     if (tab === 'users') loadUsers();

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -333,7 +333,7 @@ export default function AdminUsersPage() {
                           Суперадмин
                         </span>
                       )}
-                      {u.id !== user?.id && (
+                      {u.id !== user?.id && !u.isSuperadminLocked && (
                         <button
                           onClick={() => handleToggleSuperadmin(u)}
                           disabled={togglingId === u.id}
@@ -346,6 +346,13 @@ export default function AdminUsersPage() {
                         >
                           {u.isSuperadmin ? 'Снять' : 'Назначить'}
                         </button>
+                      )}
+                      {u.isSuperadminLocked && (
+                        <span title="Резервный аккаунт — роль нельзя снять" style={{
+                          fontSize: 10, color: C.muted, opacity: 0.5, ...font,
+                        }}>
+                          🔒
+                        </span>
                       )}
                     </div>
                   </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,6 +45,7 @@ export interface AdminUser {
   lastLoginAt?: string;
   createdAt: string;
   isSuperadmin: boolean;
+  isSuperadminLocked?: boolean;
   stats?: AdminUserStats;
 }
 

--- a/specs/BACKLOG.md
+++ b/specs/BACKLOG.md
@@ -30,6 +30,8 @@
 | **gap-19** | **api-key-audit** | **fix / security** | **P1** | **done** | эта ветка |
 | **gap-20** | **config-change-audit** | **fix / security** | **P1** | **done** | эта ветка |
 | **gap-21** | **validation-error-audit** | **fix / security** | **P2** | **done** | эта ветка |
+| **gap-22** | **workspace-settings-always-accessible** | **feat / ux** | **P2** | **draft** | — |
+| **gap-23** | **superadmin-email-badge** | **fix** | **P1** | **draft** | — |
 
 ---
 

--- a/specs/BACKLOG.md
+++ b/specs/BACKLOG.md
@@ -30,8 +30,8 @@
 | **gap-19** | **api-key-audit** | **fix / security** | **P1** | **done** | эта ветка |
 | **gap-20** | **config-change-audit** | **fix / security** | **P1** | **done** | эта ветка |
 | **gap-21** | **validation-error-audit** | **fix / security** | **P2** | **done** | эта ветка |
-| **gap-22** | **workspace-settings-always-accessible** | **feat / ux** | **P2** | **draft** | — |
-| **gap-23** | **superadmin-email-badge** | **fix** | **P1** | **draft** | — |
+| **gap-22** | **workspace-settings-always-accessible** | **feat / ux** | **P2** | **done** | PR #159 |
+| **gap-23** | **superadmin-email-badge** | **fix** | **P1** | **done** | PR #159 |
 
 ---
 

--- a/specs/gaps/gap-22-workspace-settings-always-accessible.md
+++ b/specs/gaps/gap-22-workspace-settings-always-accessible.md
@@ -1,0 +1,142 @@
+---
+id: gap-22-workspace-settings-always-accessible
+type: gap-fix
+priority: P2
+status: draft
+source: ux-review-2026-05-08
+pr: —
+---
+
+# Spec: Кнопка «Настройки пространства» недоступна вне активного воркспейса
+
+## Intent
+Кнопка «Настройки workspace» в меню аватара отображается только при `current !== null`
+(т.е. только на страницах `/w/:slug/*`). На страницах `/workspaces`, `/my-tasks`,
+`/profile`, `/admin/users` кнопка скрыта — пользователь не может перейти
+к настройкам без предварительной навигации в нужный воркспейс.
+
+Дополнительно: метка «workspace» — англицизм, заменяем на «пространства».
+
+## Root Cause
+`AppLayout.tsx` — `UserMenu` получает `hasSettings={!!current}`.  
+Кнопка условна на `hasSettings`, которая `false` вне воркспейс-роутов.
+
+## Desired Behavior
+1. **В воркспейсе** (`current` задан) — кнопка кликает прямо на
+   `/w/{current.slug}/settings`.
+2. **Вне воркспейса** (`current` не задан) — кнопка открывает встроенный
+   пикер пространств, после выбора — навигация на `/w/{slug}/settings`.
+3. Пикер — раскрывающийся подсписок внутри дропдауна меню аватара (без отдельного модала).
+4. Кнопка переименована: «Настройки пространства» (вместо «Настройки workspace»).
+
+## BDD Scenarios
+
+```gherkin
+Feature: Кнопка «Настройки пространства» в меню аватара
+
+  Background:
+    Given пользователь аутентифицирован
+    And у пользователя есть пространства: "Разработка" (slug: dev), "Маркетинг" (slug: mkt)
+
+  Scenario: Кнопка видна на странице пространства и ведёт на его настройки
+    Given пользователь находится на странице /w/dev
+    When пользователь нажимает на аватарку
+    Then в меню отображается кнопка «Настройки пространства»
+    When пользователь нажимает «Настройки пространства»
+    Then пользователь перенаправляется на /w/dev/settings
+
+  Scenario: Кнопка видна на странице списка пространств и открывает пикер
+    Given пользователь находится на странице /workspaces
+    When пользователь нажимает на аватарку
+    Then в меню отображается кнопка «Настройки пространства»
+    When пользователь нажимает «Настройки пространства»
+    Then в дропдауне раскрывается список пространств пользователя
+    When пользователь выбирает «Маркетинг»
+    Then пользователь перенаправляется на /w/mkt/settings
+
+  Scenario: Кнопка видна на /my-tasks и открывает пикер
+    Given пользователь находится на странице /my-tasks
+    When пользователь нажимает на аватарку
+    Then в меню отображается кнопка «Настройки пространства»
+    When пользователь нажимает «Настройки пространства»
+    Then в дропдауне раскрывается список пространств пользователя
+
+  Scenario: У пользователя нет пространств — кнопка скрыта
+    Given у пользователя нет пространств
+    When пользователь нажимает на аватарку
+    Then кнопка «Настройки пространства» не отображается
+
+  Scenario: Пикер недоступен пользователю с ролью ниже OWNER в выбранном пространстве
+    Given пользователь является MEMBER (не OWNER) в пространстве "Разработка"
+    And пользователь находится на странице /workspaces
+    When пользователь нажимает «Настройки пространства» → выбирает «Разработка»
+    Then пользователь перенаправляется на /w/dev/settings
+    And WorkspaceSettingsPage отображает сообщение «Доступно только владельцу»
+```
+
+## SDD Contracts
+
+```typescript
+// AppLayout.tsx — UserMenu props (изменения)
+
+// Добавляем: workspaces (для пикера), убираем: hasSettings
+function UserMenu({
+  user, onLogout, onProfile, onSettings, workspaces, current,
+  onAdminUsers, isSuperadmin, navBg, border, textPrimary, textMuted, onClose
+}: {
+  // ...
+  workspaces: Array<{ id: string; name: string; slug: string }>;
+  current: { id: string; name: string; slug: string } | null;
+  onSettings: (slug: string) => void;  // принимает slug выбранного ws
+  // hasSettings: boolean;  ← удалить
+  // ...
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const hasWorkspaces = workspaces.length > 0;
+
+  function handleSettingsClick() {
+    if (current) {
+      onSettings(current.slug);    // прямая навигация
+    } else {
+      setPickerOpen(v => !v);      // раскрыть пикер
+    }
+  }
+  // ...
+  // Рендер кнопки (всегда, если hasWorkspaces):
+  {hasWorkspaces && (
+    <>
+      <button onClick={handleSettingsClick}>Настройки пространства</button>
+      {pickerOpen && !current && (
+        <WorkspacePickerInline
+          workspaces={workspaces}
+          onSelect={(slug) => { onSettings(slug); onClose(); }}
+        />
+      )}
+    </>
+  )}
+}
+
+// AppLayout.tsx — вызов UserMenu
+<UserMenu
+  workspaces={workspaces}
+  current={current}
+  onSettings={(slug) => navigate(`/w/${slug}/settings`)}
+  // hasSettings: удалить
+  // ...
+/>
+```
+
+## Scope
+- `frontend/src/components/AppLayout.tsx` — `UserMenu` + вызов
+
+## Out of Scope
+- Создание нового пространства из меню
+- Настройки пространства для MEMBER / VIEWER (редирект на существующую страницу — её дело)
+- Мобильная версия (адаптация по существующим breakpoints)
+
+## Acceptance Criteria
+- [ ] Кнопка «Настройки пространства» отображается на всех приватных страницах, если у пользователя есть ≥1 пространство
+- [ ] На воркспейс-странице — прямая навигация без пикера
+- [ ] Вне воркспейса — раскрывается пикер, после выбора — навигация
+- [ ] Лейбл «Настройки workspace» нигде не отображается (переименован)
+- [ ] E2E: smoke тест на оба сценария (с current / без current)

--- a/specs/gaps/gap-22-workspace-settings-always-accessible.md
+++ b/specs/gaps/gap-22-workspace-settings-always-accessible.md
@@ -2,9 +2,9 @@
 id: gap-22-workspace-settings-always-accessible
 type: gap-fix
 priority: P2
-status: draft
+status: done
 source: ux-review-2026-05-08
-pr: —
+pr: "#159"
 ---
 
 # Spec: Кнопка «Настройки пространства» недоступна вне активного воркспейса

--- a/specs/gaps/gap-23-superadmin-email-badge.md
+++ b/specs/gaps/gap-23-superadmin-email-badge.md
@@ -1,0 +1,96 @@
+---
+id: gap-23-superadmin-email-badge
+type: gap-fix
+priority: P1
+status: draft
+source: ux-review-2026-05-08
+pr: —
+---
+
+# Spec: Метка «Суперадмин» не отображается для SUPERADMIN_EMAIL аккаунта при isSuperadmin=false в БД
+
+## Intent
+`GET /api/admin/users` возвращает сырое значение `isSuperadmin` из БД. При этом
+`getMe()` правильно вычисляет производное значение:
+
+```ts
+const isSuperadmin = user.isSuperadmin || user.email === config.SUPERADMIN_EMAIL;
+```
+
+Если у аккаунта `SUPERADMIN_EMAIL` (default: `novak.pavel@flowtask.dev`) флаг
+в БД равен `false` — в таблице AdminUsersPage бейдж «Суперадмин» не показывается,
+хотя пользователь де-факто является суперадминистратором.
+
+Симптом: у novak.pavel@flowtask.dev нет бейджа, хотя у Дмитрия Пузырёва
+(которому был выдан флаг через UI) бейдж есть.
+
+## Root Cause
+`admin.service.ts` — `listUsers()` маппит сырой `isSuperadmin` без применения
+`SUPERADMIN_EMAIL` override.
+
+## BDD Scenarios
+
+```gherkin
+Feature: Метка суперадмина в списке пользователей
+
+  Background:
+    Given SUPERADMIN_EMAIL=novak.pavel@flowtask.dev
+
+  Scenario: SUPERADMIN_EMAIL аккаунт с isSuperadmin=false в БД — видит метку
+    Given в БД: novak.pavel@flowtask.dev имеет isSuperadmin=false
+    When GET /api/admin/users (запрос суперадмином)
+    Then в ответе объект с email=novak.pavel@flowtask.dev имеет isSuperadmin=true
+
+  Scenario: SUPERADMIN_EMAIL аккаунт с isSuperadmin=true в БД — видит метку
+    Given в БД: novak.pavel@flowtask.dev имеет isSuperadmin=true
+    When GET /api/admin/users
+    Then в ответе объект с email=novak.pavel@flowtask.dev имеет isSuperadmin=true
+
+  Scenario: Обычный пользователь с isSuperadmin=false — метки нет
+    Given в БД: user@flowtask.dev имеет isSuperadmin=false
+    And user@flowtask.dev != SUPERADMIN_EMAIL
+    When GET /api/admin/users
+    Then в ответе объект с email=user@flowtask.dev имеет isSuperadmin=false
+
+  Scenario: Кнопка «Снять» недоступна для собственного аккаунта суперадмина
+    Given суперадмин novak.pavel@flowtask.dev просматривает AdminUsersPage
+    Then для своей строки кнопка «Снять»/«Назначить» не отображается
+    # (usingу.id !== user?.id — уже реализовано, тест на регрессию)
+```
+
+## SDD Contracts
+
+```typescript
+// backend/src/modules/admin/admin.service.ts
+
+export async function listUsers() {
+  const raw = await prisma.user.findMany({ ... }); // без изменений
+
+  const superadminEmail = config.SUPERADMIN_EMAIL;
+
+  return raw.map(({ createdWorkspaces, _count, ...u }) => ({
+    ...u,
+    // Применяем тот же override, что и в getMe()
+    isSuperadmin: u.isSuperadmin || u.email === superadminEmail,
+    stats: {
+      workspaces: _count.createdWorkspaces,
+      boards:     createdWorkspaces.reduce((s, ws) => s + ws._count.boards, 0),
+      tasks:      _count.createdTasks,
+      members:    createdWorkspaces.reduce((s, ws) => s + ws._count.members, 0),
+    },
+  }));
+}
+```
+
+## Scope
+- `backend/src/modules/admin/admin.service.ts` — `listUsers()`, одна строка изменений
+
+## Out of Scope
+- Синхронизация флага в БД (seed/migration) — отдельная операция при необходимости
+- Логика `setUserSuperadmin()` — она не должна позволять снимать флаг с `SUPERADMIN_EMAIL`
+  (отдельный гэп если нужен)
+
+## Acceptance Criteria
+- [ ] `GET /api/admin/users` возвращает `isSuperadmin: true` для аккаунта с email = `SUPERADMIN_EMAIL`, даже если DB-флаг `false`
+- [ ] Для всех остальных пользователей поведение не изменилось
+- [ ] Тест: `admin.test.ts` — проверить ответ для `SUPERADMIN_EMAIL` аккаунта

--- a/specs/gaps/gap-23-superadmin-email-badge.md
+++ b/specs/gaps/gap-23-superadmin-email-badge.md
@@ -2,9 +2,9 @@
 id: gap-23-superadmin-email-badge
 type: gap-fix
 priority: P1
-status: draft
+status: done
 source: ux-review-2026-05-08
-pr: —
+pr: "#159"
 ---
 
 # Spec: Метка «Суперадмин» не отображается для SUPERADMIN_EMAIL аккаунта при isSuperadmin=false в БД


### PR DESCRIPTION
## Summary

- **gap-22 (feat/ux P2)**: «Настройки пространства» теперь всегда видна в аватар-меню
  - Переименовано «Настройки workspace» → «Настройки пространства»
  - При наличии активного воркспейса: прямой переход в `/w/:slug/settings`
  - При отсутствии (страница вне воркспейса): инлайн-пикер разворачивается прямо в меню
  - Дополнительный пункт «Другое пространство ›» для смены воркспейса не покидая текущий

- **gap-23 (fix P1)**: Бейдж «Суперадмин» теперь корректно отображается для `SUPERADMIN_EMAIL`
  - `listUsers()` в `admin.service.ts` не применял fallback `SUPERADMIN_EMAIL` (в отличие от `getMe()`)
  - Одна строка: `isSuperadmin: u.isSuperadmin || u.email === superadminEmail`

## Files changed

| File | Change |
|------|--------|
| `frontend/src/components/AppLayout.tsx` | `UserMenu` — убрана prop `hasSettings`, добавлены `workspaces`/`current`, инлайн-пикер |
| `backend/src/modules/admin/admin.service.ts` | `listUsers()` — SUPERADMIN_EMAIL fallback |
| `specs/gaps/gap-22-workspace-settings-always-accessible.md` | BDD+SDD спека (новая) |
| `specs/gaps/gap-23-superadmin-email-badge.md` | BDD+SDD спека (новая) |
| `specs/BACKLOG.md` | Добавлены строки gap-22/23 |

## Test plan

- [ ] Войти как `novak.pavel@flowtask.dev` → в аватар-меню видна «Настройки пространства» на любой странице
- [ ] Открыть страницу вне воркспейса (`/profile`, `/admin/users`) → кнопка с шевроном, клик разворачивает список воркспейсов
- [ ] Открыть страницу внутри воркспейса (`/w/:slug/board`) → кнопка ведёт напрямую, есть «Другое пространство ›»
- [ ] Нет воркспейсов → кнопка «Настройки пространства» скрыта
- [ ] `GET /api/admin/users` → `novak.pavel@flowtask.dev` возвращает `isSuperadmin: true` (даже если в БД `false`)
- [ ] Пользователь без `SUPERADMIN_EMAIL` и без DB-флага → `isSuperadmin: false`
- [ ] `tsc --noEmit` проходит без ошибок