### PR TITLE
fix(config): dotenv override existing env

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,5 +1,11 @@
-import 'dotenv/config';
+import { config as loadDotenv } from 'dotenv';
 import { z } from 'zod';
+
+// override: true — .env wins over inherited process env (PM2/daemon cache).
+// Production incident 2026-05-13: PM2 daemon cached a revoked GITHUB_ISSUES_TOKEN
+// in its env, dotenv (default no-override) silently ignored the new value in .env,
+// and only a full `pm2 kill` recovered. Override removes that footgun.
+loadDotenv({ override: true });
 
 const envSchema = z.object({
   DATABASE_URL: z.string(),


### PR DESCRIPTION
## Summary
- `dotenv` теперь грузится с `{ override: true }` — значения из `.env` всегда перекрывают унаследованное окружение процесса.
- Закрывает root-cause продакшен-инцидента 13.05.2026: после ротации `GITHUB_ISSUES_TOKEN` форма обратной связи продолжала отдавать 401 «Bad credentials», потому что PM2-демон кэшировал старый токен в собственном окружении, а `dotenv` по умолчанию не перезаписывает уже существующие переменные.

## Почему это важно
Без override любая замена секрета в `.env` требовала полного `pm2 kill && pm2 start` под чистым шеллом (`env -i`). С override достаточно обычного `pm2 restart` после правки `.env`.

## Что НЕ менял
- `__tests__/setup.ts` оставил как есть — там override может поломать env, который CI/vitest конфигурируют вручную.
- Зависимость `dotenv` уже в `package.json`, ничего не добавлял.

## Test plan
- [ ] CI зелёный (tsc + lint + unit/integration tests)
- [ ] На staging после мёрджа: подменить `GITHUB_ISSUES_TOKEN` в `.env`, `pm2 restart flowtask-api` (без `kill` + `env -i`) — форма обратной связи отправляет issue
- [ ] Никакой регресс с другими env-переменными (`DATABASE_URL`, `JWT_SECRET`, и т.д.)