### PR TITLE
fix(ui): человекочитаемые подписи в ленте «Последняя активность»

### DIFF
--- a/frontend/src/components/TaskHistoryTimeline.tsx
+++ b/frontend/src/components/TaskHistoryTimeline.tsx
@@ -25,7 +25,14 @@ const FIELD_LABELS: Record<string, string> = {
   assigneeId:  'исполнитель',
   dueDate:     'срок',
   startDate:   'дата начала',
+  boardId:     'доску',
+  parentId:    'родительскую задачу',
+  archived:    'архивный флаг',
 };
+
+function fieldLabelFor(field: string): string {
+  return FIELD_LABELS[field] ?? 'поле задачи';
+}
 
 const PRIORITY_LABELS: Record<string, string> = {
   HIGH: 'Высокий', MEDIUM: 'Средний', LOW: 'Низкий',
@@ -91,7 +98,7 @@ export default function TaskHistoryTimeline({ taskId, statuses }: Props) {
       {history.map((entry, i) => {
         const dotColor = avatarColor(entry.user.name);
         const isLast = i === history.length - 1;
-        const fieldLabel = FIELD_LABELS[entry.field] ?? entry.field;
+        const fieldLabel = fieldLabelFor(entry.field);
         const verb = verbForm(entry.user.name);
 
         return (

--- a/frontend/src/components/WorkspaceHistoryTimeline.tsx
+++ b/frontend/src/components/WorkspaceHistoryTimeline.tsx
@@ -43,25 +43,37 @@ const ACTION_SVG: Record<string, string> = {
 
 function formatMessage(event: WorkspaceEvent): string {
   const meta = event.meta as Record<string, string> | undefined;
+  const m = meta ?? {};
+  const who = event.user.name;
   switch (event.action) {
-    case 'member_added':         return `${event.user.name} добавил участника ${meta?.name ?? ''} (${meta?.role ?? ''})`;
-    case 'member_removed':       return `${event.user.name} удалил участника ${meta?.name ?? ''}`;
-    case 'member_role_changed':  return `${event.user.name} изменил роль ${meta?.name ?? ''} на ${meta?.role ?? ''}`;
-    case 'workflow_created':     return `${event.user.name} создал workflow «${meta?.name ?? ''}»`;
-    case 'workflow_deleted':     return `${event.user.name} удалил workflow «${meta?.name ?? ''}»`;
-    case 'workspace_created':    return `${event.user.name} создал рабочее пространство «${meta?.name ?? ''}»`;
+    case 'member_added':         return `${who} добавил участника ${m.name ?? ''} (${m.role ?? ''})`;
+    case 'member_removed':       return `${who} удалил участника ${m.name ?? ''}`;
+    case 'member_role_changed':  return `${who} изменил роль ${m.name ?? ''} на ${m.role ?? ''}`;
+    case 'workflow_created':     return `${who} создал воркфлоу «${m.name ?? ''}»`;
+    case 'workflow_updated':     return `${who} обновил воркфлоу «${m.nameTo ?? m.name ?? m.workflowName ?? ''}»`;
+    case 'workflow_deleted':     return `${who} удалил воркфлоу «${m.name ?? ''}»`;
+    case 'workflow_status_added':
+      return `${who} добавил колонку «${m.statusName ?? ''}»${m.workflowName ? ` в воркфлоу «${m.workflowName}»` : ''}`;
+    case 'workflow_status_renamed':
+      return `${who} переименовал колонку «${m.nameFrom ?? ''}» → «${m.nameTo ?? ''}»`;
+    case 'workflow_status_deleted':
+      return `${who} удалил колонку «${m.statusName ?? ''}»${m.workflowName ? ` из воркфлоу «${m.workflowName}»` : ''}`;
+    case 'workspace_created':    return `${who} создал рабочее пространство «${m.name ?? ''}»`;
+    case 'workspace_soft_deleted': return `${who} удалил пространство «${m.name ?? ''}»`;
+    case 'workspace_restored':   return `${who} восстановил пространство «${m.name ?? ''}»`;
     case 'workspace_updated': {
       const changes: string[] = [];
-      if (meta?.name)        changes.push(`название → «${meta.name}»`);
-      if (meta?.description !== undefined) changes.push(`описание обновлено`);
-      if (meta?.isPrivate !== undefined)   changes.push(meta.isPrivate === 'true' ? 'сделал приватным' : 'сделал публичным');
+      if (m.name)              changes.push(`название → «${m.name}»`);
+      if (m.description !== undefined) changes.push('описание обновлено');
+      if (m.isPrivate !== undefined)   changes.push(m.isPrivate === 'true' ? 'сделал приватным' : 'сделал публичным');
       return changes.length > 0
-        ? `${event.user.name} изменил настройки: ${changes.join(', ')}`
-        : `${event.user.name} обновил настройки пространства`;
+        ? `${who} изменил настройки: ${changes.join(', ')}`
+        : `${who} обновил настройки пространства`;
     }
-    case 'board_created':        return `${event.user.name} создал доску «${meta?.name ?? ''}»`;
-    case 'board_deleted':        return `${event.user.name} удалил доску «${meta?.name ?? ''}»`;
-    default: return `${event.user.name}: ${event.action}`;
+    case 'board_created':        return `${who} создал доску «${m.name ?? ''}»`;
+    case 'board_updated':        return `${who} обновил доску «${m.boardName ?? m.name ?? ''}»`;
+    case 'board_deleted':        return `${who} удалил доску «${m.name ?? ''}»`;
+    default: return `${who} выполнил действие`;
   }
 }
 

--- a/frontend/src/pages/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/WorkspaceDashboardPage.tsx
@@ -521,6 +521,8 @@ export default function WorkspaceDashboardPage() {
                 const ACTION_LABELS: Record<string, string> = {
                   workspace_created:       isFem ? 'создала пространство' : 'создал пространство',
                   workspace_updated:       isFem ? 'обновила настройки пространства' : 'обновил настройки пространства',
+                  workspace_soft_deleted:  isFem ? `удалила пространство «${m.name ?? ''}»` : `удалил пространство «${m.name ?? ''}»`,
+                  workspace_restored:      isFem ? `восстановила пространство «${m.name ?? ''}»` : `восстановил пространство «${m.name ?? ''}»`,
                   member_added:            isFem ? `добавила участника ${m.name ?? ''}` : `добавил участника ${m.name ?? ''}`,
                   member_removed:          isFem ? `удалила участника ${m.name ?? ''}` : `удалил участника ${m.name ?? ''}`,
                   member_role_changed:     isFem ? `изменила роль ${m.name ?? ''}` : `изменил роль ${m.name ?? ''}`,
@@ -538,7 +540,7 @@ export default function WorkspaceDashboardPage() {
                   workflow_status_renamed: isFem ? `переименовала колонку «${m.nameFrom ?? ''}» → «${m.nameTo ?? ''}»` : `переименовал колонку «${m.nameFrom ?? ''}» → «${m.nameTo ?? ''}»`,
                   workflow_status_deleted: isFem ? `удалила колонку «${m.statusName ?? ''}» из воркфлоу «${m.workflowName ?? ''}»` : `удалил колонку «${m.statusName ?? ''}» из воркфлоу «${m.workflowName ?? ''}»`,
                 };
-                const label = ACTION_LABELS[ev.action] ?? ev.action;
+                const label = ACTION_LABELS[ev.action] ?? (isFem ? 'выполнила действие' : 'выполнил действие');
                 const time  = new Date(ev.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
                 const AVATAR_COLORS = ['#4F6EF7','#8B5CF6','#F59E0B','#34D399','#F87171','#38BDF8'];
                 const avColor = AVATAR_COLORS[(name.charCodeAt(0) ?? 0) % AVATAR_COLORS.length];

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -9,6 +9,61 @@ import { useResponsiveValue } from '../utils/useBreakpoint';
 import type { Workspace, WorkspaceEvent } from '../types';
 import * as workspacesApi from '../api/workspaces';
 
+// ─── Human-readable labels for workspace activity events ─────────────────────
+type ActionRender = { label: string; title?: string };
+
+function renderActionText(
+  action: string,
+  meta: Record<string, string | undefined>,
+  isFem: boolean,
+  workspaceName?: string,
+): ActionRender {
+  const v = (m: string, f: string): string => (isFem ? f : m);
+  switch (action) {
+    case 'workspace_created':
+      return { label: v('создал пространство', 'создала пространство'), title: meta.name ?? workspaceName };
+    case 'workspace_updated':
+      return { label: v('обновил настройки пространства', 'обновила настройки пространства'), title: workspaceName };
+    case 'workspace_soft_deleted':
+      return { label: v('удалил пространство', 'удалила пространство'), title: meta.name ?? workspaceName };
+    case 'workspace_restored':
+      return { label: v('восстановил пространство', 'восстановила пространство'), title: meta.name ?? workspaceName };
+    case 'member_added':
+      return { label: v('добавил участника', 'добавила участника'), title: meta.name };
+    case 'member_removed':
+      return { label: v('удалил участника', 'удалила участника'), title: meta.name };
+    case 'member_role_changed':
+      return { label: v('изменил роль участника', 'изменила роль участника'), title: meta.name };
+    case 'board_created':
+      return { label: v('создал доску', 'создала доску'), title: meta.name };
+    case 'board_updated':
+      return { label: v('обновил доску', 'обновила доску'), title: meta.boardName ?? meta.name };
+    case 'board_deleted':
+      return { label: v('удалил доску', 'удалила доску'), title: meta.name };
+    case 'workflow_created':
+      return { label: v('создал воркфлоу', 'создала воркфлоу'), title: meta.name };
+    case 'workflow_updated':
+      return { label: v('обновил воркфлоу', 'обновила воркфлоу'), title: meta.nameTo ?? meta.name ?? meta.workflowName };
+    case 'workflow_deleted':
+      return { label: v('удалил воркфлоу', 'удалила воркфлоу'), title: meta.name };
+    case 'workflow_status_added': {
+      const wf = meta.workflowName ? ` в воркфлоу «${meta.workflowName}»` : '';
+      return { label: v('добавил колонку', 'добавила колонку') + wf, title: meta.statusName };
+    }
+    case 'workflow_status_renamed':
+      return {
+        label: v('переименовал колонку', 'переименовала колонку'),
+        title: meta.nameFrom && meta.nameTo ? `${meta.nameFrom} → ${meta.nameTo}` : meta.statusName,
+      };
+    case 'workflow_status_deleted': {
+      const wf = meta.workflowName ? ` из воркфлоу «${meta.workflowName}»` : '';
+      return { label: v('удалил колонку', 'удалила колонку') + wf, title: meta.statusName };
+    }
+    default:
+      return { label: v('выполнил действие', 'выполнила действие'), title: workspaceName };
+  }
+}
+
 // ─── Design tokens (Paper: 135-0 dark, 16D-0 light) ──────────────────────────
 type Theme = Record<string, string>;
 const DARK_C: Theme = {
@@ -466,24 +521,16 @@ export default function WorkspacesPage() {
               const name = ev.user?.name ?? 'Кто-то';
               const nameParts = name.trim().split(/\s+/);
               const isFem = /[аяАЯ]$/u.test(nameParts[nameParts.length - 1] ?? name);
-              const ACTION_LABELS: Record<string, string> = {
-                workspace_created: isFem ? 'создала пространство' : 'создал пространство',
-                workspace_updated: isFem ? 'обновила настройки' : 'обновил настройки',
-                member_added:      isFem ? 'добавила участника' : 'добавил участника',
-                member_removed:    isFem ? 'удалила участника' : 'удалил участника',
-                board_created:     isFem ? 'создала доску' : 'создал доску',
-                board_deleted:     isFem ? 'удалила доску' : 'удалил доску',
-                member_role_changed: isFem ? 'изменила роль участника' : 'изменил роль участника',
-              };
-              const label = ACTION_LABELS[ev.action] ?? ev.action;
               const ws = workspaces.find(w => w.id === ev.workspaceId);
+              const meta = (ev.meta ?? {}) as Record<string, string | undefined>;
+              const { label, title } = renderActionText(ev.action, meta, isFem, ws?.name);
               const time = new Date(ev.createdAt).toLocaleString('ru-RU', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
               return (
                 <div key={ev.id} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, minWidth: 0 }}>
                   <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#4F6EF7', flexShrink: 0, marginTop: 5 }} />
                   <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 13, color: C.actText, flex: 1, overflow: 'hidden' }}>
                     <span style={{ fontWeight: 600 }}>{name}</span>
-                    {' '}{label}{ws ? ` «${ws.name}»` : ''}
+                    {' '}{label}{title ? ` «${title}»` : ''}
                   </span>
                   <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 11, color: C.actTime, flexShrink: 0, whiteSpace: 'nowrap' }}>{time}</span>
                 </div>


### PR DESCRIPTION
## Что было

В виджете «Последняя активность» на странице «Мои рабочие пространства» (а также в полной ленте истории воркспейса) для незнакомых event-типов выводился сырой системный код:

> Новак Павел **workflow_status_added** «test-board»
> Новак Павел **workflow_updated** «test-board»
> Новак Павел **workflow_created** «test-board»

Причина — в `ACTION_LABELS` (`WorkspacesPage.tsx`) и `formatMessage` (`WorkspaceHistoryTimeline.tsx`) была покрыта только часть событий из бэкенда; всё остальное падало в фоллбэк и печаталось as is.

## Что стало

- В `WorkspacesPage.tsx` вынес мапу в функцию `renderActionText(action, meta, isFem, workspaceName)`. Покрыты все события, которые шлёт бэкенд: `workflow_created/updated/deleted`, `workflow_status_added/renamed/deleted`, `workspace_created/updated/soft_deleted/restored`, `board_created/updated/deleted`, `member_added/removed/role_changed`.
- Заголовок в `«...»` теперь берётся осмысленно: для воркфлоу/доски/колонки — соответствующее `meta.name` / `meta.statusName`, для колоночных событий дополнительно «в воркфлоу «...»».
- Род подписи (он/она) подставляется по последнему слову имени.
- Дефолт-фоллбэк — нейтральное «выполнил/выполнила действие» вместо сырого `action`.
- Тот же набор подписей синхронизирован в `WorkspaceHistoryTimeline.tsx` (полная история).

Пример «после»:
- `Новак Павел добавил колонку «To Do» в воркфлоу «test-board»`
- `Новак Павел обновил воркфлоу «test-board»`
- `Новак Павел создал воркфлоу «test-board»`

## Test plan

- [ ] `tsc --noEmit` зелёный (проверено локально).
- [ ] Открыть `/workspaces` → виджет «Последняя активность» — события воркфлоу читаются по-русски, без сырых `workflow_*`.
- [ ] Открыть страницу воркспейса с расширенной лентой истории — те же события без `user: workflow_status_added`.
- [ ] Проверить женский род на пользователе с именем, заканчивающимся на «а»/«я».