### PR TITLE
feat(workspace): корзина с soft-delete и 10-day retention (#157)

### DIFF
--- a/backend/src/__tests__/workspace-trash.test.ts
+++ b/backend/src/__tests__/workspace-trash.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { api, auth, registerUser, createWorkspace, cleanupTestData } from './helpers.js';
+import { addBusinessDays } from '../modules/workspaces/workspaces.service.js';
+import { prisma } from '../prisma/client.js';
+
+describe('Workspace Trash (#157)', () => {
+  let ownerToken: string;
+  let ownerId: string;
+  let memberToken: string;
+  let memberId: string;
+  let strangerToken: string;
+  let workspaceId: string;
+  let originalSlug: string;
+
+  beforeAll(async () => {
+    const owner = await registerUser();
+    const member = await registerUser();
+    const stranger = await registerUser();
+    ownerToken = owner.token;
+    ownerId = owner.userId;
+    memberToken = member.token;
+    memberId = member.userId;
+    strangerToken = stranger.token;
+
+    const ws = await createWorkspace(ownerToken);
+    workspaceId = ws.id;
+    originalSlug = ws.slug;
+
+    await api
+      .post(`/api/workspaces/${workspaceId}/members`)
+      .set(auth(ownerToken))
+      .send({ userId: memberId, role: 'MEMBER' });
+  });
+
+  afterAll(cleanupTestData);
+
+  describe('addBusinessDays helper', () => {
+    it('skips weekends — Friday + 1 business day = Monday', () => {
+      // 2026-05-15 is a Friday (UTC). +1 business day should be Monday 2026-05-18.
+      const fri = new Date('2026-05-15T00:00:00.000Z');
+      const result = addBusinessDays(fri, 1);
+      expect(result.getUTCDay()).toBe(1); // Monday
+      expect(result.toISOString().slice(0, 10)).toBe('2026-05-18');
+    });
+
+    it('skips weekends — Monday + 10 business days = 2 weeks later Monday', () => {
+      // 2026-05-04 is Monday. +10 business days = 2026-05-18 (next-next Monday).
+      const mon = new Date('2026-05-04T00:00:00.000Z');
+      const result = addBusinessDays(mon, 10);
+      expect(result.toISOString().slice(0, 10)).toBe('2026-05-18');
+    });
+  });
+
+  describe('DELETE /api/workspaces/:id — soft-delete', () => {
+    it('Owner soft-deletes workspace; it disappears from list', async () => {
+      const ws = await createWorkspace(ownerToken);
+
+      const deleteRes = await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      expect(deleteRes.status).toBe(200);
+
+      const listRes = await api.get('/api/workspaces').set(auth(ownerToken));
+      expect(listRes.body.find((w: { id: string }) => w.id === ws.id)).toBeUndefined();
+
+      const getRes = await api.get(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      expect(getRes.status).toBe(404);
+    });
+
+    it('Member cannot soft-delete workspace (403)', async () => {
+      const res = await api.delete(`/api/workspaces/${workspaceId}`).set(auth(memberToken));
+      expect(res.status).toBe(403);
+    });
+
+    it('frees the slug by suffixing it', async () => {
+      const ws = await createWorkspace(ownerToken);
+      const sameSlug = ws.slug;
+
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      // Creating new workspace with the original slug should succeed
+      const newRes = await api
+        .post('/api/workspaces')
+        .set(auth(ownerToken))
+        .send({ name: 'Replacement', slug: sameSlug });
+      expect(newRes.status).toBe(201);
+    });
+
+    it('sets purgeAt 10 business days in future', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      const row = await prisma.workspace.findUnique({
+        where: { id: ws.id },
+        select: { deletedAt: true, deletedBy: true, purgeAt: true },
+      });
+      expect(row?.deletedAt).not.toBeNull();
+      expect(row?.deletedBy).toBe(ownerId);
+      expect(row?.purgeAt).not.toBeNull();
+
+      const diffMs = row!.purgeAt!.getTime() - row!.deletedAt!.getTime();
+      const diffDays = diffMs / (24 * 60 * 60 * 1000);
+      // 10 business days = at least 12 calendar days, at most 16 (depending on weekend overlap)
+      expect(diffDays).toBeGreaterThanOrEqual(11);
+      expect(diffDays).toBeLessThanOrEqual(17);
+    });
+  });
+
+  describe('GET /api/workspaces/trash/list', () => {
+    it('Owner sees workspaces they own that are in trash', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      const res = await api.get('/api/workspaces/trash/list').set(auth(ownerToken));
+      expect(res.status).toBe(200);
+      expect(res.body.find((w: { id: string }) => w.id === ws.id)).toBeDefined();
+    });
+
+    it('Member sees workspace they deleted themselves', async () => {
+      const member = await registerUser();
+      const wsOwn = await createWorkspace(member.token);
+
+      // Member is Owner of their own workspace — they CAN delete it
+      await api.delete(`/api/workspaces/${wsOwn.id}`).set(auth(member.token));
+
+      const res = await api.get('/api/workspaces/trash/list').set(auth(member.token));
+      expect(res.body.find((w: { id: string }) => w.id === wsOwn.id)).toBeDefined();
+    });
+
+    it('Member of foreign workspace does NOT see it in their trash', async () => {
+      const ws = await createWorkspace(ownerToken);
+      // Add memberId to ws
+      await api
+        .post(`/api/workspaces/${ws.id}/members`)
+        .set(auth(ownerToken))
+        .send({ userId: memberId, role: 'MEMBER' });
+      // Owner deletes
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      const memberRes = await api.get('/api/workspaces/trash/list').set(auth(memberToken));
+      expect(memberRes.body.find((w: { id: string }) => w.id === ws.id)).toBeUndefined();
+    });
+
+    it('Stranger sees empty trash', async () => {
+      const res = await api.get('/api/workspaces/trash/list').set(auth(strangerToken));
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it('GET /trash/count returns same count as list', async () => {
+      const list = await api.get('/api/workspaces/trash/list').set(auth(ownerToken));
+      const count = await api.get('/api/workspaces/trash/count').set(auth(ownerToken));
+      expect(count.body.count).toBe(list.body.length);
+    });
+  });
+
+  describe('POST /api/workspaces/:id/restore', () => {
+    it('Owner restores workspace; it becomes accessible again', async () => {
+      const ws = await createWorkspace(ownerToken);
+      const slug = ws.slug;
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      const restoreRes = await api.post(`/api/workspaces/${ws.id}/restore`).set(auth(ownerToken));
+      expect(restoreRes.status).toBe(200);
+
+      // Workspace is accessible
+      const getRes = await api.get(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.slug).toBe(slug); // original slug restored
+    });
+
+    it('Member cannot restore workspace they did not delete (403)', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api
+        .post(`/api/workspaces/${ws.id}/members`)
+        .set(auth(ownerToken))
+        .send({ userId: memberId, role: 'MEMBER' });
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      const res = await api.post(`/api/workspaces/${ws.id}/restore`).set(auth(memberToken));
+      expect(res.status).toBe(403);
+    });
+
+    it('Returns 400 if workspace is not in trash', async () => {
+      const ws = await createWorkspace(ownerToken);
+      const res = await api.post(`/api/workspaces/${ws.id}/restore`).set(auth(ownerToken));
+      expect(res.status).toBe(400);
+    });
+
+    it('Suffixes slug if the original is now occupied', async () => {
+      const ws = await createWorkspace(ownerToken);
+      const slug = ws.slug;
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      // Someone takes the freed slug
+      await api.post('/api/workspaces').set(auth(ownerToken)).send({ name: 'Squatter', slug });
+
+      // Restore — slug must be suffixed
+      const restoreRes = await api.post(`/api/workspaces/${ws.id}/restore`).set(auth(ownerToken));
+      expect(restoreRes.status).toBe(200);
+
+      const getRes = await api.get(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      expect(getRes.body.slug).not.toBe(slug);
+      expect(getRes.body.slug).toMatch(new RegExp(`^${slug}-restored-`));
+    });
+  });
+
+  describe('DELETE /api/workspaces/:id/purge', () => {
+    it('Owner permanently deletes workspace from trash', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      const purgeRes = await api.delete(`/api/workspaces/${ws.id}/purge`).set(auth(ownerToken));
+      expect(purgeRes.status).toBe(200);
+
+      // Workspace fully gone from DB
+      const row = await prisma.workspace.findUnique({ where: { id: ws.id } });
+      expect(row).toBeNull();
+    });
+
+    it('Cannot purge a workspace that is NOT in trash (400)', async () => {
+      const ws = await createWorkspace(ownerToken);
+      const res = await api.delete(`/api/workspaces/${ws.id}/purge`).set(auth(ownerToken));
+      expect(res.status).toBe(400);
+    });
+
+    it('Non-owner cannot purge (403)', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api
+        .post(`/api/workspaces/${ws.id}/members`)
+        .set(auth(ownerToken))
+        .send({ userId: memberId, role: 'MEMBER' });
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+
+      const res = await api.delete(`/api/workspaces/${ws.id}/purge`).set(auth(memberToken));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('Access to soft-deleted workspace resources is denied', () => {
+    it('GET /workspaces/:id returns 404 when soft-deleted', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      const res = await api.get(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      expect(res.status).toBe(404);
+    });
+
+    it('Listing boards in deleted workspace returns 404', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      const res = await api.get(`/api/workspaces/${ws.id}/boards/by-prefix/X`).set(auth(ownerToken));
+      // Either 404 (workspace not found) or 404 (board not found within deleted ws)
+      expect([403, 404]).toContain(res.status);
+    });
+
+    it('PATCH on deleted workspace fails with 404', async () => {
+      const ws = await createWorkspace(ownerToken);
+      await api.delete(`/api/workspaces/${ws.id}`).set(auth(ownerToken));
+      const res = await api
+        .patch(`/api/workspaces/${ws.id}`)
+        .set(auth(ownerToken))
+        .send({ name: 'Renamed' });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -18,8 +18,10 @@ function parseIsoDate(s: string): Date {
 async function assertMember(workspaceId: string, userId: string) {
   const m = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId, userId } },
+    include: { workspace: { select: { deletedAt: true } } },
   });
   if (!m) throw new AppError(403, 'Access denied');
+  if (m.workspace.deletedAt !== null) throw new AppError(404, 'Workspace not found');
   return m;
 }
 

--- a/backend/src/modules/checklists/checklists.service.ts
+++ b/backend/src/modules/checklists/checklists.service.ts
@@ -3,8 +3,12 @@ import { AppError } from '../../shared/middleware/error-handler.js';
 import type { CreateChecklistDto, CreateChecklistItemDto, UpdateChecklistItemDto } from './checklists.dto.js';
 
 async function verifyTaskWrite(taskId: string, userId: string) {
-  const task = await prisma.task.findUnique({ where: { id: taskId }, include: { board: true } });
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    include: { board: { include: { workspace: { select: { deletedAt: true } } } } },
+  });
   if (!task) throw new AppError(404, 'Task not found');
+  if (task.board.workspace.deletedAt !== null) throw new AppError(404, 'Task not found');
 
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId: task.board.workspaceId, userId } },
@@ -17,9 +21,10 @@ async function verifyTaskWrite(taskId: string, userId: string) {
 async function verifyChecklistAccess(checklistId: string, userId: string) {
   const checklist = await prisma.checklist.findUnique({
     where: { id: checklistId },
-    include: { task: { include: { board: true } } },
+    include: { task: { include: { board: { include: { workspace: { select: { deletedAt: true } } } } } } },
   });
   if (!checklist) throw new AppError(404, 'Checklist not found');
+  if (checklist.task.board.workspace.deletedAt !== null) throw new AppError(404, 'Checklist not found');
 
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId: checklist.task.board.workspaceId, userId } },

--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -6,8 +6,12 @@ import type { CreateCommentDto, UpdateCommentDto } from './comments.dto.js';
 const AUTHOR_SELECT = { id: true, name: true, avatar: true } as const;
 
 async function verifyTaskAccess(taskId: string, userId: string) {
-  const task = await prisma.task.findUnique({ where: { id: taskId }, include: { board: true } });
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    include: { board: { include: { workspace: { select: { deletedAt: true } } } } },
+  });
   if (!task) throw new AppError(404, 'Task not found');
+  if (task.board.workspace.deletedAt !== null) throw new AppError(404, 'Task not found');
 
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId: task.board.workspaceId, userId } },
@@ -23,8 +27,12 @@ export async function listComments(
   limit = 50,
   offset = 0,
 ) {
-  const task = await prisma.task.findUnique({ where: { id: taskId }, include: { board: true } });
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    include: { board: { include: { workspace: { select: { deletedAt: true } } } } },
+  });
   if (!task) throw new AppError(404, 'Task not found');
