### PR TITLE
feat(roadmap): bulk expand/collapse подзадач (#156)

### DIFF
--- a/frontend/src/components/RoadmapView.tsx
+++ b/frontend/src/components/RoadmapView.tsx
@@ -316,6 +316,29 @@ export default function RoadmapView({ boardId, statuses }: Props) {
     [statuses],
   );
 
+  // IDs всех parent-задач (тех, у которых есть дети) — для bulk expand/collapse
+  const isParent = (t: Task) => (t._count?.children ?? t.children?.length ?? 0) > 0;
+  const parentIds = useMemo(
+    () => new Set(tasks.filter(isParent).map(t => t.id)),
+    [tasks],
+  );
+  const hasAnyParents = parentIds.size > 0;
+  const hasAnyExpanded = useMemo(() => {
+    if (!hasAnyParents) return false;
+    for (const id of parentIds) if (expanded.has(id)) return true;
+    return false;
+  }, [parentIds, expanded, hasAnyParents]);
+
+  // Functional setter — immune to stale-closure under rapid clicks
+  const bulkToggleExpand = useCallback(() => {
+    if (!hasAnyParents) return;
+    setExpanded(prev => {
+      let anyExpanded = false;
+      for (const id of parentIds) if (prev.has(id)) { anyExpanded = true; break; }
+      return anyExpanded ? new Set<string>() : new Set(parentIds);
+    });
+  }, [hasAnyParents, parentIds]);
+
   const leftRef          = useRef<HTMLDivElement>(null);
   const rightRef         = useRef<HTMLDivElement>(null);
   const legendPopoverRef = useRef<HTMLDivElement>(null);
@@ -362,11 +385,12 @@ export default function RoadmapView({ boardId, statuses }: Props) {
       if (e.key === 'w' || e.key === 'W') setZoom('week');
       else if (e.key === 'm' || e.key === 'M') setZoom('month');
       else if (e.key === 'q' || e.key === 'Q') setZoom('quarter');
+      else if (e.key === 'e' || e.key === 'E') bulkToggleExpand();
       else if (e.key === 'Escape') setShowLegend(false);
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, []);
+  }, [bulkToggleExpand]);
 
   // ── Fetch ──────────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -380,7 +404,8 @@ export default function RoadmapView({ boardId, statuses }: Props) {
         const data = await boardsApi.getRoadmapTasks(boardId, from, to);
         if (active) {
           setTasks(data);
-          const ids = new Set(data.filter(t => (t._count?.children ?? 0) > 0).map(t => t.id));
+          // Same predicate as isParent — keep memo + initial state consistent
+          const ids = new Set(data.filter(t => (t._count?.children ?? t.children?.length ?? 0) > 0).map(t => t.id));
           setExpanded(ids);
           setLoading(false);
         }
@@ -696,6 +721,42 @@ export default function RoadmapView({ boardId, statuses }: Props) {
               <circle cx="7" cy="7" r="1.5" fill="currentColor"/>
             </svg>
           )}
+        </button>
+
+        {/* Bulk expand/collapse all parent tasks */}
+        <button
+          onClick={bulkToggleExpand}
+          disabled={!hasAnyParents}
+          title={
+            !hasAnyParents
+              ? 'Нет подзадач для разворачивания'
+              : hasAnyExpanded
+                ? 'Свернуть все подзадачи (E)'
+                : 'Развернуть все подзадачи (E)'
+          }
+          aria-pressed={hasAnyParents ? hasAnyExpanded : undefined}
+          aria-label={hasAnyExpanded ? 'Свернуть все подзадачи' : 'Развернуть все подзадачи'}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 5,
+            padding: '5px 10px', border: `1px solid ${c.border}`,
+            borderRadius: 7, background: 'transparent',
+            cursor: 'pointer',
+            fontFamily: '"Inter",system-ui,sans-serif', fontSize: 12, color: c.muted,
+            opacity: hasAnyParents ? 1 : 0.4,
+          }}
+        >
+          {hasAnyExpanded ? (
+            <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M3 5l4 4 4-4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M3 9l4 4 4-4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" opacity="0.4"/>
+            </svg>
+          ) : (
+            <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M3 9l4-4 4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M3 5l4-4 4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" opacity="0.4"/>
+            </svg>
+          )}
+          {hasAnyExpanded ? 'Свернуть все' : 'Развернуть все'}
         </button>
 
         <div style={{ flex: 1 }} />


### PR DESCRIPTION
## Summary

Кнопка-toggle в toolbar Roadmap для разворачивания/сворачивания всех parent-задач сразу. Клавиатурный shortcut: \`E\`.

Closes #156.

## Что внутри

Один файл — \`frontend/src/components/RoadmapView.tsx\`, +63 строки.

- \`parentIds\` useMemo — \`Set<string>\` всех task IDs с \`children > 0\`
- \`hasAnyExpanded\` useMemo — есть ли хотя бы один развёрнутый
- \`bulkToggleExpand\` useCallback с functional setter (immune to stale closure)
- Кнопка в toolbar после "Открыто", после "Развернуть все" → "Свернуть все"
- \`disabled\` когда на доске нет parent-задач + \`aria-pressed=undefined\` в этом состоянии
- Keyboard shortcut \`E\` встроен в существующий handler (W/M/Q/Escape)

## UX & A11y

- \`aria-label\`: «Свернуть все подзадачи» / «Развернуть все подзадачи»
- \`aria-pressed\` корректно отражает текущее состояние, отсутствует когда disabled
- \`title\`: "(E)" hint для discoverability
- Иконка: converging chevrons (collapse) ↔ diverging (expand)

## Smoke

| Сценарий | Результат |
|---|---|
| По умолчанию (с parent-задачами) | "Свернуть все", \`aria-pressed=true\`, expanded ✓ |
| Клик "Свернуть все" → "Развернуть все", 0 expanded rows | ✓ |
| Keyboard \`E\` toggle | ✓ |
| Без parent-задач | disabled, title "Нет подзадач для разворачивания" ✓ |

## Review

code-reviewer:
- HIGH: stale closure в bulkToggleExpand → **fixed** functional setter
- MED: aria-pressed когда disabled → **fixed** \`hasAnyParents ? hasAnyExpanded : undefined\`
- MED: расхождение predicate между memo и fetch initializer → **fixed**
- LOW: cursor:not-allowed избыточен → **fixed**

## Test plan

- [x] tsc clean
- [x] eslint clean (1 pre-existing warning не из этого PR)
- [x] vitest: 45 passed
- [x] Smoke вручную на /w/demo/boards/prd с временными подзадачами (cleaned up)
- [ ] Staging smoke — proper validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)