+  if (task.board.workspace.deletedAt !== null) throw new AppError(404, 'Task not found');
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId: task.board.workspaceId, userId } },
   });
@@ -112,9 +120,10 @@ export async function updateComment(commentId: string, userId: string, dto: Upda
 export async function deleteComment(commentId: string, userId: string) {
   const comment = await prisma.comment.findUnique({
     where: { id: commentId },
-    include: { task: { include: { board: true } } },
+    include: { task: { include: { board: { include: { workspace: { select: { deletedAt: true } } } } } } },
   });
   if (!comment) throw new AppError(404, 'Comment not found');
+  if (comment.task.board.workspace.deletedAt !== null) throw new AppError(404, 'Comment not found');
 
   // Author or workspace owner can delete
   if (comment.authorId !== userId) {

--- a/backend/src/modules/integrations/integrations.service.ts
+++ b/backend/src/modules/integrations/integrations.service.ts
@@ -30,7 +30,7 @@ export async function deleteApiKey(userId: string, keyId: string) {
 
 export async function getWorkspacesForIntegration(userId: string) {
   const memberships = await prisma.workspaceMember.findMany({
-    where: { userId },
+    where: { userId, workspace: { deletedAt: null } },
     include: {
       workspace: {
         select: { id: true, name: true, slug: true },
@@ -46,7 +46,10 @@ const PULSAR_LABEL = { name: 'Pulsar', color: '#4F6EF7' } as const;
 export async function attachPulsarLabel(taskId: string, workspaceId: string, userId: string): Promise<void> {
   // Verify task belongs to workspaceId AND requesting user is a workspace member (IDOR guard)
   const [task, member] = await Promise.all([
-    prisma.task.findFirst({ where: { id: taskId, board: { workspaceId } }, select: { id: true } }),
+    prisma.task.findFirst({
+      where: { id: taskId, board: { workspaceId, workspace: { deletedAt: null } } },
+      select: { id: true },
+    }),
     prisma.workspaceMember.findUnique({ where: { workspaceId_userId: { workspaceId, userId } } }),
   ]);
   if (!task) throw new AppError(404, 'Task not found');
@@ -67,8 +70,10 @@ export async function attachPulsarLabel(taskId: string, workspaceId: string, use
 export async function getBoardsForIntegration(workspaceId: string, userId: string) {
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId, userId } },
+    include: { workspace: { select: { deletedAt: true } } },
   });
   if (!member) throw new AppError(403, 'Access denied');
+  if (member.workspace.deletedAt !== null) throw new AppError(404, 'Workspace not found');
 
   return prisma.board.findMany({
     where: { workspaceId },

--- a/backend/src/modules/labels/labels.service.ts
+++ b/backend/src/modules/labels/labels.service.ts
@@ -5,8 +5,10 @@ import type { CreateLabelDto, UpdateLabelDto } from './labels.dto.js';
 async function getWorkspaceMember(workspaceId: string, userId: string) {
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId, userId } },
+    include: { workspace: { select: { deletedAt: true } } },
   });
   if (!member) throw new AppError(403, 'Access denied');
+  if (member.workspace.deletedAt !== null) throw new AppError(404, 'Workspace not found');
   return member;
 }
 

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -5,7 +5,7 @@ export async function globalSearch(userId: string, q: string, limit = 5) {
   if (!term) return { tasks: [], boards: [], workspaces: [] };
 
   const memberships = await prisma.workspaceMember.findMany({
-    where: { userId },
+    where: { userId, workspace: { deletedAt: null } },
     select: { workspaceId: true, role: true },
   });
   if (memberships.length === 0) return { tasks: [], boards: [], workspaces: [] };

--- a/backend/src/modules/tasks/tasks.service.ts
+++ b/backend/src/modules/tasks/tasks.service.ts
@@ -10,7 +10,7 @@ async function getBoardWithAccess(boardId: string, userId: string) {
   const board = await prisma.board.findFirst({
     where: {
       id: boardId,
-      workspace: { members: { some: { userId } } },
+      workspace: { deletedAt: null, members: { some: { userId } } },
     },
     include: { workflow: { include: { statuses: { orderBy: { position: 'asc' } }, transitions: true } } },
   });
@@ -26,7 +26,7 @@ async function getTaskWithAccess(taskId: string, userId: string) {
   const task = await prisma.task.findFirst({
     where: {
       id: taskId,
-      board: { workspace: { members: { some: { userId } } } },
+      board: { workspace: { deletedAt: null, members: { some: { userId } } } },
     },
     include: { board: true },
   });
@@ -606,9 +606,9 @@ export async function bulkDeleteTasks(boardId: string, userId: string, ids: stri
 // ─── My Tasks (cross-workspace) ───────────────────────────────────────────────
 
 export async function listMyTasks(userId: string, filters: MyTasksFiltersDto) {
-  // All workspaces where user is a member
+  // All workspaces where user is a member (excluding soft-deleted)
   const memberships = await prisma.workspaceMember.findMany({
-    where: { userId },
+    where: { userId, workspace: { deletedAt: null } },
     select: { workspaceId: true },
   });
   const workspaceIds = memberships.map((m) => m.workspaceId);

--- a/backend/src/modules/workflows/workflows.service.ts
+++ b/backend/src/modules/workflows/workflows.service.ts
@@ -67,8 +67,12 @@ async function generateTransitions(workflowId: string) {
 // ─── Workspace access check ───────────────────────────────────────────────────
 
 async function assertWorkspaceAccess(workflowId: string, userId: string) {
-  const workflow = await prisma.workflow.findUnique({ where: { id: workflowId } });
+  const workflow = await prisma.workflow.findUnique({
+    where: { id: workflowId },
+    include: { workspace: { select: { deletedAt: true } } },
+  });
   if (!workflow) throw new AppError(404, 'Workflow not found');
+  if (workflow.workspace.deletedAt !== null) throw new AppError(404, 'Workflow not found');
 
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId: workflow.workspaceId, userId } },
@@ -88,8 +92,10 @@ async function assertWorkspaceOwner(workflowId: string, userId: string) {
 export async function listWorkflows(workspaceId: string, userId: string) {
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId, userId } },
+    include: { workspace: { select: { deletedAt: true } } },
   });
   if (!member) throw new AppError(403, 'Access denied');
+  if (member.workspace.deletedAt !== null) throw new AppError(404, 'Workspace not found');
 
   return prisma.workflow.findMany({
     where: { workspaceId },
@@ -104,8 +110,10 @@ export async function listWorkflows(workspaceId: string, userId: string) {
 export async function createWorkflow(workspaceId: string, userId: string, dto: CreateWorkflowDto) {
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId, userId } },
+    include: { workspace: { select: { deletedAt: true } } },
   });
   if (!member) throw new AppError(403, 'Access denied');
+  if (member.workspace.deletedAt !== null) throw new AppError(404, 'Workspace not found');
   if (member.role !== 'OWNER') throw new AppError(403, 'Only workspace owners can create workflows');
 
   const workflow = await prisma.workflow.create({

--- a/backend/src/modules/workspaces/workspaces.router.ts
+++ b/backend/src/modules/workspaces/workspaces.router.ts
@@ -20,6 +20,26 @@ router.get('/', authHandler(async (req, res) => {
   res.json(await ws.listMyWorkspaces(req.user!.userId));
 }));
 
+// ─── Trash ────────────────────────────────────────────────────────────────────
+
+router.get('/trash/list', authHandler(async (req, res) => {
+  res.json(await ws.listTrash(req.user!.userId));
+}));
+
+router.get('/trash/count', authHandler(async (req, res) => {
+  res.json({ count: await ws.countTrash(req.user!.userId) });
+}));
+
+router.post('/:id/restore', authHandler(async (req, res) => {
+  await ws.restoreWorkspace(String(req.params.id), req.user!.userId);
+  res.json({ message: 'Workspace restored' });
+}));
+
+router.delete('/:id/purge', authHandler(async (req, res) => {
+  await ws.purgeWorkspace(String(req.params.id), req.user!.userId);
+  res.json({ message: 'Workspace permanently deleted' });
+}));
+
 router.post('/', validate(createWorkspaceDto), authHandler(async (req, res) => {
   res.status(201).json(await ws.createWorkspace(req.user!.userId, req.body));
 }));

--- a/backend/src/modules/workspaces/workspaces.service.ts
+++ b/backend/src/modules/workspaces/workspaces.service.ts
@@ -2,7 +2,13 @@ import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { createDefaultWorkflow } from '../workflows/workflows.service.js';
 import { emitMemberAddedNotification } from '../notifications/notifications.service.js';
+import { auditLog } from '../../shared/utils/audit-logger.js';
 import type { CreateWorkspaceDto, UpdateWorkspaceDto, AddMemberDto, UpdateMemberRoleDto, InviteByEmailDto } from './workspaces.dto.js';
+
+// Match the deletion suffix: __deleted_<13-digit unix-millis>
+// Anchored to exactly 13 digits to avoid corrupting legitimate slugs that may
+// contain "__deleted_" followed by digits with a different length.
+const DELETED_SLUG_SUFFIX = /__deleted_\d{13}$/;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -29,8 +35,10 @@ export async function logEvent(
 async function assertMember(workspaceId: string, userId: string) {
   const member = await prisma.workspaceMember.findUnique({
     where: { workspaceId_userId: { workspaceId, userId } },
+    include: { workspace: { select: { deletedAt: true } } },
   });
   if (!member) throw new AppError(403, 'Access denied');
+  if (member.workspace.deletedAt !== null) throw new AppError(404, 'Workspace not found');
   return member;
 }
 
@@ -40,11 +48,24 @@ async function assertOwner(workspaceId: string, userId: string) {
   return member;
 }
 
+/**
+ * Like assertMember, but allows access to soft-deleted workspaces.
+ * Used by trash operations (list/restore/purge) which need to see deleted workspaces.
+ */
+async function assertMemberIncludingDeleted(workspaceId: string, userId: string) {
+  const member = await prisma.workspaceMember.findUnique({
+    where: { workspaceId_userId: { workspaceId, userId } },
+    include: { workspace: true },
+  });
+  if (!member) throw new AppError(403, 'Access denied');
+  return member;
+}
+
 // ─── Workspace CRUD ──────────────────────────────────────────────────────────
 
 export async function listMyWorkspaces(userId: string) {
   const memberships = await prisma.workspaceMember.findMany({
-    where: { userId },
+    where: { userId, workspace: { deletedAt: null } },
     include: {
       workspace: {
         include: {
@@ -82,7 +103,11 @@ export async function listMyWorkspaces(userId: string) {
 }
 
 export async function createWorkspace(userId: string, dto: CreateWorkspaceDto) {
-  const slugExists = await prisma.workspace.findUnique({ where: { slug: dto.slug } });
+  // Active workspaces enforce slug uniqueness;
+  // soft-deleted workspaces have suffixed slugs so don't conflict.
+  const slugExists = await prisma.workspace.findFirst({
+    where: { slug: dto.slug, deletedAt: null },
+  });
   if (slugExists) throw new AppError(409, 'Slug already taken');
 
   const workspace = await prisma.workspace.create({
@@ -167,9 +192,172 @@ export async function updateWorkspace(workspaceId: string, userId: string, dto: 
   return updated;
 }
 
+// ─── Soft-delete (Trash) ──────────────────────────────────────────────────
+// Retention: 10 business days (skip Sat/Sun). After purgeAt expires,
+// the background scheduler hard-deletes the workspace via cascade.
+
+const BUSINESS_DAYS_RETENTION = 10;
+
+export function addBusinessDays(start: Date, days: number): Date {
+  const d = new Date(start);
+  let remaining = days;
+  while (remaining > 0) {
+    d.setUTCDate(d.getUTCDate() + 1);
+    const dow = d.getUTCDay(); // 0=Sun, 6=Sat
+    if (dow !== 0 && dow !== 6) remaining -= 1;
+  }
+  return d;
+}
+
 export async function deleteWorkspace(workspaceId: string, userId: string) {
   await assertOwner(workspaceId, userId);
+
+  const purgeAt = addBusinessDays(new Date(), BUSINESS_DAYS_RETENTION);
+  const current = await prisma.workspace.findUniqueOrThrow({
+    where: { id: workspaceId },
+    select: { slug: true },
+  });
+
+  // Free the slug by suffixing it; restore reverses this.
+  // Original slug is preserved in a sibling field via the meta event log.
+  const suffixedSlug = `${current.slug}__deleted_${Date.now()}`;
+
+  await prisma.workspace.update({
+    where: { id: workspaceId },
+    data: { deletedAt: new Date(), deletedBy: userId, purgeAt, slug: suffixedSlug },
+  });
+
+  await logEvent(workspaceId, userId, 'workspace_soft_deleted', 'workspace', workspaceId, {
+    originalSlug: current.slug,
+    purgeAt: purgeAt.toISOString(),
+  });
+}
+
+export async function restoreWorkspace(workspaceId: string, userId: string) {
+  const member = await assertMemberIncludingDeleted(workspaceId, userId);
+  const ws = member.workspace;
+  if (ws.deletedAt === null) throw new AppError(400, 'Workspace is not in trash');
+  // Owner check first (clearer semantics); fall back to deletedBy when caller is not Owner.
+  if (member.role !== 'OWNER' && ws.deletedBy !== userId) {
+    throw new AppError(403, 'Only the workspace owner or the user who deleted it can restore');
+  }
+
+  // Strip the __deleted_<13-digit-ts> suffix to restore the original slug.
+  const originalSlug = ws.slug.replace(DELETED_SLUG_SUFFIX, '');
+
+  // Resolve slug atomically: try original, then retry with -restored-<ts> on P2002.
+  // This closes the find/update race where another workspace claims the slug between
+  // the conflict check and the update (TS H-3).
+  const tryUpdate = async (candidateSlug: string) =>
+    prisma.workspace.update({
+      where: { id: workspaceId },
+      data: { deletedAt: null, deletedBy: null, purgeAt: null, slug: candidateSlug },
+    });
+
+  let restoredSlug = originalSlug;
+  try {
+    await tryUpdate(originalSlug);
+  } catch (err: unknown) {
+    // P2002 = unique constraint violation on slug
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== 'P2002') throw err;
+    restoredSlug = `${originalSlug}-restored-${Date.now().toString(36)}`;
+    await tryUpdate(restoredSlug);
+  }
+
+  await logEvent(workspaceId, userId, 'workspace_restored', 'workspace', workspaceId, {
+    slug: restoredSlug,
+  });
+}
+
+export async function purgeWorkspace(workspaceId: string, userId: string) {
+  const member = await assertMemberIncludingDeleted(workspaceId, userId);
+  const ws = member.workspace;
+  if (ws.deletedAt === null) throw new AppError(400, 'Workspace must be in trash before permanent delete');
+  if (member.role !== 'OWNER') throw new AppError(403, 'Only the workspace owner can permanently delete');
+
+  // Write platform-level audit BEFORE cascade delete — WorkspaceEvent rows are erased
+  // when the workspace is purged, so internal event log won't survive.
+  void auditLog({
+    actorId: userId,
+    action: 'workspace.purge',
+    targetId: workspaceId,
+    result: 'SUCCESS',
+    meta: { name: ws.name, deletedAt: ws.deletedAt?.toISOString() ?? null },
+  });
+
+  // Cascade onDelete will remove boards, tasks, members, workflows, labels, events.
   await prisma.workspace.delete({ where: { id: workspaceId } });
+}
+
+export async function listTrash(userId: string) {
+  // Push the Owner-or-deleter filter into the DB query (avoids fetching irrelevant rows).
+  const memberships = await prisma.workspaceMember.findMany({
+    where: {
+      userId,
+      workspace: { deletedAt: { not: null } },
+      OR: [
+        { role: 'OWNER' },
+        { workspace: { deletedBy: userId } },
+      ],
+    },
+    include: {
+      workspace: {
+        include: {
+          deletedByUser: { select: { id: true, name: true, avatar: true } },
+          _count: { select: { boards: true } },
+        },
+      },
+    },
+    orderBy: { workspace: { deletedAt: 'desc' } },
+  });
+
+  return memberships.map((m) => ({
+    id: m.workspace.id,
+    name: m.workspace.name,
+    slug: m.workspace.slug.replace(DELETED_SLUG_SUFFIX, ''),
+    description: m.workspace.description,
+    deletedAt: m.workspace.deletedAt,
+    deletedBy: m.workspace.deletedByUser,
+    purgeAt: m.workspace.purgeAt,
+    role: m.role,
+    boardCount: m.workspace._count.boards,
+  }));
+}
+
+export async function countTrash(userId: string): Promise<number> {
+  // Used by Profile dropdown badge. Filter in DB to avoid full membership fetch.
+  return prisma.workspaceMember.count({
+    where: {
+      userId,
+      workspace: { deletedAt: { not: null } },
+      OR: [
+        { role: 'OWNER' },
+        { workspace: { deletedBy: userId } },
+      ],
+    },
+  });
+}
+
+/**
+ * Background purge: hard-delete workspaces whose purgeAt has passed.
+ *
+ * Uses deleteMany for atomicity — safe under multi-instance deployments where
+ * two scheduler ticks could otherwise race on the same rows (see issue #157 review C-2).
+ */
+export async function purgeExpired(): Promise<{ purged: number; ids: string[] }> {
+  // Fetch IDs first for forensic logging, then deleteMany with the same filter.
+  // deleteMany itself is idempotent: a second call simply matches 0 rows.
+  const expired = await prisma.workspace.findMany({
+    where: { deletedAt: { not: null }, purgeAt: { lte: new Date() } },
+    select: { id: true },
+  });
+  if (expired.length === 0) return { purged: 0, ids: [] };
+
+  const result = await prisma.workspace.deleteMany({
+    where: { deletedAt: { not: null }, purgeAt: { lte: new Date() } },
+  });
+  return { purged: result.count, ids: expired.map(w => w.id) };
 }
 
 // ─── Members ─────────────────────────────────────────────────────────────────

--- a/backend/src/prisma/migrations/20260518095615_add_workspace_soft_delete/migration.sql
+++ b/backend/src/prisma/migrations/20260518095615_add_workspace_soft_delete/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "deletedBy" TEXT,
+ADD COLUMN     "purgeAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "workspaces_deletedAt_idx" ON "workspaces"("deletedAt");
+
+-- AddForeignKey
+ALTER TABLE "workspaces" ADD CONSTRAINT "workspaces_deletedBy_fkey" FOREIGN KEY ("deletedBy") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   apiKeys              ApiKey[]
   workspaceMemberships WorkspaceMember[]
   createdWorkspaces    Workspace[]       @relation("WorkspaceCreator")
+  deletedWorkspaces    Workspace[]       @relation("WorkspaceDeleter")
   createdTasks         Task[]            @relation("taskCreator")
   assignedTasks        Task[]            @relation("taskAssignee")
   comments             Comment[]
@@ -124,13 +125,20 @@ model Workspace {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  creator   User              @relation("WorkspaceCreator", fields: [creatorId], references: [id])
-  members   WorkspaceMember[]
-  workflows Workflow[]
-  boards    Board[]
-  labels    Label[]
-  events    WorkspaceEvent[]
+  // Soft-delete (Trash) — see issue #157
+  deletedAt DateTime?
+  deletedBy String?
+  purgeAt   DateTime?
 
+  creator     User              @relation("WorkspaceCreator", fields: [creatorId], references: [id])
+  deletedByUser User?           @relation("WorkspaceDeleter", fields: [deletedBy], references: [id])
+  members     WorkspaceMember[]
+  workflows   Workflow[]
+  boards      Board[]
+  labels      Label[]
+  events      WorkspaceEvent[]
+
+  @@index([deletedAt])
   @@map("workspaces")
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,7 @@
 import { createApp } from './app.js';
 import { config } from './config.js';
 import { auditLog } from './shared/utils/audit-logger.js';
+import { startTrashScheduler } from './services/trash-scheduler.js';
 
 const app = createApp();
 
@@ -12,4 +13,5 @@ app.listen(config.PORT, () => {
     result: 'SUCCESS',
     meta: { port: config.PORT, env: config.NODE_ENV },
   });
+  startTrashScheduler();
 });

--- a/backend/src/services/trash-scheduler.ts
+++ b/backend/src/services/trash-scheduler.ts
@@ -1,0 +1,30 @@
+import { purgeExpired } from '../modules/workspaces/workspaces.service.js';
+import { logger } from '../shared/utils/logger.js';
+
+const PURGE_INTERVAL_MS = 60 * 60 * 1000; // hourly
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+async function runOnce(): Promise<void> {
+  try {
+    const { purged, ids } = await purgeExpired();
+    if (purged > 0) logger.info('trash_purge_completed', { purged, ids });
+  } catch (err: unknown) {
+    logger.error('trash_purge_failed', { error: String(err) });
+  }
+}
+
+export function startTrashScheduler(): void {
+  if (timer) return;
+  void runOnce();
+  timer = setInterval(() => { void runOnce(); }, PURGE_INTERVAL_MS);
+  // Allow Node to exit if this is the only outstanding timer (esp. for integration tests).
+  timer.unref?.();
+}
+
+export function stopTrashScheduler(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/backend/src/shared/middleware/workspace-mfa-guard.ts
+++ b/backend/src/shared/middleware/workspace-mfa-guard.ts
@@ -10,10 +10,11 @@ const MFA_AMR_VALUES = ['totp', 'otp', 'mfa', 'hwk', 'swk'];
 async function enforceMfa(workspaceId: string, req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
   const workspace = await prisma.workspace.findUnique({
     where: { id: workspaceId },
-    select: { requireMfa: true },
+    select: { requireMfa: true, deletedAt: true },
   });
 
-  if (!workspace || !workspace.requireMfa) return next();
+  // Soft-deleted workspaces: skip MFA gate; downstream handler will 404.
+  if (!workspace || workspace.deletedAt !== null || !workspace.requireMfa) return next();
 
   const userId = req.user!.userId;
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import MyTasksPage from './pages/MyTasksPage';
 import WorkspaceSettingsPage from './pages/WorkspaceSettingsPage';
 import BoardSettingsPage from './pages/BoardSettingsPage';
 import ProfilePage from './pages/ProfilePage';
+import TrashPage from './pages/TrashPage';
 import AdminUsersPage from './pages/AdminUsersPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
 import RoadmapsPage from './pages/RoadmapsPage';
@@ -170,6 +171,7 @@ export default function App() {
           <Route path="/w/:slug/settings" element={<PrivateRoute><WorkspaceSettingsPage /></PrivateRoute>} />
           <Route path="/my-tasks" element={<PrivateRoute><MyTasksPage /></PrivateRoute>} />
           <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />
+          <Route path="/trash" element={<PrivateRoute><TrashPage /></PrivateRoute>} />
           <Route path="/admin/users" element={<PrivateRoute><AdminUsersPage /></PrivateRoute>} />
           {/* Legacy — kept for now */}
           <Route path="/home" element={<PrivateRoute><HomePage /></PrivateRoute>} />

--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -78,3 +78,36 @@ export async function getWorkspaceHistory(
   );
   return data;
 }
+
+// ─── Trash (issue #157) ─────────────────────────────────────────────────────────
+
+export interface TrashedWorkspace {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string | null;
+  // Filtered server-side to non-null, but DB allows null — type defensively.
+  deletedAt: string | null;
+  deletedBy: { id: string; name: string; avatar?: string } | null;
+  purgeAt: string | null;
+  role: 'OWNER' | 'MEMBER' | 'VIEWER';
+  boardCount: number;
+}
+
+export async function listTrash(): Promise<TrashedWorkspace[]> {
+  const { data } = await api.get<TrashedWorkspace[]>('/workspaces/trash/list');
+  return data;
+}
+
+export async function countTrash(): Promise<number> {
+  const { data } = await api.get<{ count: number }>('/workspaces/trash/count');
+  return data.count;
+}
+
+export async function restoreWorkspace(workspaceId: string): Promise<void> {
+  await api.post(`/workspaces/${workspaceId}/restore`);
+}
+
+export async function purgeWorkspace(workspaceId: string): Promise<void> {
+  await api.delete(`/workspaces/${workspaceId}/purge`);
+}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -28,15 +28,17 @@ function GridIcon() {
 }
 
 // ─── User dropdown menu ───────────────────────────────────────────────────────
-function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, onAdminUsers, isSuperadmin, navBg, border, textPrimary, textMuted, onClose }: {
+function UserMenu({ user, onLogout, onProfile, onTrash, onSettings, workspaces, current, onAdminUsers, isSuperadmin, trashCount, navBg, border, textPrimary, textMuted, onClose }: {
   user: { name: string; email?: string };
   onLogout: () => void;
   onProfile: () => void;
+  onTrash: () => void;
   onSettings: (slug: string) => void;
   workspaces: Array<{ id: string; name: string; slug: string }>;
   current: { id: string; name: string; slug: string } | null;
   onAdminUsers: () => void;
   isSuperadmin: boolean;
+  trashCount: number;
   navBg: string; border: string; textPrimary: string; textMuted: string;
   onClose: () => void;
 }) {
@@ -84,6 +86,27 @@ function UserMenu({ user, onLogout, onProfile, onSettings, workspaces, current, 
         fontSize: 13, padding: '8px 16px', textAlign: 'left', width: '100%',
       }}>
         Профиль
+      </button>
+      <button
+        role="menuitem"
+        onClick={() => { onTrash(); onClose(); }}
+        aria-label={trashCount > 0 ? `Корзина (${trashCount})` : 'Корзина'}
+        style={{
+          alignItems: 'center', background: 'none', border: 'none', borderRadius: 6, color: textMuted,
+          cursor: 'pointer', display: 'flex', justifyContent: 'space-between',
+          fontFamily: '"Inter", system-ui, sans-serif',
+          fontSize: 13, padding: '8px 16px', textAlign: 'left', width: '100%',
+        }}
+      >
+        <span>Корзина</span>
+        {trashCount > 0 && (
+          <span aria-hidden="true" style={{
+            background: '#3D54E6', color: '#fff', fontSize: 12, fontWeight: 600,
+            borderRadius: 10, padding: '1px 8px', minWidth: 20, textAlign: 'center',
+          }}>
+            {trashCount}
+          </span>
+        )}
       </button>
       {isSuperadmin && (
         <button role="menuitem" onClick={() => { onAdminUsers(); onClose(); }} style={{
@@ -266,6 +289,12 @@ export default function AppLayout({ children }: Props) {
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [wsMenuOpen, setWsMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const trashCount = useWorkspaceStore(s => s.trashCount);
+  const refreshTrashCount = useWorkspaceStore(s => s.refreshTrashCount);
+
+  // Initial fetch only — store is then updated by explicit calls from TrashPage
+  // (after restore / purge) and by the main delete-workspace flow.
+  useEffect(() => { void refreshTrashCount(); }, [refreshTrashCount]);
 
   // ── Design tokens ──────────────────────────────────────────────────────────
   const isDark = mode !== 'light';
@@ -517,11 +546,13 @@ export default function AppLayout({ children }: Props) {
               user={user}
               onLogout={handleLogout}
               onProfile={() => navigate('/profile')}
+              onTrash={() => navigate('/trash')}
               onSettings={(slug) => navigate(`/w/${slug}/settings`)}
               workspaces={workspaces}
               current={current}
               onAdminUsers={() => navigate('/admin/users')}
               isSuperadmin={!!user.isSuperadmin}
+              trashCount={trashCount}
               navBg={navBg} border={navBorder} textPrimary={wsSelectorText} textMuted={tabIdleText}
               onClose={() => setUserMenuOpen(false)}
             />

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -1,0 +1,499 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { message } from 'antd';
+import { useThemeStore } from '../store/theme.store';
+import { useWorkspaceStore } from '../store/workspace.store';
+import { useBreakpoint } from '../utils/useBreakpoint';
+import { plural, DAYS_FORMS, BOARDS_FORMS, ELEMENTS_FORMS } from '../utils/plural';
+import * as workspacesApi from '../api/workspaces';
+import type { TrashedWorkspace } from '../api/workspaces';
+
+// ── Design tokens ──────────────────────────────────────────────────────────────
+type C = Record<string, string>;
+
+const DARK: C = {
+  bg: '#03050F', cardBg: '#0F1320', border: '#1C2236',
+  text: '#E2E8F8', muted: '#8B949E', label: '#8B95B0',
+  accent: '#4F6EF7', danger: '#F87171', dangerBg: 'rgba(239,68,68,0.08)',
+  warn: '#FBBF24', warnBg: 'rgba(251,191,36,0.10)',
+  hoverBg: '#131729',
+};
+const LIGHT: C = {
+  bg: '#F5F3FF', cardBg: '#FDFCFF', border: '#E8E5F0',
+  text: '#1A1A2E', muted: '#6B7194', label: '#6B7194',
+  accent: '#4F6EF7', danger: '#EF4444', dangerBg: '#FEE2E2',
+  warn: '#D97706', warnBg: '#FFFBEB',
+  hoverBg: '#F0EEF8',
+};
+
+const INTER = '"Inter", system-ui, sans-serif';
+
+function avatarInitials(name: string): string {
+  return name.split(/\s+/).map(w => w[0]).slice(0, 2).join('').toUpperCase() || '?';
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('ru-RU', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function daysUntil(iso: string): number {
+  const diffMs = new Date(iso).getTime() - Date.now();
+  // floor: "1 hour left" displays as "Сегодня", not "Через 1 день"
+  return Math.max(0, Math.floor(diffMs / (24 * 60 * 60 * 1000)));
+}
+
+export default function TrashPage() {
+  const navigate = useNavigate();
+  const mode = useThemeStore(s => s.mode);
+  const c = mode === 'light' ? LIGHT : DARK;
+  const bp = useBreakpoint();
+  const reloadWorkspaces = useWorkspaceStore(s => s.load);
+  const refreshTrashCount = useWorkspaceStore(s => s.refreshTrashCount);
+
+  const [items, setItems] = useState<TrashedWorkspace[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionInFlight, setActionInFlight] = useState<string | null>(null);
+  const [confirmPurge, setConfirmPurge] = useState<TrashedWorkspace | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await workspacesApi.listTrash();
+      setItems(data);
+    } catch {
+      setError('Не удалось загрузить корзину');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const handleRestore = useCallback(async (ws: TrashedWorkspace) => {
+    setActionInFlight(ws.id);
+    try {
+      await workspacesApi.restoreWorkspace(ws.id);
+      setItems(prev => prev.filter(w => w.id !== ws.id));
+      // Reload + refresh count are best-effort — failure shouldn't surface as
+      // "restore failed" because the restore itself succeeded.
+      void reloadWorkspaces().catch(() => { /* main list refresh is best-effort */ });
+      void refreshTrashCount().catch(() => { /* counter refresh is best-effort */ });
+      message.success(`«${ws.name}» восстановлено`);
+    } catch {
+      message.error('Не удалось восстановить');
+    } finally {
+      setActionInFlight(null);
+    }
+  }, [reloadWorkspaces, refreshTrashCount]);
+
+  const closeConfirm = useCallback(() => setConfirmPurge(null), []);
+
+  const handlePurgeConfirmed = useCallback(async (ws: TrashedWorkspace) => {
+    setActionInFlight(ws.id);
+    try {
+      await workspacesApi.purgeWorkspace(ws.id);
+      setItems(prev => prev.filter(w => w.id !== ws.id));
+      void refreshTrashCount().catch(() => { /* best-effort */ });
+      message.success(`«${ws.name}» удалено навсегда`);
+      setConfirmPurge(null);
+    } catch {
+      message.error('Не удалось удалить');
+    } finally {
+      setActionInFlight(null);
+    }
+  }, [refreshTrashCount]);
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+  return (
+    <div style={{
+      background: c.bg, minHeight: '100%',
+      padding: bp === 'mobile' ? '20px 16px' : '32px 40px',
+      fontFamily: INTER,
+    }}>
+      <BackButton color={c.muted} onClick={() => {
+        if (window.history.length > 1) navigate(-1);
+        else navigate('/workspaces');
+      }} />
+
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 6 }}>
+        <h1 id="trash-title" style={{ color: c.text, fontFamily: INTER, fontSize: 28, fontWeight: 700, margin: 0 }}>
+          Корзина
+        </h1>
+        {!loading && (
+          <span aria-live="polite" style={{ color: c.muted, fontSize: 13 }}>
+            {items.length === 0
+              ? 'пусто'
+              : `${items.length} ${plural(items.length, ELEMENTS_FORMS)}`}
+          </span>
+        )}
+      </div>
+      <p id="trash-desc" style={{ color: c.muted, fontSize: 13, marginTop: 0, marginBottom: 24 }}>
+        Удалённые воркспейсы хранятся 10 рабочих дней. После этого срока они удаляются навсегда вместе со всеми досками и задачами.
+      </p>
+
+      {/* Loading */}
+      {loading && (
+        <div role="status" aria-live="polite" style={{ display: 'grid', gap: 12 }}>
+          <span style={{ position: 'absolute', left: -9999, top: -9999 }}>Загрузка корзины…</span>
+          {[1, 2, 3].map(i => (
+            <div key={i} style={{
+              background: c.cardBg, border: `1px solid ${c.border}`, borderRadius: 10,
+              height: 84, opacity: 0.6, animation: 'tp-pulse 1.4s ease-in-out infinite',
+            }} />
+          ))}
+        </div>
+      )}
+
+      {!loading && error && (
+        <div role="alert" style={{
+          background: c.dangerBg, border: `1px solid ${c.danger}`, borderRadius: 10,
+          padding: 16, color: c.danger, fontSize: 13,
+        }}>
+          {error}
+          <button
+            onClick={() => void load()}
+            className="tp-btn"
+            style={{
+              background: 'transparent', border: `1px solid ${c.danger}`, borderRadius: 6,
+              color: c.danger, cursor: 'pointer', fontFamily: INTER, fontSize: 12,
+              marginLeft: 12, padding: '4px 10px',
+            }}
+          >
+            Попробовать снова
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <div style={{
+          background: c.cardBg, border: `1px solid ${c.border}`, borderRadius: 12,
+          padding: 40, textAlign: 'center',
+        }}>
+          <div style={{ fontSize: 40, marginBottom: 8 }} aria-hidden="true">🗑</div>
+          <div style={{ color: c.text, fontSize: 15, fontWeight: 600, marginBottom: 4 }}>
+            Корзина пуста
+          </div>
+          <div style={{ color: c.muted, fontSize: 13, marginBottom: 16 }}>
+            Удалённые воркспейсы появятся здесь
+          </div>
+          <button
+            onClick={() => navigate('/workspaces')}
+            className="tp-btn"
+            style={{
+              background: 'transparent', border: `1px solid ${c.accent}`, borderRadius: 8,
+              color: c.accent, cursor: 'pointer', fontFamily: INTER, fontSize: 13,
+              fontWeight: 500, padding: '10px 16px', minHeight: 44,
+            }}
+          >
+            К списку воркспейсов
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && items.length > 0 && (
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 12 }}>
+          {items.map(ws => (
+            <TrashItem
+              key={ws.id}
+              ws={ws}
+              c={c}
+              inFlight={actionInFlight === ws.id}
+              isMobile={bp === 'mobile'}
+              onRestore={() => void handleRestore(ws)}
+              onAskPurge={() => setConfirmPurge(ws)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {/* Confirm purge modal */}
+      {confirmPurge && (
+        <ConfirmPurgeModal
+          ws={confirmPurge}
+          c={c}
+          busy={actionInFlight === confirmPurge.id}
+          onCancel={closeConfirm}
+          onConfirm={() => void handlePurgeConfirmed(confirmPurge)}
+        />
+      )}
+
+      <style>{`
+        @keyframes tp-pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.7; } }
+        .tp-btn:focus-visible {
+          outline: 2px solid #4F6EF7;
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ── BackButton ────────────────────────────────────────────────────────────────
+
+function BackButton({ color, onClick }: { color: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="tp-btn"
+      style={{
+        alignItems: 'center', background: 'none', border: 'none',
+        color, cursor: 'pointer', display: 'inline-flex',
+        fontFamily: INTER, fontSize: 13, gap: 6, marginBottom: 16, padding: 0,
+      }}
+    >
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+        <path d="M9 2.5L4.5 7L9 11.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+      Назад
+    </button>
+  );
+}
+
+// ── TrashItem ────────────────────────────────────────────────────────────────
+
+interface TrashItemProps {
+  ws: TrashedWorkspace;
+  c: C;
+  inFlight: boolean;
+  isMobile: boolean;
+  onRestore: () => void;
+  onAskPurge: () => void;
+}
+
+function TrashItem({ ws, c, inFlight, isMobile, onRestore, onAskPurge }: TrashItemProps) {
+  const days = ws.purgeAt ? daysUntil(ws.purgeAt) : 0;
+  const expiringSoon = days <= 2;
+  const purgeAt = ws.purgeAt ?? '';
+  const deletedAt = ws.deletedAt ?? '';
+
+  return (
+    <li
+      style={{
+        background: c.cardBg, border: `1px solid ${c.border}`, borderRadius: 12,
+        padding: 16, display: 'flex', gap: 16, alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 200 }}>
+        <div style={{ color: c.text, fontSize: 15, fontWeight: 600, marginBottom: 4 }}>
+          {ws.name}
+        </div>
+        <div style={{ color: c.muted, fontSize: 12, marginBottom: 6 }}>
+          {ws.boardCount} {plural(ws.boardCount, BOARDS_FORMS)}
+          {ws.description ? ` · ${ws.description.slice(0, 80)}${ws.description.length > 80 ? '…' : ''}` : ''}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          {ws.deletedBy && deletedAt && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: c.muted, fontSize: 12 }}>
+              <span style={{
+                alignItems: 'center', background: c.accent, borderRadius: '50%',
+                color: '#fff', display: 'inline-flex', fontSize: 9, fontWeight: 700,
+                height: 18, justifyContent: 'center', width: 18,
+              }} aria-hidden="true">
+                {avatarInitials(ws.deletedBy.name)}
+              </span>
+              Удалил {ws.deletedBy.name} · {fmtDate(deletedAt)}
+            </span>
+          )}
+          {purgeAt && (
+            <span
+              style={{
+                background: expiringSoon ? c.dangerBg : c.warnBg,
+                color: expiringSoon ? c.danger : c.warn,
+                fontSize: 11, fontWeight: 600,
+                padding: '2px 8px', borderRadius: 6,
+              }}
+              aria-label={`Удалится навсегда: ${fmtDate(purgeAt)}`}
+            >
+              {days === 0 ? 'Сегодня' : `Через ${days} ${plural(days, DAYS_FORMS)}`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div style={{
+        display: 'flex', gap: isMobile ? 12 : 8, flexShrink: 0,
+        flexDirection: isMobile ? 'column' : 'row',
+        width: isMobile ? '100%' : 'auto',
+      }}>
+        <button
+          onClick={onRestore}
+          disabled={inFlight}
+          aria-label={`Восстановить ${ws.name}`}
+          className="tp-btn"
+          style={{
+            background: 'transparent', border: `1px solid ${c.accent}`, borderRadius: 8,
+            color: c.accent, cursor: 'pointer', fontFamily: INTER, fontSize: 13,
+            fontWeight: 500, padding: '10px 16px', minHeight: 44,
+            opacity: inFlight ? 0.5 : 1,
+            width: isMobile ? '100%' : 'auto',
+          }}
+        >
+          Восстановить
+        </button>
+        {ws.role === 'OWNER' && (
+          <button
+            onClick={onAskPurge}
+            disabled={inFlight}
+            aria-label={`Удалить навсегда ${ws.name}`}
+            className="tp-btn"
+            style={{
+              background: 'transparent', border: `1px solid ${c.danger}`, borderRadius: 8,
+              color: c.danger, cursor: 'pointer', fontFamily: INTER, fontSize: 13,
+              fontWeight: 500, padding: '10px 16px', minHeight: 44,
+              opacity: inFlight ? 0.5 : 1,
+              width: isMobile ? '100%' : 'auto',
+            }}
+          >
+            Удалить навсегда
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ── ConfirmPurgeModal ────────────────────────────────────────────────────────
+
+interface ConfirmPurgeModalProps {
+  ws: TrashedWorkspace;
+  c: C;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function ConfirmPurgeModal({ ws, c, busy, onCancel, onConfirm }: ConfirmPurgeModalProps) {
+  const [confirmText, setConfirmText] = useState('');
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const canPurge = confirmText.trim() === ws.name && !busy;
+
+  // Capture trigger to restore focus on close, then focus the safe default (Cancel).
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    cancelBtnRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus?.();
+    };
+  }, []);
+
+  // Esc closes; focus trap cycles Cancel ↔ Input ↔ Confirm.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel();
+      } else if (e.key === 'Tab') {
+        const raw: Array<HTMLButtonElement | HTMLInputElement | null> = [
+          cancelBtnRef.current,
+          inputRef.current,
+          confirmBtnRef.current,
+        ];
+        const focusables: HTMLElement[] = [];
+        for (const el of raw) if (el && !el.disabled) focusables.push(el);
+        if (focusables.length === 0) return;
+        const active = document.activeElement as HTMLElement | null;
+        const idx = active ? focusables.indexOf(active) : -1;
+        if (e.shiftKey) {
+          if (idx <= 0) {
+            e.preventDefault();
+            focusables[focusables.length - 1].focus();
+          }
+        } else if (idx === focusables.length - 1) {
+          e.preventDefault();
+          focusables[0].focus();
+        }
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      // Backdrop intentionally does NOT dismiss on click — destructive irreversible action.
+      style={{
+        alignItems: 'center', background: 'rgba(0,0,0,0.5)', bottom: 0,
+        display: 'flex', justifyContent: 'center', left: 0, position: 'fixed',
+        right: 0, top: 0, zIndex: 1000,
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="purge-title"
+        aria-describedby="purge-desc"
+        style={{
+          background: c.cardBg, border: `1px solid ${c.border}`, borderRadius: 12,
+          maxWidth: 480, padding: 24, width: '90%',
+        }}
+      >
+        <h2 id="purge-title" style={{ color: c.text, fontSize: 17, fontWeight: 600, margin: 0, marginBottom: 8 }}>
+          Удалить «{ws.name}» навсегда?
+        </h2>
+        <p id="purge-desc" style={{ color: c.muted, fontSize: 13, marginTop: 0, marginBottom: 16 }}>
+          Это действие необратимо. Воркспейс и все вложенные доски ({ws.boardCount}), задачи, метки и история будут удалены без возможности восстановления.
+        </p>
+        <label style={{ display: 'block', color: c.label, fontSize: 12, marginBottom: 6 }}>
+          Введите имя воркспейса для подтверждения:
+          <strong style={{ color: c.text, marginLeft: 6, fontWeight: 600 }}>{ws.name}</strong>
+        </label>
+        <input
+          ref={inputRef}
+          type="text"
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          aria-label={`Введите имя «${ws.name}» для подтверждения удаления`}
+          autoComplete="off"
+          spellCheck={false}
+          disabled={busy}
+          className="tp-btn"
+          style={{
+            background: c.bg, border: `1px solid ${c.border}`, borderRadius: 8,
+            color: c.text, fontFamily: INTER, fontSize: 13,
+            padding: '10px 12px', width: '100%', marginBottom: 20,
+            boxSizing: 'border-box', minHeight: 44,
+          }}
+        />
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button
+            ref={cancelBtnRef}
+            type="button"
+            onClick={onCancel}
+            className="tp-btn"
+            style={{
+              background: c.accent, border: 'none', borderRadius: 8,
+              color: '#fff', cursor: 'pointer', fontFamily: INTER, fontSize: 13, fontWeight: 500,
+              padding: '10px 16px', minHeight: 44,
+            }}
+          >
+            Отмена
+          </button>
+          <button
+            ref={confirmBtnRef}
+            type="button"
+            onClick={onConfirm}
+            disabled={!canPurge}
+            className="tp-btn"
+            style={{
+              background: 'transparent', border: `1px solid ${c.danger}`, borderRadius: 8,
+              color: c.danger, cursor: canPurge ? 'pointer' : 'not-allowed',
+              fontFamily: INTER, fontSize: 13, fontWeight: 500,
+              padding: '10px 16px', minHeight: 44,
+              opacity: canPurge ? 1 : 0.5,
+            }}
+          >
+            Удалить навсегда
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkspaceSettingsPage.tsx
+++ b/frontend/src/pages/WorkspaceSettingsPage.tsx
@@ -354,11 +354,13 @@ export default function WorkspaceSettingsPage() {
   const handleDeleteWorkspace = () => {
     setConfirmModal({
       title: `Удалить "${workspace.name}"?`,
-      message: 'Это действие необратимо. Все доски, задачи и участники будут удалены.',
+      message: 'Workspace будет перемещён в Корзину и удалён навсегда через 10 рабочих дней. До этого его можно восстановить из профиля.',
       onConfirm: async () => {
         try {
           await workspacesApi.deleteWorkspace(workspace.id);
           await load();
+          // Refresh trash counter so badge in user-menu reflects the new state.
+          void useWorkspaceStore.getState().refreshTrashCount();
           navigate('/workspaces');
         } catch { message.error('Не удалось удалить workspace'); }
       },

--- a/frontend/src/store/workspace.store.ts
+++ b/frontend/src/store/workspace.store.ts
@@ -6,16 +6,20 @@ interface WorkspaceState {
   workspaces: Workspace[];
   current: Workspace | null;
   loading: boolean;
+  trashCount: number;
   load: () => Promise<void>;
   create: (payload: { name: string; slug: string; description?: string }) => Promise<Workspace>;
   setCurrent: (ws: Workspace | null) => void;
   incrementBoardCount: (workspaceId: string) => void;
+  refreshTrashCount: () => Promise<void>;
+  setTrashCount: (n: number) => void;
 }
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   workspaces: [],
   current: null,
   loading: false,
+  trashCount: 0,
 
   load: async () => {
     set({ loading: true });
@@ -47,4 +51,15 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       ),
     }));
   },
+
+  refreshTrashCount: async () => {
+    try {
+      const n = await workspacesApi.countTrash();
+      set({ trashCount: n });
+    } catch {
+      // Silent — badge just doesn't appear.
+    }
+  },
+
+  setTrashCount: (n) => set({ trashCount: n }),
 }));

--- a/frontend/src/utils/plural.ts
+++ b/frontend/src/utils/plural.ts
@@ -1,0 +1,23 @@
+/**
+ * Russian three-form plural helper (1, 2-4, 5+).
+ *
+ * Examples:
+ *   plural(1, ['день', 'дня', 'дней'])    → 'день'
+ *   plural(2, ['день', 'дня', 'дней'])    → 'дня'
+ *   plural(5, ['день', 'дня', 'дней'])    → 'дней'
+ *   plural(21, ['день', 'дня', 'дней'])   → 'день'
+ *   plural(22, ['день', 'дня', 'дней'])   → 'дня'
+ *   plural(11, ['день', 'дня', 'дней'])   → 'дней'  (11..14 → form3)
+ */
+export function plural(n: number, forms: [string, string, string]): string {
+  const abs = Math.abs(n);
+  const mod10 = abs % 10;
+  const mod100 = abs % 100;
+  if (mod10 === 1 && mod100 !== 11) return forms[0];
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) return forms[1];
+  return forms[2];
+}
+
+export const DAYS_FORMS: [string, string, string] = ['день', 'дня', 'дней'];
+export const BOARDS_FORMS: [string, string, string] = ['доска', 'доски', 'досок'];
+export const ELEMENTS_FORMS: [string, string, string] = ['элемент', 'элемента', 'элементов'];


### PR DESCRIPTION
## Summary

- **Soft-delete воркспейсов** в корзину с retention 10 рабочих дней
- **Восстановление** из корзины или **безвозвратное удаление** (cascade)
- **/trash страница** в Profile dropdown с счетчиком
- **Background scheduler** автоматически очищает expired каждый час

Closes #157.

## Что внутри

### Backend
- **Schema:** \`Workspace\` получает \`deletedAt\`, \`deletedBy\`, \`purgeAt\` + \`@@index([deletedAt])\`. Boards/Tasks внутри удалённого workspace становятся недоступны автоматически (через всеобщий audit \`deletedAt: null\`).
- **Operations:**
  - \`addBusinessDays(date, 10)\` — skip Sat/Sun
  - \`deleteWorkspace\` — soft-delete с suffix slug \`__deleted_<13-digit-epoch>\` (освобождает slug)
  - \`restoreWorkspace\` — atomic slug resolution через try/catch P2002 (immune to race)
  - \`purgeWorkspace\` — auditLog ДО cascade (event log умирает)
  - \`purgeExpired\` — \`deleteMany\` atomic (multi-instance idempotent)
- **Trash scheduler:** \`setInterval\` hourly, \`.unref()\` для test cleanup
- **Audit \`deletedAt: null\`:** boards, labels, workflows, comments, checklists, tasks, integrations, search, mfa-guard, listMyTasks

### Frontend
- **/trash route** + \`TrashPage.tsx\`
- **Confirm-modal с type-to-confirm** — введи имя workspace для подтверждения purge
- **A11y:** focus trap (Tab/Shift+Tab cycle), Esc, focus return на trigger, Cancel — primary visual, \`aria-labelledby\` + \`aria-describedby\`
- **Backdrop НЕ dismiss'ит modal** (destructive irreversible — GitHub/Linear pattern)
- **Touch targets 44×44** (WCAG 2.5.5 AAA + Apple HIG)
- **Russian plurals** через \`frontend/src/utils/plural.ts\`
- **Counter в Zustand store** — explicit updates вместо refetch на каждый route change
- **Badge contrast** \`#3D54E6\` (passes AA)
- **focus-visible outline** везде

### Tests
- 21 integration tests (\`workspace-trash.test.ts\`):
  - \`addBusinessDays\`
  - soft-delete + slug freeing
  - listTrash / countTrash RBAC (Owner vs Member vs deletedBy)
  - restore + slug conflict
  - purge
  - access denial на soft-deleted workspace
- **Все 213 backend tests зелёные**

## Review summary

| Reviewer | Severity / verdict |
|----------|-------------------|
| TypeScript / code | 7 HIGH → **все fixed** |
| Security | 2 CRITICAL + 4 HIGH → **CRITICAL + 3 HIGH fixed**, 1 HIGH (#176 IDOR) — pre-existing, отдельный issue |
| UX/UI | 2 CRITICAL + 5 HIGH → **все fixed** |

### Follow-up issues созданы
- **#176** SECURITY HIGH: searchMembers IDOR (pre-existing, не блокирует)
- **#177** Rate limiting на trash endpoints
- **#178** \`originalSlug\` DB field (replace regex parsing — текущий 13-digit anchor хорошо защищает)
- **#179** UX polish (restore warning, header level, error types)

## Test plan

- [x] Backend tsc clean
- [x] Frontend tsc clean
- [x] Backend: 213/213 tests passed
- [x] Frontend: 45/45 tests passed
- [x] Local smoke (Docker stack):
  - Создание + soft-delete → исчезает из /workspaces ✓
  - /trash показывает удалённый ws с badge "Через N дней" ✓
  - Restore → workspace появляется в /workspaces со slug ✓
  - Confirm-modal: type-to-confirm gating works ✓
  - Confirm-modal: Esc closes ✓
  - Confirm-modal: focus trap Tab cycles ✓
  - Purge → workspace полностью удалён из DB ✓
  - Frontend WorkspaceSettingsPage confirm-message обновлён на "перемещён в Корзину" ✓
- [ ] Staging smoke
- [ ] Manual: Member видит только свои deleted; Owner видит все в своем ws

🤖 Generated with [Claude Code](https://claude.com/claude-code)