### PR TITLE
feat(permissions): RBAC engine + per-board ACL — Phase 1 critical path

### DIFF
--- a/backend/src/__tests__/permissions/cache.test.ts
+++ b/backend/src/__tests__/permissions/cache.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for permissions-cache.ts — see plan.md §Caching strategy.
+ *
+ * The cache stores a "permission context" object — the aggregate of system features,
+ * workspace features, role permissions, grants, revokes, and metadata — keyed by
+ * (userId, workspaceId, permissionsRev, systemRev). A new permissionsRev or systemRev
+ * counts as a fresh key, so older entries naturally evict from the LRU.
+ *
+ * Tested behaviors:
+ *   - hit: same (user, ws, rev) returns cached value, no DB call
+ *   - miss after permissionsRev increment: re-queries
+ *   - miss after systemRev increment: re-queries
+ *   - bypass via fresh=true: always re-queries, no cache write
+ *   - bulk workspace feature change invalidates all members
+ *   - independent users do not share entries
+ */
+
+const fetchFromDb = vi.fn();
+
+vi.mock('../../prisma/client.js', () => ({ prisma: {} }));
+
+vi.mock('../../shared/utils/permissions-loader.js', () => ({
+  loadPermissionContextFromDb: (...args: unknown[]) => fetchFromDb(...args),
+  loadBoardAccessContextFromDb: vi.fn(),
+}));
+
+// Sentinel marker added to mock results so individual mockResolvedValueOnce
+// calls can be distinguished. Not part of the production PermissionContext shape.
+type MockContext = { permissionsRev: number; systemRev: number; marker: string };
+const readMarker = (ctx: unknown): string => (ctx as MockContext).marker;
+
+import {
+  getPermissionContext,
+  invalidateUser,
+  invalidateWorkspace,
+  invalidateSystem,
+  __clearCacheForTests,
+} from '../../shared/utils/permissions-cache.js';
+
+beforeEach(() => {
+  fetchFromDb.mockReset();
+  __clearCacheForTests();
+});
+
+describe('permissions-cache — basic hit/miss', () => {
+  it('returns cached value on second call with same key', async () => {
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'v1' });
+    await getPermissionContext('u1', 'ws1');
+    await getPermissionContext('u1', 'ws1');
+    expect(fetchFromDb).toHaveBeenCalledTimes(1);
+  });
+
+  it('different users do not share cache', async () => {
+    fetchFromDb.mockResolvedValue({ permissionsRev: 1, systemRev: 1, marker: 'x' });
+    await getPermissionContext('u1', 'ws1');
+    await getPermissionContext('u2', 'ws1');
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+  });
+
+  it('null workspaceId and a real workspaceId are separate cache keys', async () => {
+    fetchFromDb.mockResolvedValue({ permissionsRev: 1, systemRev: 1, marker: 'x' });
+    await getPermissionContext('u1', null);
+    await getPermissionContext('u1', 'ws1');
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('permissions-cache — invalidation on permissionsRev increment', () => {
+  it('after invalidateUser → next call re-fetches', async () => {
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'v1' });
+    await getPermissionContext('u1', 'ws1');
+
+    invalidateUser('u1');
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 2, systemRev: 1, marker: 'v2' });
+    const result = await getPermissionContext('u1', 'ws1');
+
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+    expect(readMarker(result)).toBe('v2');
+  });
+
+  it('invalidateUser does NOT affect other users', async () => {
+    fetchFromDb.mockResolvedValue({ permissionsRev: 1, systemRev: 1, marker: 'x' });
+    await getPermissionContext('u1', 'ws1');
+    await getPermissionContext('u2', 'ws1');
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+
+    invalidateUser('u1');
+    await getPermissionContext('u2', 'ws1'); // u2 still cached
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+
+    await getPermissionContext('u1', 'ws1'); // u1 invalidated
+    expect(fetchFromDb).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('permissions-cache — invalidation on workspace feature change', () => {
+  it('invalidateWorkspace flushes all members of that workspace', async () => {
+    fetchFromDb.mockResolvedValue({ permissionsRev: 1, systemRev: 1, marker: 'x' });
+    await getPermissionContext('u1', 'ws1');
+    await getPermissionContext('u2', 'ws1');
+    await getPermissionContext('u3', 'ws-other');
+    expect(fetchFromDb).toHaveBeenCalledTimes(3);
+
+    invalidateWorkspace('ws1');
+
+    await getPermissionContext('u1', 'ws1');
+    await getPermissionContext('u2', 'ws1');
+    expect(fetchFromDb).toHaveBeenCalledTimes(5); // both u1@ws1 and u2@ws1 re-queried
+
+    await getPermissionContext('u3', 'ws-other');
+    expect(fetchFromDb).toHaveBeenCalledTimes(5); // ws-other untouched
+  });
+});
+
+describe('permissions-cache — system-level invalidation', () => {
+  it('invalidateSystem flushes everything', async () => {
+    fetchFromDb.mockResolvedValue({ permissionsRev: 1, systemRev: 1, marker: 'x' });
+    await getPermissionContext('u1', 'ws1');
+    await getPermissionContext('u2', null);
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+
+    invalidateSystem();
+
+    await getPermissionContext('u1', 'ws1');
+    await getPermissionContext('u2', null);
+    expect(fetchFromDb).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('permissions-cache — fresh=true bypass', () => {
+  it('fresh=true skips the cache on read', async () => {
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'v1' });
+    await getPermissionContext('u1', 'ws1');
+
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'v2' });
+    const result = await getPermissionContext('u1', 'ws1', { fresh: true });
+
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+    expect(readMarker(result)).toBe('v2');
+  });
+
+  it('fresh=true does NOT poison cache for subsequent normal calls', async () => {
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'cached' });
+    await getPermissionContext('u1', 'ws1');
+
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'fresh-only' });
+    await getPermissionContext('u1', 'ws1', { fresh: true });
+
+    // Next normal call should still hit the original cached value
+    const cached = await getPermissionContext('u1', 'ws1');
+    expect(readMarker(cached)).toBe('cached');
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('permissions-cache — invalidation cancels in-flight DB write (HIGH-2)', () => {
+  it('invalidateUser between fetch start and DB resolve discards stale write', async () => {
+    let resolveDb: (value: unknown) => void = () => {};
+    fetchFromDb.mockImplementationOnce(
+      () => new Promise((r) => { resolveDb = r; }),
+    );
+
+    // First fetch begins
+    const inflightP = getPermissionContext('u1', 'ws1');
+
+    // Invalidation arrives BEFORE the DB resolves
+    invalidateUser('u1');
+
+    // DB finally returns "stale" data
+    resolveDb({ permissionsRev: 1, systemRev: 1, marker: 'stale' });
+    await inflightP;
+
+    // Next read must NOT see the stale write — should hit DB again
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 2, systemRev: 1, marker: 'fresh' });
+    const next = await getPermissionContext('u1', 'ws1');
+
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+    expect(readMarker(next)).toBe('fresh');
+  });
+});
+
+describe('permissions-cache — concurrent reads coalesce', () => {
+  it('two parallel reads for the same key result in a single DB query', async () => {
+    let resolveDb: (value: unknown) => void = () => {};
+    fetchFromDb.mockImplementation(
+      () => new Promise((r) => { resolveDb = r; }),
+    );
+
+    const p1 = getPermissionContext('u1', 'ws1');
+    const p2 = getPermissionContext('u1', 'ws1');
+
+    resolveDb({ permissionsRev: 1, systemRev: 1, marker: 'one' });
+    const [a, b] = await Promise.all([p1, p2]);
+
+    expect(fetchFromDb).toHaveBeenCalledTimes(1);
+    expect(readMarker(a)).toBe('one');
+    expect(readMarker(b)).toBe('one');
+  });
+});
+
+describe('permissions-cache — TTL/expiry', () => {
+  it('entries older than TTL are not returned (5 min default)', async () => {
+    vi.useFakeTimers();
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'fresh' });
+    await getPermissionContext('u1', 'ws1');
+    expect(fetchFromDb).toHaveBeenCalledTimes(1);
+
+    // advance past TTL — implementation uses 5 min default
+    vi.setSystemTime(Date.now() + 6 * 60 * 1000);
+
+    fetchFromDb.mockResolvedValueOnce({ permissionsRev: 1, systemRev: 1, marker: 'refetched' });
+    const result = await getPermissionContext('u1', 'ws1');
+    expect(fetchFromDb).toHaveBeenCalledTimes(2);
+    expect(readMarker(result)).toBe('refetched');
+
+    vi.useRealTimers();
+  });
+});

--- a/backend/src/__tests__/permissions/can-access-board.test.ts
+++ b/backend/src/__tests__/permissions/can-access-board.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for canAccessBoard() — algorithm spec: board-acl.md §4
+ *
+ * Rules (in order):
+ *   0a. superadmin → { allowed: true, role: 'system:admin', source: 'superadmin' }
+ *   0b. workspace.deletedAt !== null → { allowed: false }
+ *   0c. user not WorkspaceMember → { allowed: false }
+ *   1.  workspace owner (regardless of BoardMember) → allowed, source: 'workspace-owner'
+ *   2.  BoardMember with rolePresetId=null → { allowed: false } (explicit DENY)
+ *   3.  BoardMember with rolePresetId set → allowed, source: 'board-override', role: that preset
+ *   4.  isGuest=true and no BoardMember → { allowed: false } (guest blocked from public defaults)
+ *   5.  board.isPrivate=true and no BoardMember → { allowed: false }
+ *   6.  public board, member → allowed, source: 'workspace', role: workspace role
+ */
+
+vi.mock('../../prisma/client.js', () => ({ prisma: {} }));
+vi.mock('../../shared/utils/permissions-cache.js', () => ({
+  getBoardAccessContext: vi.fn(),
+}));
+
+import { canAccessBoard } from '../../shared/utils/permissions.js';
+import { getBoardAccessContext } from '../../shared/utils/permissions-cache.js';
+
+const mockedGet = vi.mocked(getBoardAccessContext);
+
+type Args = {
+  isSuperadmin?: boolean;
+  workspaceDeletedAt?: string | null;
+  isWorkspaceMember?: boolean;
+  isWorkspaceOwner?: boolean;
+  workspaceRolePresetId?: string | null;
+  isGuest?: boolean;
+  boardIsPrivate?: boolean;
+  boardMember?: { rolePresetId: string | null } | null;
+};
+
+function ctx(args: Args) {
+  return {
+    isSuperadmin: args.isSuperadmin ?? false,
+    workspaceId: 'ws-test',
+    workspaceDeletedAt: args.workspaceDeletedAt ?? null,
+    isWorkspaceMember: args.isWorkspaceMember ?? true,
+    isWorkspaceOwner: args.isWorkspaceOwner ?? false,
+    workspaceRolePresetId: args.workspaceRolePresetId ?? 'system:member',
+    isGuest: args.isGuest ?? false,
+    boardIsPrivate: args.boardIsPrivate ?? false,
+    boardMember: args.boardMember ?? null,
+  };
+}
+
+beforeEach(() => mockedGet.mockReset());
+
+describe('canAccessBoard — rule 0a: superadmin', () => {
+  it('superadmin sees any board, even with denied BoardMember and deleted workspace', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        isSuperadmin: true,
+        workspaceDeletedAt: '2026-01-01',
+        isWorkspaceMember: false,
+        boardMember: { rolePresetId: null },
+      }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(true);
+    expect(result.source).toBe('superadmin');
+  });
+});
+
+describe('canAccessBoard — rule 0b: soft-deleted workspace', () => {
+  it('blocks access when workspace.deletedAt is set', async () => {
+    mockedGet.mockResolvedValue(ctx({ workspaceDeletedAt: '2026-01-01' }));
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe('canAccessBoard — rule 0c: not a workspace member', () => {
+  it('blocks when user is not in WorkspaceMember', async () => {
+    mockedGet.mockResolvedValue(ctx({ isWorkspaceMember: false }));
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe('canAccessBoard — rule 1: workspace owner always wins', () => {
+  it('owner has access even with BoardMember denied', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        isWorkspaceOwner: true,
+        workspaceRolePresetId: 'system:owner',
+        boardMember: { rolePresetId: null },
+      }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(true);
+    expect(result.source).toBe('workspace-owner');
+  });
+
+  it('owner has access to private board without BoardMember entry', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        isWorkspaceOwner: true,
+        workspaceRolePresetId: 'system:owner',
+        boardIsPrivate: true,
+        boardMember: null,
+      }),
+    );
+    expect((await canAccessBoard('u1', 'b1')).allowed).toBe(true);
+  });
+});
+
+describe('canAccessBoard — rule 2: explicit DENY', () => {
+  it('BoardMember.rolePresetId=null blocks a non-owner member', async () => {
+    mockedGet.mockResolvedValue(ctx({ boardMember: { rolePresetId: null } }));
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe('canAccessBoard — rule 3: per-board OVERRIDE', () => {
+  it('viewer in workspace with board-override member gets member access on that board', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        workspaceRolePresetId: 'system:viewer',
+        boardMember: { rolePresetId: 'system:member' },
+      }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(true);
+    expect(result.source).toBe('board-override');
+    expect(result.role).toBe('system:member');
+  });
+
+  it('member in workspace with board-override viewer gets viewer access on that board', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        workspaceRolePresetId: 'system:member',
+        boardMember: { rolePresetId: 'system:viewer' },
+      }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(true);
+    expect(result.role).toBe('system:viewer');
+  });
+});
+
+describe('canAccessBoard — rule 4: guest without explicit BoardMember', () => {
+  it('guest cannot see public board without BoardMember', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({ isGuest: true, boardIsPrivate: false, boardMember: null }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('guest with explicit BoardMember gets access via rule 3', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        isGuest: true,
+        boardMember: { rolePresetId: 'system:member' },
+      }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(true);
+    expect(result.source).toBe('board-override');
+  });
+});
+
+describe('canAccessBoard — rule 5: private board without BoardMember', () => {
+  it('non-owner member sees no access to private without BoardMember', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({ boardIsPrivate: true, boardMember: null }),
+    );
+    expect((await canAccessBoard('u1', 'b1')).allowed).toBe(false);
+  });
+});
+
+describe('canAccessBoard — rule 6: public board uses workspace role', () => {
+  it('public board, no override → workspace role applies', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({ workspaceRolePresetId: 'system:member', boardIsPrivate: false, boardMember: null }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(true);
+    expect(result.source).toBe('workspace');
+    expect(result.role).toBe('system:member');
+  });
+
+  it('public board with viewer workspace role → access as viewer', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({ workspaceRolePresetId: 'system:viewer', boardIsPrivate: false }),
+    );
+    const result = await canAccessBoard('u1', 'b1');
+    expect(result.allowed).toBe(true);
+    expect(result.role).toBe('system:viewer');
+  });
+});
+
+describe('canAccessBoard — rule precedence', () => {
+  it('rule 1 (owner) beats rule 2 (denied) — owner cannot be banned', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        isWorkspaceOwner: true,
+        workspaceRolePresetId: 'system:owner',
+        boardMember: { rolePresetId: null },
+      }),
+    );
+    expect((await canAccessBoard('u1', 'b1')).source).toBe('workspace-owner');
+  });
+
+  it('rule 2 (denied) beats rule 4 (guest) — explicit DENY wins over guest fallback', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({ isGuest: true, boardMember: { rolePresetId: null } }),
+    );
+    expect((await canAccessBoard('u1', 'b1')).allowed).toBe(false);
+  });
+
+  it('rule 3 (override) beats rule 5 (private) — override grants access to private', async () => {
+    mockedGet.mockResolvedValue(
+      ctx({
+        boardIsPrivate: true,
+        boardMember: { rolePresetId: 'system:member' },
+      }),
+    );
+    expect((await canAccessBoard('u1', 'b1')).allowed).toBe(true);
+  });
+});

--- a/backend/src/__tests__/permissions/derive-feature-code.test.ts
+++ b/backend/src/__tests__/permissions/derive-feature-code.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { deriveFeatureCode } from '../../shared/utils/permissions.js';
+
+/**
+ * Test matrix for deriveFeatureCode(permission)
+ * Source: docs/design/feature-permissions.md §5 + tasks/feature-permissions-acl/plan.md Step 1.3
+ *
+ * Maps permission codes to workspace-level FeatureCode that gates them.
+ * Returns null for permissions that are NOT gated by any workspace feature
+ * (core operations, admin operations, and the WS_* feature codes themselves).
+ */
+
+describe('deriveFeatureCode — workspace feature gating map', () => {
+  describe('WS_COMMENTS gates all comment-related permissions', () => {
+    it('COMMENT_READ → WS_COMMENTS', () => {
+      expect(deriveFeatureCode('COMMENT_READ')).toBe('WS_COMMENTS');
+    });
+    it('COMMENT_CREATE → WS_COMMENTS', () => {
+      expect(deriveFeatureCode('COMMENT_CREATE')).toBe('WS_COMMENTS');
+    });
+    it('COMMENT_UPDATE_OWN → WS_COMMENTS', () => {
+      expect(deriveFeatureCode('COMMENT_UPDATE_OWN')).toBe('WS_COMMENTS');
+    });
+    it('COMMENT_DELETE_OWN → WS_COMMENTS', () => {
+      expect(deriveFeatureCode('COMMENT_DELETE_OWN')).toBe('WS_COMMENTS');
+    });
+    it('COMMENT_DELETE_ANY → WS_COMMENTS', () => {
+      expect(deriveFeatureCode('COMMENT_DELETE_ANY')).toBe('WS_COMMENTS');
+    });
+  });
+
+  describe('WS_CHECKLISTS gates checklist permissions', () => {
+    it('CHECKLIST_READ → WS_CHECKLISTS', () => {
+      expect(deriveFeatureCode('CHECKLIST_READ')).toBe('WS_CHECKLISTS');
+    });
+    it('CHECKLIST_WRITE → WS_CHECKLISTS', () => {
+      expect(deriveFeatureCode('CHECKLIST_WRITE')).toBe('WS_CHECKLISTS');
+    });
+  });
+
+  describe('WS_LABELS gates label permissions', () => {
+    it('LABEL_READ → WS_LABELS', () => {
+      expect(deriveFeatureCode('LABEL_READ')).toBe('WS_LABELS');
+    });
+    it('LABEL_CREATE → WS_LABELS', () => {
+      expect(deriveFeatureCode('LABEL_CREATE')).toBe('WS_LABELS');
+    });
+    it('LABEL_UPDATE → WS_LABELS', () => {
+      expect(deriveFeatureCode('LABEL_UPDATE')).toBe('WS_LABELS');
+    });
+    it('LABEL_DELETE → WS_LABELS', () => {
+      expect(deriveFeatureCode('LABEL_DELETE')).toBe('WS_LABELS');
+    });
+  });
+
+  describe('WS_BULK_OPS gates bulk task editing', () => {
+    it('TASK_BULK_EDIT → WS_BULK_OPS', () => {
+      expect(deriveFeatureCode('TASK_BULK_EDIT')).toBe('WS_BULK_OPS');
+    });
+  });
+
+  describe('WS_EXPORT gates CSV export', () => {
+    it('TASK_EXPORT → WS_EXPORT', () => {
+      expect(deriveFeatureCode('TASK_EXPORT')).toBe('WS_EXPORT');
+    });
+  });
+
+  describe('WS_HISTORY_UI gates history viewing in UI', () => {
+    it('HISTORY_READ → WS_HISTORY_UI', () => {
+      expect(deriveFeatureCode('HISTORY_READ')).toBe('WS_HISTORY_UI');
+    });
+  });
+
+  describe('Core permissions are NOT gated by workspace features', () => {
+    it.each([
+      'TASK_READ',
+      'TASK_CREATE',
+      'TASK_UPDATE',
+      'TASK_DELETE',
+      'TASK_REASSIGN',
+      'BOARD_READ',
+      'BOARD_CREATE',
+      'BOARD_UPDATE',
+      'BOARD_DELETE',
+      'BOARD_MANAGE_COLUMNS',
+      'BOARD_MANAGE_ACL',
+      'WORKFLOW_READ',
+      'WORKFLOW_CREATE',
+      'WORKFLOW_UPDATE',
+      'WORKFLOW_DELETE',
+      'WORKSPACE_READ',
+    ])('%s → null (core, not gated)', (perm) => {
+      expect(deriveFeatureCode(perm as never)).toBeNull();
+    });
+  });
+
+  describe('Workspace-level admin permissions are NOT gated', () => {
+    it.each([
+      'WS_INVITE_MEMBER',
+      'WS_REMOVE_MEMBER',
+      'WS_CHANGE_MEMBER_ROLE',
+      'WS_EDIT_SETTINGS',
+      'WS_EDIT_SECURITY',
+      'WS_TOGGLE_FEATURES',
+      'WS_DELETE',
+      'WS_RESTORE_FROM_TRASH',
+    ])('%s → null (workspace admin, not gated)', (perm) => {
+      expect(deriveFeatureCode(perm as never)).toBeNull();
+    });
+  });
+
+  describe('System admin permissions are NOT gated by workspace features', () => {
+    it.each([
+      'ADMIN_USERS',
+      'ADMIN_ROLES',
+      'ADMIN_PERMISSIONS',
+      'ADMIN_AUDIT',
+      'ADMIN_FEATURE_FLAGS',
+      'ADMIN_SYSTEM_CONFIG',
+    ])('%s → null (system admin, not gated)', (perm) => {
+      expect(deriveFeatureCode(perm as never)).toBeNull();
+    });
+  });
+});

--- a/backend/src/__tests__/permissions/is-allowed.test.ts
+++ b/backend/src/__tests__/permissions/is-allowed.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for isAllowed() — algorithm spec: feature-permissions.md §5
+ *
+ * Algorithm rules (in order):
+ *   0a. superadmin + permission starts with "ADMIN_" → true
+ *   0b. superadmin + non-admin permission → continues normal flow (fallback only for ADMIN_*)
+ *   1.  system feature disabled (per deriveFeatureCode) → false
+ *   2.  workspace feature disabled (when workspaceId given) → false
+ *   3.  explicit REVOKE on (user, workspace) → false
+ *   3b. explicit REVOKE on (user, null=global) → false
+ *   4.  explicit GRANT on (user, workspace) → true (and feature is enabled, see rules 1-2)
+ *   4b. explicit GRANT on (user, null=global) → true
+ *   5.  permission present in workspace member's RolePreset → true
+ *   6.  permission present in user's globalRolePreset → true
+ *   default: false
+ *
+ * Strategy: mock the underlying Prisma fetcher (getEffectivePermissions) so we test
+ * the algorithm in isolation. The aggregate query lives in cache.ts and is tested separately.
+ */
+
+vi.mock('../../prisma/client.js', () => ({ prisma: {} }));
+vi.mock('../../shared/utils/permissions-cache.js', () => ({
+  getPermissionContext: vi.fn(),
+  invalidateUser: vi.fn(),
+  invalidateWorkspace: vi.fn(),
+  invalidateSystem: vi.fn(),
+}));
+
+import { isAllowed } from '../../shared/utils/permissions.js';
+import { getPermissionContext } from '../../shared/utils/permissions-cache.js';
+
+const mockedGet = vi.mocked(getPermissionContext);
+
+function makeCtx(overrides: Partial<NonNullable<Awaited<ReturnType<typeof getPermissionContext>>>> = {}) {
+  return {
+    isSuperadmin: false,
+    isGuest: false,
+    workspaceRolePermissions: new Set<string>(),
+    globalRolePermissions: new Set<string>(),
+    grants: new Set<string>(),    // "WS:perm" or "GLOBAL:perm"
+    revokes: new Set<string>(),
+    systemFeatures: {
+      LOCAL_REGISTRATION: true, SSO: true, MFA: true, EMAIL_NOTIFICATIONS: true,
+      FEEDBACK_WIDGET: true, API_KEYS: true, GLOBAL_SEARCH: true, REGISTRATION_REQUESTS: true,
+      WS_COMMENTS: true, WS_CHECKLISTS: true, WS_LABELS: true, WS_MENTIONS: true,
+      WS_BULK_OPS: true, WS_EXPORT: true, WS_TRASH: true, WS_HISTORY_UI: true,
+      WS_ONBOARDING_TOUR: true,
+    },
+    workspaceFeatures: {},
+    permissionsRev: 0,
+    systemRev: 0,
+    ...overrides,
+  } satisfies Awaited<ReturnType<typeof getPermissionContext>>;
+}
+
+beforeEach(() => {
+  mockedGet.mockReset();
+});
+
+describe('isAllowed — rule 0: superadmin shortcut for ADMIN_*', () => {
+  it('superadmin always passes ADMIN_USERS regardless of role', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ isSuperadmin: true }));
+    expect(await isAllowed('u1', null, 'ADMIN_USERS')).toBe(true);
+  });
+
+  it('superadmin always passes ADMIN_ROLES even with no role preset', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ isSuperadmin: true }));
+    expect(await isAllowed('u1', null, 'ADMIN_ROLES')).toBe(true);
+  });
+
+  it('superadmin without TASK_DELETE in any role → falls through and returns false', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ isSuperadmin: true }));
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(false);
+  });
+
+  it('superadmin with TASK_DELETE via global role → true', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({ isSuperadmin: true, globalRolePermissions: new Set(['TASK_DELETE']) }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(true);
+  });
+});
+
+describe('isAllowed — rule 1: system feature off blocks gated permissions', () => {
+  it('WS_COMMENTS system-off blocks COMMENT_CREATE everywhere', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        systemFeatures: { ...makeCtxDefaults().systemFeatures, WS_COMMENTS: false },
+        workspaceRolePermissions: new Set(['COMMENT_CREATE']),
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'COMMENT_CREATE')).toBe(false);
+  });
+
+  it('core permission (TASK_READ) is not affected by system feature toggles', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        workspaceRolePermissions: new Set(['TASK_READ']),
+        systemFeatures: { ...makeCtxDefaults().systemFeatures, FEEDBACK_WIDGET: false },
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'TASK_READ')).toBe(true);
+  });
+});
+
+describe('isAllowed — rule 2: workspace feature off', () => {
+  it('WS_COMMENTS off in workspace blocks COMMENT_CREATE there', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        workspaceRolePermissions: new Set(['COMMENT_CREATE']),
+        workspaceFeatures: { WS_COMMENTS: false },
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'COMMENT_CREATE')).toBe(false);
+  });
+
+  it('WS_LABELS off blocks LABEL_CREATE even with explicit GRANT override', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        grants: new Set(['WS:LABEL_CREATE']),
+        workspaceFeatures: { WS_LABELS: false },
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'LABEL_CREATE')).toBe(false);
+  });
+
+  it('workspace feature gate is skipped when workspaceId is null', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        globalRolePermissions: new Set(['COMMENT_READ']),
+        workspaceFeatures: { WS_COMMENTS: false },
+      }),
+    );
+    expect(await isAllowed('u1', null, 'COMMENT_READ')).toBe(true);
+  });
+});
+
+describe('isAllowed — rules 3 & 3b: explicit REVOKE wins', () => {
+  it('workspace REVOKE blocks even if role grants permission', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        workspaceRolePermissions: new Set(['TASK_DELETE']),
+        revokes: new Set(['WS:TASK_DELETE']),
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(false);
+  });
+
+  it('global REVOKE blocks across all workspaces', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        globalRolePermissions: new Set(['TASK_DELETE']),
+        revokes: new Set(['GLOBAL:TASK_DELETE']),
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(false);
+  });
+
+  it('REVOKE beats GRANT on same scope', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        grants: new Set(['WS:TASK_DELETE']),
+        revokes: new Set(['WS:TASK_DELETE']),
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(false);
+  });
+
+  it('workspace REVOKE does NOT affect another workspace', async () => {
+    mockedGet.mockResolvedValueOnce(
+      makeCtx({
+        workspaceRolePermissions: new Set(['TASK_DELETE']),
+        revokes: new Set([]),
+      }),
+    );
+    expect(await isAllowed('u1', 'ws-other', 'TASK_DELETE')).toBe(true);
+  });
+});
+
+describe('isAllowed — rules 4 & 4b: explicit GRANT', () => {
+  it('workspace GRANT enables permission not in role', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ grants: new Set(['WS:TASK_DELETE']) }));
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(true);
+  });
+
+  it('global GRANT enables permission across workspaces', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ grants: new Set(['GLOBAL:TASK_DELETE']) }));
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(true);
+    expect(await isAllowed('u1', 'ws2', 'TASK_DELETE')).toBe(true);
+  });
+});
+
+describe('isAllowed — rule 5: workspace role preset', () => {
+  it('permission in workspace role → true', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ workspaceRolePermissions: new Set(['TASK_CREATE']) }));
+    expect(await isAllowed('u1', 'ws1', 'TASK_CREATE')).toBe(true);
+  });
+
+  it('permission missing from workspace role → falls through', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ workspaceRolePermissions: new Set(['TASK_READ']) }));
+    expect(await isAllowed('u1', 'ws1', 'TASK_DELETE')).toBe(false);
+  });
+});
+
+describe('isAllowed — rule 6: global role preset fallback', () => {
+  it('permission in global role applies when workspace role does not have it', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        workspaceRolePermissions: new Set([]),
+        globalRolePermissions: new Set(['TASK_READ']),
+      }),
+    );
+    expect(await isAllowed('u1', 'ws1', 'TASK_READ')).toBe(true);
+  });
+
+  it('global role works when workspaceId is null', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ globalRolePermissions: new Set(['ADMIN_AUDIT']) }));
+    expect(await isAllowed('u1', null, 'ADMIN_AUDIT')).toBe(true);
+  });
+});
+
+describe('isAllowed — default deny', () => {
+  it('no role, no override, no superadmin → false', async () => {
+    mockedGet.mockResolvedValue(makeCtx());
+    expect(await isAllowed('u1', 'ws1', 'TASK_READ')).toBe(false);
+  });
+
+  it('user has only unrelated permissions → false for requested', async () => {
+    mockedGet.mockResolvedValue(makeCtx({ workspaceRolePermissions: new Set(['LABEL_READ']) }));
+    expect(await isAllowed('u1', 'ws1', 'BOARD_DELETE')).toBe(false);
+  });
+});
+
+describe('isAllowed — opts.withRolePermissions (board override scope)', () => {
+  it('withRolePermissions replaces the workspace role permissions used in rule 5', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({ workspaceRolePermissions: new Set(['TASK_READ']) }),
+    );
+    expect(
+      await isAllowed('u1', 'ws1', 'TASK_CREATE', {
+        withRolePermissions: new Set(['TASK_READ', 'TASK_CREATE', 'TASK_UPDATE']),
+      }),
+    ).toBe(true);
+  });
+
+  it('withRolePermissions does NOT fall through to global role (HIGH-1 fail-closed)', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({
+        workspaceRolePermissions: new Set(['TASK_DELETE']),
+        globalRolePermissions: new Set(['ADMIN_AUDIT']),
+      }),
+    );
+    // Board-override scopes the role strictly — global ADMIN_AUDIT does not apply on this board.
+    expect(
+      await isAllowed('u1', 'ws1', 'ADMIN_AUDIT', {
+        withRolePermissions: new Set(['TASK_READ']),
+      }),
+    ).toBe(false);
+  });
+
+  it('Empty withRolePermissions denies everything except superadmin and explicit grants', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({ globalRolePermissions: new Set(['TASK_READ']) }),
+    );
+    expect(
+      await isAllowed('u1', 'ws1', 'TASK_READ', {
+        withRolePermissions: new Set(),
+      }),
+    ).toBe(false);
+  });
+
+  it('Rule 4 GRANT still wins over withRolePermissions — explicit grant survives board scope', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({ grants: new Set(['WS:TASK_DELETE']) }),
+    );
+    expect(
+      await isAllowed('u1', 'ws1', 'TASK_DELETE', {
+        withRolePermissions: new Set(['TASK_READ']),
+      }),
+    ).toBe(true);
+  });
+
+  it('Rule 3 REVOKE still wins over withRolePermissions', async () => {
+    mockedGet.mockResolvedValue(
+      makeCtx({ revokes: new Set(['WS:TASK_DELETE']) }),
+    );
+    expect(
+      await isAllowed('u1', 'ws1', 'TASK_DELETE', {
+        withRolePermissions: new Set(['TASK_DELETE']),
+      }),
+    ).toBe(false);
+  });
+});
+
+// helper used inside the describe blocks (defined here, hoisted)
+function makeCtxDefaults() {
+  return makeCtx();
+}

--- a/backend/src/prisma/migrations/20260518143122_add_feature_permissions_and_board_acl/migration.sql
+++ b/backend/src/prisma/migrations/20260518143122_add_feature_permissions_and_board_acl/migration.sql
@@ -1,0 +1,235 @@
+-- CreateEnum
+CREATE TYPE "PermissionCode" AS ENUM ('TASK_READ', 'BOARD_READ', 'WORKFLOW_READ', 'LABEL_READ', 'COMMENT_READ', 'CHECKLIST_READ', 'HISTORY_READ', 'WORKSPACE_READ', 'TASK_CREATE', 'TASK_UPDATE', 'TASK_DELETE', 'TASK_REASSIGN', 'TASK_BULK_EDIT', 'TASK_EXPORT', 'BOARD_CREATE', 'BOARD_UPDATE', 'BOARD_DELETE', 'BOARD_MANAGE_COLUMNS', 'BOARD_MANAGE_ACL', 'WORKFLOW_CREATE', 'WORKFLOW_UPDATE', 'WORKFLOW_DELETE', 'LABEL_CREATE', 'LABEL_UPDATE', 'LABEL_DELETE', 'COMMENT_CREATE', 'COMMENT_UPDATE_OWN', 'COMMENT_DELETE_OWN', 'COMMENT_DELETE_ANY', 'CHECKLIST_WRITE', 'WS_INVITE_MEMBER', 'WS_REMOVE_MEMBER', 'WS_CHANGE_MEMBER_ROLE', 'WS_EDIT_SETTINGS', 'WS_EDIT_SECURITY', 'WS_TOGGLE_FEATURES', 'WS_DELETE', 'WS_RESTORE_FROM_TRASH', 'ADMIN_USERS', 'ADMIN_ROLES', 'ADMIN_PERMISSIONS', 'ADMIN_AUDIT', 'ADMIN_FEATURE_FLAGS', 'ADMIN_SYSTEM_CONFIG');
+
+-- CreateEnum
+CREATE TYPE "PermissionType" AS ENUM ('GRANT', 'REVOKE');
+
+-- CreateEnum
+CREATE TYPE "FeatureScope" AS ENUM ('SYSTEM', 'WORKSPACE');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "globalRolePresetId" TEXT,
+ADD COLUMN     "permissions_rev" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "workspace_members" ADD COLUMN     "is_guest" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "role_preset_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "system_features" (
+    "code" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "system_features_pkey" PRIMARY KEY ("code")
+);
+
+-- CreateTable
+CREATE TABLE "workspace_features" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "workspace_features_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "role_presets" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "display_name" TEXT NOT NULL,
+    "scope" "FeatureScope" NOT NULL,
+    "is_system" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "role_presets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "role_permissions" (
+    "id" TEXT NOT NULL,
+    "presetId" TEXT NOT NULL,
+    "permission" "PermissionCode" NOT NULL,
+
+    CONSTRAINT "role_permissions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_permissions" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "workspaceId" TEXT,
+    "permission" "PermissionCode" NOT NULL,
+    "type" "PermissionType" NOT NULL,
+    "grantedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_permissions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "board_members" (
+    "id" TEXT NOT NULL,
+    "boardId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role_preset_id" TEXT,
+    "added_by" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "board_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workspace_features_workspaceId_code_key" ON "workspace_features"("workspaceId", "code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "role_presets_name_key" ON "role_presets"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "role_permissions_presetId_permission_key" ON "role_permissions"("presetId", "permission");
+
+-- CreateIndex
+CREATE INDEX "user_permissions_userId_workspaceId_idx" ON "user_permissions"("userId", "workspaceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_permissions_userId_workspaceId_permission_key" ON "user_permissions"("userId", "workspaceId", "permission");
+
+-- CreateIndex
+CREATE INDEX "board_members_userId_idx" ON "board_members"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "board_members_boardId_userId_key" ON "board_members"("boardId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_globalRolePresetId_fkey" FOREIGN KEY ("globalRolePresetId") REFERENCES "role_presets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workspace_members" ADD CONSTRAINT "workspace_members_role_preset_id_fkey" FOREIGN KEY ("role_preset_id") REFERENCES "role_presets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workspace_features" ADD CONSTRAINT "workspace_features_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_presetId_fkey" FOREIGN KEY ("presetId") REFERENCES "role_presets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "board_members" ADD CONSTRAINT "board_members_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "boards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "board_members" ADD CONSTRAINT "board_members_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "board_members" ADD CONSTRAINT "board_members_role_preset_id_fkey" FOREIGN KEY ("role_preset_id") REFERENCES "role_presets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Seed + Backfill (G2-1, G2-2)
+-- Idempotent — uses ON CONFLICT DO NOTHING for re-running safety.
+-- ─────────────────────────────────────────────────────────────────────────
+
+-- 1. Seed system feature flags (defaults: all enabled)
+INSERT INTO "system_features" ("code", "enabled", "updatedAt") VALUES
+  ('LOCAL_REGISTRATION',    true, NOW()),
+  ('SSO',                   true, NOW()),
+  ('MFA',                   true, NOW()),
+  ('EMAIL_NOTIFICATIONS',   true, NOW()),
+  ('FEEDBACK_WIDGET',       true, NOW()),
+  ('API_KEYS',              true, NOW()),
+  ('GLOBAL_SEARCH',         true, NOW()),
+  ('REGISTRATION_REQUESTS', true, NOW())
+ON CONFLICT ("code") DO NOTHING;
+
+-- 2. Seed system role presets (fixed UUIDs for deterministic backfill)
+INSERT INTO "role_presets" ("id", "name", "display_name", "scope", "is_system", "createdAt", "updatedAt") VALUES
+  ('00000000-0000-0000-0000-000000000001', 'system:owner',  'Owner',  'WORKSPACE', true, NOW(), NOW()),
+  ('00000000-0000-0000-0000-000000000002', 'system:member', 'Member', 'WORKSPACE', true, NOW(), NOW()),
+  ('00000000-0000-0000-0000-000000000003', 'system:viewer', 'Viewer', 'WORKSPACE', true, NOW(), NOW()),
+  ('00000000-0000-0000-0000-000000000004', 'system:admin',  'Admin',  'SYSTEM',    true, NOW(), NOW())
+ON CONFLICT ("name") DO NOTHING;
+
+-- 3. Seed RolePermission for system:viewer (8 codes — READ only)
+INSERT INTO "role_permissions" ("id", "presetId", "permission")
+SELECT gen_random_uuid(), '00000000-0000-0000-0000-000000000003', p::"PermissionCode"
+FROM (VALUES
+  ('TASK_READ'), ('BOARD_READ'), ('WORKFLOW_READ'), ('LABEL_READ'),
+  ('COMMENT_READ'), ('CHECKLIST_READ'), ('HISTORY_READ'), ('WORKSPACE_READ')
+) AS t(p)
+ON CONFLICT ("presetId", "permission") DO NOTHING;
+
+-- 4. Seed RolePermission for system:member (viewer + non-destructive writes; without TASK_EXPORT — plan §Open Q1)
+INSERT INTO "role_permissions" ("id", "presetId", "permission")
+SELECT gen_random_uuid(), '00000000-0000-0000-0000-000000000002', p::"PermissionCode"
+FROM (VALUES
+  -- viewer baseline
+  ('TASK_READ'), ('BOARD_READ'), ('WORKFLOW_READ'), ('LABEL_READ'),
+  ('COMMENT_READ'), ('CHECKLIST_READ'), ('HISTORY_READ'), ('WORKSPACE_READ'),
+  -- additions for member
+  ('TASK_CREATE'), ('TASK_UPDATE'), ('TASK_REASSIGN'), ('TASK_BULK_EDIT'),
+  ('BOARD_CREATE'), ('BOARD_UPDATE'),
+  ('LABEL_CREATE'), ('LABEL_UPDATE'),
+  ('COMMENT_CREATE'), ('COMMENT_UPDATE_OWN'), ('COMMENT_DELETE_OWN'),
+  ('CHECKLIST_WRITE')
+) AS t(p)
+ON CONFLICT ("presetId", "permission") DO NOTHING;
+
+-- 5. Seed RolePermission for system:owner (all workspace-scope permissions)
+INSERT INTO "role_permissions" ("id", "presetId", "permission")
+SELECT gen_random_uuid(), '00000000-0000-0000-0000-000000000001', p::"PermissionCode"
+FROM (VALUES
+  -- everything from member
+  ('TASK_READ'), ('BOARD_READ'), ('WORKFLOW_READ'), ('LABEL_READ'),
+  ('COMMENT_READ'), ('CHECKLIST_READ'), ('HISTORY_READ'), ('WORKSPACE_READ'),
+  ('TASK_CREATE'), ('TASK_UPDATE'), ('TASK_REASSIGN'), ('TASK_BULK_EDIT'), ('TASK_EXPORT'),
+  ('BOARD_CREATE'), ('BOARD_UPDATE'),
+  ('LABEL_CREATE'), ('LABEL_UPDATE'),
+  ('COMMENT_CREATE'), ('COMMENT_UPDATE_OWN'), ('COMMENT_DELETE_OWN'),
+  ('CHECKLIST_WRITE'),
+  -- owner additions
+  ('TASK_DELETE'),
+  ('BOARD_DELETE'), ('BOARD_MANAGE_COLUMNS'), ('BOARD_MANAGE_ACL'),
+  ('LABEL_DELETE'),
+  ('COMMENT_DELETE_ANY'),
+  ('WORKFLOW_CREATE'), ('WORKFLOW_UPDATE'), ('WORKFLOW_DELETE'),
+  ('WS_INVITE_MEMBER'), ('WS_REMOVE_MEMBER'), ('WS_CHANGE_MEMBER_ROLE'),
+  ('WS_EDIT_SETTINGS'), ('WS_EDIT_SECURITY'), ('WS_TOGGLE_FEATURES'),
+  ('WS_DELETE'), ('WS_RESTORE_FROM_TRASH')
+) AS t(p)
+ON CONFLICT ("presetId", "permission") DO NOTHING;
+
+-- 6. Seed RolePermission for system:admin (system scope)
+INSERT INTO "role_permissions" ("id", "presetId", "permission")
+SELECT gen_random_uuid(), '00000000-0000-0000-0000-000000000004', p::"PermissionCode"
+FROM (VALUES
+  ('ADMIN_USERS'), ('ADMIN_ROLES'), ('ADMIN_PERMISSIONS'),
+  ('ADMIN_AUDIT'), ('ADMIN_FEATURE_FLAGS'), ('ADMIN_SYSTEM_CONFIG')
+) AS t(p)
+ON CONFLICT ("presetId", "permission") DO NOTHING;
+
+-- 7. Backfill WorkspaceMember.role_preset_id from legacy role enum
+UPDATE "workspace_members"
+   SET "role_preset_id" = '00000000-0000-0000-0000-000000000001'
+ WHERE "role_preset_id" IS NULL AND "role" = 'OWNER';
+
+UPDATE "workspace_members"
+   SET "role_preset_id" = '00000000-0000-0000-0000-000000000002'
+ WHERE "role_preset_id" IS NULL AND "role" = 'MEMBER';
+
+UPDATE "workspace_members"
+   SET "role_preset_id" = '00000000-0000-0000-0000-000000000003'
+ WHERE "role_preset_id" IS NULL AND "role" = 'VIEWER';
+
+-- 8. Backfill User.globalRolePresetId for superadmins
+UPDATE "users"
+   SET "globalRolePresetId" = '00000000-0000-0000-0000-000000000004'
+ WHERE "globalRolePresetId" IS NULL AND "isSuperadmin" = true;
+
+-- 9. Sanity: ensure no board has NULL is_private
+UPDATE "boards" SET "isPrivate" = false WHERE "isPrivate" IS NULL;

--- a/backend/src/prisma/migrations/20260518151650_harden_role_preset_fk_restrict/migration.sql
+++ b/backend/src/prisma/migrations/20260518151650_harden_role_preset_fk_restrict/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "board_members" DROP CONSTRAINT "board_members_role_preset_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "users" DROP CONSTRAINT "users_globalRolePresetId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "workspace_members" DROP CONSTRAINT "workspace_members_role_preset_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_globalRolePresetId_fkey" FOREIGN KEY ("globalRolePresetId") REFERENCES "role_presets"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workspace_members" ADD CONSTRAINT "workspace_members_role_preset_id_fkey" FOREIGN KEY ("role_preset_id") REFERENCES "role_presets"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "board_members" ADD CONSTRAINT "board_members_role_preset_id_fkey" FOREIGN KEY ("role_preset_id") REFERENCES "role_presets"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -27,6 +27,13 @@ model User {
   createdAt            DateTime  @default(now())
   updatedAt            DateTime  @updatedAt
 
+  // Feature-permissions (G2-1) — fallback to isSuperadmin remains for Phase 1+2
+  globalRolePresetId String?
+  globalRolePreset   RolePreset?      @relation("UserGlobalRole", fields: [globalRolePresetId], references: [id], onDelete: Restrict)
+  permissionsRev     Int              @default(0) @map("permissions_rev")
+  userPermissions    UserPermission[]
+  boardMemberships   BoardMember[]
+
   refreshTokens        RefreshToken[]
   passwordResetTokens  PasswordResetToken[]
   apiKeys              ApiKey[]
@@ -137,6 +144,7 @@ model Workspace {
   boards      Board[]
   labels      Label[]
   events      WorkspaceEvent[]
+  features    WorkspaceFeature[]
 
   @@index([deletedAt])
   @@map("workspaces")
@@ -146,12 +154,15 @@ model WorkspaceMember {
   id             String        @id @default(uuid())
   workspaceId    String
   userId         String
-  role           WorkspaceRole @default(MEMBER)
+  role           WorkspaceRole @default(MEMBER) // deprecated — kept for Phase 1+2 backward compat
+  rolePresetId   String?       @map("role_preset_id")
+  isGuest        Boolean       @default(false) @map("is_guest")
   mfaGraceUntil  DateTime?
   createdAt      DateTime      @default(now())
 
-  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  workspace  Workspace   @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rolePreset RolePreset? @relation(fields: [rolePresetId], references: [id], onDelete: Restrict)
 
   @@unique([workspaceId, userId])
   @@map("workspace_members")
@@ -243,9 +254,10 @@ model Board {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  workflow  Workflow  @relation(fields: [workflowId], references: [id])
+  workspace Workspace     @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  workflow  Workflow      @relation(fields: [workflowId], references: [id])
   tasks     Task[]
+  members   BoardMember[]
 
   @@unique([workspaceId, prefix])
   @@map("boards")
@@ -479,4 +491,159 @@ model Notification {
 
   @@index([userId, isRead, createdAt(sort: Desc)])
   @@map("notifications")
+}
+
+// ─── Feature-Permissions + ACL (G2-1, G2-2) ──────────────────────────────────
+
+enum PermissionCode {
+  // READ
+  TASK_READ
+  BOARD_READ
+  WORKFLOW_READ
+  LABEL_READ
+  COMMENT_READ
+  CHECKLIST_READ
+  HISTORY_READ
+  WORKSPACE_READ
+
+  // WRITE — tasks
+  TASK_CREATE
+  TASK_UPDATE
+  TASK_DELETE
+  TASK_REASSIGN
+  TASK_BULK_EDIT
+  TASK_EXPORT
+
+  // WRITE — boards / workflows
+  BOARD_CREATE
+  BOARD_UPDATE
+  BOARD_DELETE
+  BOARD_MANAGE_COLUMNS
+  BOARD_MANAGE_ACL
+  WORKFLOW_CREATE
+  WORKFLOW_UPDATE
+  WORKFLOW_DELETE
+
+  // WRITE — labels / comments / checklists
+  LABEL_CREATE
+  LABEL_UPDATE
+  LABEL_DELETE
+  COMMENT_CREATE
+  COMMENT_UPDATE_OWN
+  COMMENT_DELETE_OWN
+  COMMENT_DELETE_ANY
+  CHECKLIST_WRITE
+
+  // WORKSPACE admin
+  WS_INVITE_MEMBER
+  WS_REMOVE_MEMBER
+  WS_CHANGE_MEMBER_ROLE
+  WS_EDIT_SETTINGS
+  WS_EDIT_SECURITY
+  WS_TOGGLE_FEATURES
+  WS_DELETE
+  WS_RESTORE_FROM_TRASH
+
+  // SYSTEM admin
+  ADMIN_USERS
+  ADMIN_ROLES
+  ADMIN_PERMISSIONS
+  ADMIN_AUDIT
+  ADMIN_FEATURE_FLAGS
+  ADMIN_SYSTEM_CONFIG
+}
+
+enum PermissionType {
+  GRANT
+  REVOKE
+}
+
+enum FeatureScope {
+  SYSTEM
+  WORKSPACE
+}
+
+model SystemFeature {
+  code      String   @id
+  enabled   Boolean  @default(true)
+  updatedAt DateTime @updatedAt
+  updatedBy String?
+
+  @@map("system_features")
+}
+
+model WorkspaceFeature {
+  id          String   @id @default(uuid())
+  workspaceId String
+  code        String
+  enabled     Boolean  @default(true)
+  updatedAt   DateTime @updatedAt
+  updatedBy   String?
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@unique([workspaceId, code])
+  @@map("workspace_features")
+}
+
+model RolePreset {
+  id          String       @id @default(uuid())
+  name        String       @unique
+  displayName String       @map("display_name")
+  scope       FeatureScope
+  isSystem    Boolean      @default(false) @map("is_system")
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+
+  permissions    RolePermission[]
+  workspaceUsers WorkspaceMember[]
+  boardMembers   BoardMember[]
+  globalUsers    User[]            @relation("UserGlobalRole")
+
+  @@map("role_presets")
+}
+
+model RolePermission {
+  id         String         @id @default(uuid())
+  presetId   String
+  permission PermissionCode
+
+  preset RolePreset @relation(fields: [presetId], references: [id], onDelete: Cascade)
+
+  @@unique([presetId, permission])
+  @@map("role_permissions")
+}
+
+model UserPermission {
+  id          String         @id @default(uuid())
+  userId      String
+  workspaceId String?
+  permission  PermissionCode
+  type        PermissionType
+  grantedBy   String?
+  createdAt   DateTime       @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, workspaceId, permission])
+  @@index([userId, workspaceId])
+  @@map("user_permissions")
+}
+
+model BoardMember {
+  id           String   @id @default(uuid())
+  boardId      String
+  userId       String
+  rolePresetId String?  @map("role_preset_id") // null = explicit DENIED
+  addedBy      String   @map("added_by")
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  board      Board       @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rolePreset RolePreset? @relation(fields: [rolePresetId], references: [id], onDelete: Restrict)
+
+  @@unique([boardId, userId])
+  @@index([userId])
+  @@map("board_members")
 }

--- a/backend/src/shared/middleware/require-permission.ts
+++ b/backend/src/shared/middleware/require-permission.ts
@@ -1,0 +1,203 @@
+/**
+ * Permission middleware factories.
+ *
+ * Spec: plan.md Step 1.5.
+ *
+ * Three families:
+ *   - requirePermission(code)       — workspace-scoped check via isAllowed
+ *   - featureGate(featureCode, scope) — short-circuit 404/403 before routing
+ *   - requireBoardAccess()          — attach req.boardAccess, 403 BOARD_ACCESS_DENIED
+ *   - requireBoardAction(perm)      — canAccessBoard + isAllowed(withRole)
+ *
+ * Phase 1: only used on new endpoints (admin permissions, workspace features,
+ * board members). Phase 2 will swap existing assertOwner / role-string checks
+ * inside services.
+ */
+
+import type { Response, NextFunction } from 'express';
+import { AppError } from './error-handler.js';
+import type { AuthRequest } from '../types/index.js';
+import {
+  isAllowed,
+  canAccessBoard,
+  canActOnBoard,
+  deriveFeatureCode,
+  type PermissionCode,
+  type BoardAccessResult,
+} from '../utils/permissions.js';
+import { getPermissionContext } from '../utils/permissions-cache.js';
+import { prisma } from '../../prisma/client.js';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    boardAccess?: BoardAccessResult;
+  }
+}
+
+export interface RequirePermissionOptions {
+  /** Name of the route param that holds the workspaceId. Default: 'workspaceId'. */
+  workspaceParam?: string;
+}
+
+/**
+ * Reject the request if the user lacks `permission` in the workspace
+ * referenced by `req.params[opts.workspaceParam]`.
+ */
+export function requirePermission(
+  permission: PermissionCode,
+  opts: RequirePermissionOptions = {},
+) {
+  const param = opts.workspaceParam ?? 'workspaceId';
+
+  return async (req: AuthRequest, _res: Response, next: NextFunction) => {
+    try {
+      if (!req.user?.userId) return next(new AppError(401, 'Не авторизован'));
+
+      const workspaceId = (req.params[param] as string | undefined) ?? null;
+      const ok = await isAllowed(req.user.userId, workspaceId, permission);
+      if (ok) return next();
+
+      // Diagnose why: feature-disabled vs missing permission
+      const ctx = await getPermissionContext(req.user.userId, workspaceId);
+      const featureCode = deriveFeatureCode(permission);
+      if (featureCode && ctx.systemFeatures[featureCode] === false) {
+        return next(
+          new AppError(
+            403,
+            'Функциональность отключена администратором',
+            { feature: featureCode },
+            'FEATURE_DISABLED',
+          ),
+        );
+      }
+      if (featureCode && workspaceId && ctx.workspaceFeatures[featureCode] === false) {
+        return next(
+          new AppError(
+            403,
+            'Функциональность отключена в этом пространстве',
+            { feature: featureCode },
+            'FEATURE_DISABLED',
+          ),
+        );
+      }
+      next(
+        new AppError(
+          403,
+          'Недостаточно прав',
+          { permission },
+          'INSUFFICIENT_PERMISSION',
+        ),
+      );
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export type FeatureScope = 'system' | 'workspace';
+
+/**
+ * Short-circuits routes when a feature is disabled.
+ *
+ * - scope='system': returns 404 — endpoint behaves as if it doesn't exist.
+ *   Queries the system_features table directly, no per-user context needed.
+ *   Safe to mount before `authenticate`.
+ * - scope='workspace': returns 403 FEATURE_DISABLED. Reads workspace_features
+ *   for the workspaceId resolved from the request param. The check does NOT
+ *   verify workspace membership — pair with `requirePermission`/route guards
+ *   that already do (H1 fix, security-review.md).
+ */
+export function featureGate(
+  featureCode: string,
+  scope: FeatureScope,
+  workspaceParam = 'workspaceId',
+) {
+  return async (req: AuthRequest, _res: Response, next: NextFunction) => {
+    try {
+      const systemRow = await prisma.systemFeature.findUnique({
+        where: { code: featureCode },
+        select: { enabled: true },
+      });
+      // Default-allow if the row is missing (feature not registered yet).
+      if (systemRow && systemRow.enabled === false) {
+        return next(new AppError(404, 'Не найдено'));
+      }
+
+      if (scope === 'workspace') {
+        const workspaceId = (req.params[workspaceParam] as string | undefined) ?? null;
+        if (!workspaceId) return next(); // route mounted on global path — workspace check N/A
+        const wsRow = await prisma.workspaceFeature.findUnique({
+          where: { workspaceId_code: { workspaceId, code: featureCode } },
+          select: { enabled: true },
+        });
+        if (wsRow && wsRow.enabled === false) {
+          return next(
+            new AppError(
+              403,
+              'Функциональность отключена в этом пространстве',
+              { feature: featureCode },
+              'FEATURE_DISABLED',
+            ),
+          );
+        }
+      }
+
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+/**
+ * Attach req.boardAccess after running canAccessBoard. 403 if denied.
+ */
+export function requireBoardAccess(boardParam = 'boardId') {
+  return async (req: AuthRequest, _res: Response, next: NextFunction) => {
+    try {
+      if (!req.user?.userId) return next(new AppError(401, 'Не авторизован'));
+      const boardId = req.params[boardParam] as string | undefined;
+      if (!boardId) return next(new AppError(400, 'Не указан boardId'));
+
+      const access = await canAccessBoard(req.user.userId, boardId);
+      if (!access.allowed) {
+        return next(new AppError(403, 'Нет доступа к доске', undefined, 'BOARD_ACCESS_DENIED'));
+      }
+      req.boardAccess = access;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+/**
+ * Combines requireBoardAccess + canActOnBoard. workspaceId is read from the
+ * BoardAccessResult to avoid the second DB fetch / TOCTOU window
+ * (H2, security-review.md).
+ */
+export function requireBoardAction(permission: PermissionCode, boardParam = 'boardId') {
+  return async (req: AuthRequest, _res: Response, next: NextFunction) => {
+    try {
+      if (!req.user?.userId) return next(new AppError(401, 'Не авторизован'));
+      const boardId = req.params[boardParam] as string | undefined;
+      if (!boardId) return next(new AppError(400, 'Не указан boardId'));
+
+      const access = req.boardAccess ?? (await canAccessBoard(req.user.userId, boardId));
+      if (!access.allowed || !access.workspaceId) {
+        return next(new AppError(403, 'Нет доступа к доске', undefined, 'BOARD_ACCESS_DENIED'));
+      }
+      req.boardAccess = access;
+
+      const ok = await canActOnBoard(req.user.userId, boardId, permission, access.workspaceId);
+      if (!ok) {
+        return next(
+          new AppError(403, 'Недостаточно прав', { permission }, 'INSUFFICIENT_PERMISSION'),
+        );
+      }
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/backend/src/shared/utils/permissions-cache.ts
+++ b/backend/src/shared/utils/permissions-cache.ts
@@ -1,0 +1,240 @@
+/**
+ * Permission cache layer.
+ *
+ * Spec: plan.md §Caching strategy.
+ *
+ * Provides cached access to the full permission context for (userId, workspaceId)
+ * pairs, with explicit invalidation hooks called from mutation paths.
+ *
+ * Implementation notes:
+ *   - In-memory Map keyed by `userId:workspaceId`. Two secondary indexes
+ *     (by user, by workspace) allow O(1) bulk invalidation.
+ *   - In-flight Promise coalescing: if two callers request the same key
+ *     before the DB has answered, they share one query.
+ *   - Default TTL: 5 minutes. Stale entries are evicted on read.
+ *   - `fresh: true` callers always re-fetch and do NOT update the cache —
+ *     critical for security-changing endpoints that need a guaranteed-current
+ *     read without poisoning the entry that other readers may rely on.
+ */
+
+import { loadPermissionContextFromDb, loadBoardAccessContextFromDb } from './permissions-loader.js';
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export interface PermissionContext {
+  isSuperadmin: boolean;
+  isGuest: boolean;
+  workspaceRolePermissions: Set<string>;
+  globalRolePermissions: Set<string>;
+  /** Override keys formatted as "WS:<perm>" or "GLOBAL:<perm>". */
+  grants: Set<string>;
+  /** Same encoding as grants. REVOKE always wins over GRANT. */
+  revokes: Set<string>;
+  systemFeatures: Record<string, boolean>;
+  workspaceFeatures: Record<string, boolean>;
+  permissionsRev: number;
+  systemRev: number;
+}
+
+export interface BoardAccessContext {
+  isSuperadmin: boolean;
+  workspaceId: string;
+  workspaceDeletedAt: string | null;
+  isWorkspaceMember: boolean;
+  isWorkspaceOwner: boolean;
+  workspaceRolePresetId: string | null;
+  isGuest: boolean;
+  boardIsPrivate: boolean;
+  boardMember: { rolePresetId: string | null } | null;
+}
+
+// ─── Cache state ─────────────────────────────────────────────────────────────
+
+interface CacheEntry {
+  value: PermissionContext;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<PermissionContext>>();
+
+/**
+ * Generation counter per key. Incremented by any invalidation. An in-flight DB
+ * promise captures the generation at start time and refuses to write back if
+ * the generation has moved — this is the fix for HIGH-2 (race condition where
+ * a stale fetch repopulates the cache after invalidation).
+ */
+const generations = new Map<string, number>();
+
+/** userId → set of cache keys (for invalidateUser). */
+const byUser = new Map<string, Set<string>>();
+/** workspaceId → set of cache keys (for invalidateWorkspace). */
+const byWorkspace = new Map<string, Set<string>>();
+
+function keyFor(userId: string, workspaceId: string | null): string {
+  return `${userId}:${workspaceId ?? 'null'}`;
+}
+
+function indexInsert(userId: string, workspaceId: string | null, key: string): void {
+  let userSet = byUser.get(userId);
+  if (!userSet) {
+    userSet = new Set();
+    byUser.set(userId, userSet);
+  }
+  userSet.add(key);
+
+  if (workspaceId) {
+    let wsSet = byWorkspace.get(workspaceId);
+    if (!wsSet) {
+      wsSet = new Set();
+      byWorkspace.set(workspaceId, wsSet);
+    }
+    wsSet.add(key);
+  }
+}
+
+function indexRemove(key: string): void {
+  for (const [userId, set] of byUser) {
+    if (set.delete(key) && set.size === 0) byUser.delete(userId);
+  }
+  for (const [wsId, set] of byWorkspace) {
+    if (set.delete(key) && set.size === 0) byWorkspace.delete(wsId);
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface GetPermissionContextOptions {
+  /** Bypass cache: always read from DB, do not update cache. */
+  fresh?: boolean;
+}
+
+export async function getPermissionContext(
+  userId: string,
+  workspaceId: string | null,
+  opts: GetPermissionContextOptions = {},
+): Promise<PermissionContext> {
+  if (opts.fresh) {
+    return loadPermissionContextFromDb(userId, workspaceId);
+  }
+
+  const key = keyFor(userId, workspaceId);
+  const now = Date.now();
+  const entry = cache.get(key);
+
+  if (entry && entry.expiresAt > now) {
+    return entry.value;
+  }
+  if (entry) {
+    // expired
+    cache.delete(key);
+    indexRemove(key);
+  }
+
+  // Coalesce concurrent reads
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const generationAtStart = generations.get(key) ?? 0;
+
+  const p = loadPermissionContextFromDb(userId, workspaceId)
+    .then((value) => {
+      // HIGH-2 fix: if an invalidation bumped the generation while we were
+      // fetching, refuse to write stale data back to the cache. Returning
+      // the value is fine — the caller asked for a fresh read anyway.
+      if ((generations.get(key) ?? 0) === generationAtStart) {
+        cache.set(key, { value, expiresAt: Date.now() + DEFAULT_TTL_MS });
+        indexInsert(userId, workspaceId, key);
+      }
+      return value;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+
+  inflight.set(key, p);
+  return p;
+}
+
+function bumpGeneration(key: string): void {
+  generations.set(key, (generations.get(key) ?? 0) + 1);
+}
+
+export async function getBoardAccessContext(
+  userId: string,
+  boardId: string,
+): Promise<BoardAccessContext> {
+  // Board access context is small and changes per board — for now skip caching.
+  // Optimization: integrate with the main cache once permissionsRev covers
+  // BoardMember mutations (Phase 1.4 follow-up).
+  return loadBoardAccessContextFromDb(userId, boardId);
+}
+
+// ─── Invalidation hooks ──────────────────────────────────────────────────────
+
+/**
+ * Returns all in-flight cache keys that belong to a given user. Used to bump
+ * generations on invalidation even before the original fetch has settled
+ * (HIGH-2 race: invalidation arrives during the DB fetch window).
+ */
+function inflightKeysForUser(userId: string): string[] {
+  const prefix = `${userId}:`;
+  return [...inflight.keys()].filter((k) => k.startsWith(prefix));
+}
+
+function inflightKeysForWorkspace(workspaceId: string): string[] {
+  const suffix = `:${workspaceId}`;
+  return [...inflight.keys()].filter((k) => k.endsWith(suffix));
+}
+
+export function invalidateUser(userId: string): void {
+  // Bump generations for all keys (cached + in-flight) so any pending fetch
+  // refuses to write back stale data.
+  for (const key of inflightKeysForUser(userId)) bumpGeneration(key);
+
+  const keys = byUser.get(userId);
+  if (keys) {
+    for (const key of keys) {
+      cache.delete(key);
+      bumpGeneration(key);
+      for (const set of byWorkspace.values()) set.delete(key);
+    }
+    byUser.delete(userId);
+  }
+}
+
+export function invalidateWorkspace(workspaceId: string): void {
+  for (const key of inflightKeysForWorkspace(workspaceId)) bumpGeneration(key);
+
+  const keys = byWorkspace.get(workspaceId);
+  if (keys) {
+    for (const key of keys) {
+      cache.delete(key);
+      bumpGeneration(key);
+      for (const set of byUser.values()) set.delete(key);
+    }
+    byWorkspace.delete(workspaceId);
+  }
+}
+
+export function invalidateSystem(): void {
+  // Bump generations for all in-flight keys so any pending fetch refuses to
+  // write back stale data.
+  for (const key of inflight.keys()) bumpGeneration(key);
+  for (const key of cache.keys()) bumpGeneration(key);
+  cache.clear();
+  inflight.clear();
+  byUser.clear();
+  byWorkspace.clear();
+}
+
+/** Test-only helper: wipes everything including in-flight promises. */
+export function __clearCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+  byUser.clear();
+  byWorkspace.clear();
+  generations.clear();
+}

--- a/backend/src/shared/utils/permissions-loader.ts
+++ b/backend/src/shared/utils/permissions-loader.ts
@@ -1,0 +1,186 @@
+/**
+ * DB layer for permission context. Isolated from the cache so unit tests can
+ * mock this single module.
+ *
+ * The single SQL aggregate query is intentionally untyped at the
+ * Prisma level — we fan out parallel `findMany` calls because Prisma's typed
+ * API gives readable code and the cache layer means the cost is paid at most
+ * once per (user, workspace, rev) window.
+ *
+ * See plan.md §Caching strategy.
+ */
+
+import { prisma } from '../../prisma/client.js';
+import type { PermissionContext, BoardAccessContext } from './permissions-cache.js';
+
+/**
+ * Load the permission set for a single role preset.
+ *
+ * Used by canActOnBoard to scope rule 5 to a per-board override. Tiny query
+ * (one preset, ~40 rows max) so we leave caching to a higher layer for now.
+ */
+export async function loadPresetPermissions(presetId: string): Promise<ReadonlySet<string>> {
+  const rows = await prisma.rolePermission.findMany({
+    where: { presetId },
+    select: { permission: true },
+  });
+  return new Set(rows.map((r) => r.permission as string));
+}
+
+const SYSTEM_OWNER = 'system:owner';
+
+/**
+ * Loads everything the permission engine needs in a single round-trip-ish
+ * fetch. Currently uses 4–7 Prisma queries in parallel; can be replaced with
+ * a single `prisma.$queryRaw` once Phase 2 deployment confirms p95 budget.
+ */
+export async function loadPermissionContextFromDb(
+  userId: string,
+  workspaceId: string | null,
+): Promise<PermissionContext> {
+  const userP = prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      isSuperadmin: true,
+      permissionsRev: true,
+      globalRolePresetId: true,
+      globalRolePreset: { select: { permissions: { select: { permission: true } } } },
+    },
+  });
+  const wsMemberP = workspaceId
+    ? prisma.workspaceMember.findUnique({
+        where: { workspaceId_userId: { workspaceId, userId } },
+        select: {
+          isGuest: true,
+          rolePresetId: true,
+          rolePreset: { select: { name: true, permissions: { select: { permission: true } } } },
+        },
+      })
+    : Promise.resolve(null);
+  const systemFeaturesP = prisma.systemFeature.findMany({
+    select: { code: true, enabled: true },
+  });
+  const workspaceFeaturesP = workspaceId
+    ? prisma.workspaceFeature.findMany({
+        where: { workspaceId },
+        select: { code: true, enabled: true },
+      })
+    : Promise.resolve([]);
+  const overridesP = prisma.userPermission.findMany({
+    where: {
+      userId,
+      OR: [{ workspaceId: null }, ...(workspaceId ? [{ workspaceId }] : [])],
+    },
+    select: { permission: true, type: true, workspaceId: true },
+  });
+  const systemRevP = prisma.systemFeature.aggregate({ _max: { updatedAt: true } });
+
+  const [user, wsMember, systemFeatures, workspaceFeatures, overrides, systemRevAgg] =
+    await Promise.all([userP, wsMemberP, systemFeaturesP, workspaceFeaturesP, overridesP, systemRevP]);
+
+  if (!user) {
+    return emptyContext();
+  }
+
+  const grants = new Set<string>();
+  const revokes = new Set<string>();
+  for (const o of overrides) {
+    const scope = o.workspaceId ? 'WS' : 'GLOBAL';
+    const key = `${scope}:${o.permission}`;
+    (o.type === 'GRANT' ? grants : revokes).add(key);
+  }
+
+  return {
+    isSuperadmin: user.isSuperadmin,
+    isGuest: wsMember?.isGuest ?? false,
+    workspaceRolePermissions: new Set(
+      wsMember?.rolePreset?.permissions.map((p) => p.permission as string) ?? [],
+    ),
+    globalRolePermissions: new Set(
+      user.globalRolePreset?.permissions.map((p) => p.permission as string) ?? [],
+    ),
+    grants,
+    revokes,
+    systemFeatures: Object.fromEntries(systemFeatures.map((f) => [f.code, f.enabled])),
+    workspaceFeatures: Object.fromEntries(workspaceFeatures.map((f) => [f.code, f.enabled])),
+    permissionsRev: user.permissionsRev,
+    systemRev: systemRevAgg._max.updatedAt?.getTime() ?? 0,
+  };
+}
+
+export async function loadBoardAccessContextFromDb(
+  userId: string,
+  boardId: string,
+): Promise<BoardAccessContext> {
+  const [user, board] = await Promise.all([
+    prisma.user.findUnique({ where: { id: userId }, select: { isSuperadmin: true } }),
+    prisma.board.findUnique({
+      where: { id: boardId },
+      select: {
+        isPrivate: true,
+        workspaceId: true,
+        workspace: { select: { deletedAt: true } },
+      },
+    }),
+  ]);
+
+  if (!board || !user) {
+    return {
+      isSuperadmin: user?.isSuperadmin ?? false,
+      // Board not found: conservative default — treat as private and unknown ws.
+      // canAccessBoard will deny based on rule 0c (not workspace member).
+      workspaceId: board?.workspaceId ?? '',
+      workspaceDeletedAt: null,
+      isWorkspaceMember: false,
+      isWorkspaceOwner: false,
+      workspaceRolePresetId: null,
+      isGuest: false,
+      boardIsPrivate: true,
+      boardMember: null,
+    };
+  }
+
+  const [wsMember, boardMember] = await Promise.all([
+    prisma.workspaceMember.findUnique({
+      where: { workspaceId_userId: { workspaceId: board.workspaceId, userId } },
+      select: {
+        isGuest: true,
+        rolePresetId: true,
+        rolePreset: { select: { name: true } },
+      },
+    }),
+    prisma.boardMember.findUnique({
+      where: { boardId_userId: { boardId, userId } },
+      select: { rolePresetId: true },
+    }),
+  ]);
+
+  return {
+    isSuperadmin: user.isSuperadmin,
+    workspaceId: board.workspaceId,
+    workspaceDeletedAt: board.workspace.deletedAt
+      ? board.workspace.deletedAt.toISOString()
+      : null,
+    isWorkspaceMember: wsMember !== null,
+    isWorkspaceOwner: wsMember?.rolePreset?.name === SYSTEM_OWNER,
+    workspaceRolePresetId: wsMember?.rolePresetId ?? null,
+    isGuest: wsMember?.isGuest ?? false,
+    boardIsPrivate: board.isPrivate,
+    boardMember,
+  };
+}
+
+function emptyContext(): PermissionContext {
+  return {
+    isSuperadmin: false,
+    isGuest: false,
+    workspaceRolePermissions: new Set(),
+    globalRolePermissions: new Set(),
+    grants: new Set(),
+    revokes: new Set(),
+    systemFeatures: {},
+    workspaceFeatures: {},
+    permissionsRev: 0,
+    systemRev: 0,
+  };
+}

--- a/backend/src/shared/utils/permissions.ts
+++ b/backend/src/shared/utils/permissions.ts
@@ -1,0 +1,250 @@
+/**
+ * Permission engine — pure algorithm functions.
+ *
+ * Spec: docs/design/feature-permissions.md §5 (isAllowed)
+ *       docs/design/board-acl.md §4 (canAccessBoard)
+ *
+ * DB access happens via permissions-cache.ts. This module orchestrates the
+ * decision logic in a side-effect-free way.
+ */
+
+import {
+  getPermissionContext,
+  getBoardAccessContext,
+  type PermissionContext,
+  type BoardAccessContext,
+} from './permissions-cache.js';
+import { loadPresetPermissions } from './permissions-loader.js';
+
+// ─── Permission code domain ──────────────────────────────────────────────────
+
+import type { PermissionCode as PrismaPermissionCode } from '@prisma/client';
+export type PermissionCode = PrismaPermissionCode;
+
+/**
+ * Workspace-level feature codes that gate certain permissions.
+ * See feature-permissions.md §3 (Level 2) and plan.md Step 1.3.
+ */
+const FEATURE_CODE_BY_PERMISSION: Record<string, string> = {
+  // WS_COMMENTS
+  COMMENT_READ: 'WS_COMMENTS',
+  COMMENT_CREATE: 'WS_COMMENTS',
+  COMMENT_UPDATE_OWN: 'WS_COMMENTS',
+  COMMENT_DELETE_OWN: 'WS_COMMENTS',
+  COMMENT_DELETE_ANY: 'WS_COMMENTS',
+
+  // WS_CHECKLISTS
+  CHECKLIST_READ: 'WS_CHECKLISTS',
+  CHECKLIST_WRITE: 'WS_CHECKLISTS',
+
+  // WS_LABELS
+  LABEL_READ: 'WS_LABELS',
+  LABEL_CREATE: 'WS_LABELS',
+  LABEL_UPDATE: 'WS_LABELS',
+  LABEL_DELETE: 'WS_LABELS',
+
+  // WS_BULK_OPS
+  TASK_BULK_EDIT: 'WS_BULK_OPS',
+
+  // WS_EXPORT
+  TASK_EXPORT: 'WS_EXPORT',
+
+  // WS_HISTORY_UI — UI gate only; API remains open by design (plan §Open Q5)
+  HISTORY_READ: 'WS_HISTORY_UI',
+};
+
+/**
+ * Maps a PermissionCode to the FeatureCode that gates it, or null if the
+ * permission is part of the core product (always available) or describes a
+ * feature toggle itself.
+ */
+export function deriveFeatureCode(permission: PermissionCode): string | null {
+  return FEATURE_CODE_BY_PERMISSION[permission] ?? null;
+}
+
+// ─── isAllowed ───────────────────────────────────────────────────────────────
+
+export interface IsAllowedOptions {
+  /**
+   * Override the role permission set used in rule 5. When set, rule 5 uses
+   * this set exclusively and rule 6 (global role fallback) is skipped — this
+   * is the strict scoping required by per-board overrides. Callers obtain
+   * the set from loadPresetPermissions().
+   */
+  withRolePermissions?: ReadonlySet<string>;
+}
+
+/**
+ * Returns true iff the user is allowed to perform `permission` in the
+ * given workspace context. workspaceId=null means a global / cross-workspace
+ * check (e.g. admin endpoints).
+ */
+export async function isAllowed(
+  userId: string,
+  workspaceId: string | null,
+  permission: PermissionCode,
+  opts: IsAllowedOptions = {},
+): Promise<boolean> {
+  const ctx = await getPermissionContext(userId, workspaceId);
+  return decide(ctx, workspaceId, permission, opts);
+}
+
+function decide(
+  ctx: PermissionContext,
+  workspaceId: string | null,
+  permission: PermissionCode,
+  opts: IsAllowedOptions,
+): boolean {
+  // Rule 0: superadmin shortcut — only for ADMIN_* permissions. Other
+  //          permissions still go through the regular flow so RBAC-debug
+  //          tooling can detect misconfigured admin roles.
+  if (ctx.isSuperadmin && permission.startsWith('ADMIN_')) return true;
+
+  const featureCode = deriveFeatureCode(permission);
+
+  // Rule 1: system feature disabled
+  if (featureCode && ctx.systemFeatures[featureCode] === false) return false;
+
+  // Rule 2: workspace feature disabled
+  if (workspaceId && featureCode && ctx.workspaceFeatures[featureCode] === false) {
+    return false;
+  }
+
+  // Rule 3: explicit REVOKE wins over GRANT and roles
+  if (workspaceId && ctx.revokes.has(`WS:${permission}`)) return false;
+  if (ctx.revokes.has(`GLOBAL:${permission}`)) return false;
+
+  // Rule 4: explicit GRANT
+  if (workspaceId && ctx.grants.has(`WS:${permission}`)) return true;
+  if (ctx.grants.has(`GLOBAL:${permission}`)) return true;
+
+  // Rule 5: workspace role preset (or per-board override).
+  // When withRolePermissions is set we are evaluating a per-board override —
+  // rule 5 uses that set exclusively and rule 6 (global fallback) is skipped.
+  // This is the strict scoping per board-acl SDD §4 (HIGH-1, code-review.md).
+  if (opts.withRolePermissions !== undefined) {
+    return opts.withRolePermissions.has(permission);
+  }
+
+  if (ctx.workspaceRolePermissions.has(permission)) return true;
+
+  // Rule 6: global role preset fallback (only when no per-board override is in play)
+  if (ctx.globalRolePermissions.has(permission)) return true;
+
+  return false;
+}
+
+// Export decide() so unit tests can hit the algorithm directly without async
+// mocking ceremony. Not used by production callers.
+export const __decideForTests = decide;
+
+// ─── canAccessBoard ──────────────────────────────────────────────────────────
+
+export type BoardAccessSource =
+  | 'superadmin'
+  | 'workspace-owner'
+  | 'workspace'
+  | 'board-override'
+  | 'denied';
+
+export interface BoardAccessResult {
+  allowed: boolean;
+  /** The effective role preset id under which this access is granted. */
+  role: string | null;
+  source: BoardAccessSource;
+  /** The workspaceId of the board — surfaced so callers avoid a second board fetch (H2). */
+  workspaceId: string | null;
+}
+
+export async function canAccessBoard(
+  userId: string,
+  boardId: string,
+): Promise<BoardAccessResult> {
+  const ctx = await getBoardAccessContext(userId, boardId);
+  return decideBoardAccess(ctx);
+}
+
+function decideBoardAccess(ctx: BoardAccessContext): BoardAccessResult {
+  const wsId = ctx.workspaceId;
+
+  // 0a: superadmin
+  if (ctx.isSuperadmin) {
+    return { allowed: true, role: 'system:admin', source: 'superadmin', workspaceId: wsId };
+  }
+
+  // 0b: soft-deleted workspace
+  if (ctx.workspaceDeletedAt !== null) {
+    return { allowed: false, role: null, source: 'denied', workspaceId: wsId };
+  }
+
+  // 0c: user must be a workspace member
+  if (!ctx.isWorkspaceMember) {
+    return { allowed: false, role: null, source: 'denied', workspaceId: wsId };
+  }
+
+  // 1: workspace owner is never blocked (cannot be denied or guestified)
+  if (ctx.isWorkspaceOwner) {
+    return {
+      allowed: true,
+      role: ctx.workspaceRolePresetId,
+      source: 'workspace-owner',
+      workspaceId: wsId,
+    };
+  }
+
+  // 2: explicit per-board DENY
+  if (ctx.boardMember && ctx.boardMember.rolePresetId === null) {
+    return { allowed: false, role: null, source: 'denied', workspaceId: wsId };
+  }
+
+  // 3: explicit per-board OVERRIDE
+  if (ctx.boardMember && ctx.boardMember.rolePresetId !== null) {
+    return {
+      allowed: true,
+      role: ctx.boardMember.rolePresetId,
+      source: 'board-override',
+      workspaceId: wsId,
+    };
+  }
+
+  // 4: guest without an explicit BoardMember entry — even public boards stay hidden
+  if (ctx.isGuest) {
+    return { allowed: false, role: null, source: 'denied', workspaceId: wsId };
+  }
+
+  // 5: private board without an explicit BoardMember entry
+  if (ctx.boardIsPrivate) {
+    return { allowed: false, role: null, source: 'denied', workspaceId: wsId };
+  }
+
+  // 6: public board, fall back to workspace role
+  return {
+    allowed: true,
+    role: ctx.workspaceRolePresetId,
+    source: 'workspace',
+    workspaceId: wsId,
+  };
+}
+
+// ─── canActOnBoard ───────────────────────────────────────────────────────────
+
+export async function canActOnBoard(
+  userId: string,
+  boardId: string,
+  permission: PermissionCode,
+  workspaceId: string,
+): Promise<boolean> {
+  const access = await canAccessBoard(userId, boardId);
+  if (!access.allowed) return false;
+
+  // Only the explicit per-board override changes scope. Workspace-owner and
+  // workspace (default) keep the regular role-fallback semantics, while
+  // superadmin reaches Rule 0a inside isAllowed for ADMIN_* permissions.
+  if (access.source === 'board-override' && access.role) {
+    const overridePermissions = await loadPresetPermissions(access.role);
+    return isAllowed(userId, workspaceId, permission, {
+      withRolePermissions: overridePermissions,
+    });
+  }
+  return isAllowed(userId, workspaceId, permission);
+}

--- a/docs/design/board-acl.md
+++ b/docs/design/board-acl.md
@@ -1,0 +1,371 @@
+# SDD: Per-board ACL
+
+> Status: **APPROVED** (G2-2, 2026-05-18)
+> Owner: jackrescuer-gif
+> Дата: 2026-05-18
+> Связанный документ: [feature-permissions.md](./feature-permissions.md) (G2-1, утверждён)
+
+## 1. Цель
+
+Дать workspace owner возможность управлять доступом участников **к конкретным доскам**: давать разные роли на разные доски, ограничивать доступ только к одной доске, явно запрещать доступ.
+
+Текущая модель — плоская: если пользователь `WorkspaceMember`, он видит **все** доски. Поле `Board.isPrivate` существует, но не используется в коде.
+
+## 2. Контекст и принципы
+
+### Существующее состояние
+
+```prisma
+model Board {
+  isPrivate Boolean @default(false)  // существует, не используется
+  // ...
+}
+model WorkspaceMember { workspaceId, userId, role }
+```
+
+В коде нет ни одной проверки на `Board.isPrivate`. Список досок отдаёт `boards.service.listByWorkspace(wsId)` без фильтра по доступу пользователя.
+
+### Принципы (после обсуждения)
+
+1. **Полная ACL `(user × board × role)`** — выбрано на G2-1.
+2. **Override-модель**: base = workspace role; per-board override либо переопределяет роль, либо явно запрещает доступ.
+3. **Public boards (`isPrivate = false`)** — workspace role работает по умолчанию; per-board override опционален.
+4. **Private boards (`isPrivate = true`)** — доступ **только** через явный `BoardMember` (allow-list). Owner workspace всегда видит все доски workspace (включая private — иначе он не сможет их администрировать).
+5. **Per-board роль** — переиспользуем `RolePreset` из feature-permissions с `scope = WORKSPACE`. То есть на доску можно дать «system:viewer» даже если в workspace у человека «system:member».
+6. **Гость к одной доске**: `BoardMember` нельзя добавить для пользователя, которого нет в `WorkspaceMember`. Но при API-вызове `POST /api/boards/:id/members { userId }` backend **автоматически** создаёт `WorkspaceMember` с `isGuest = true`. Гость видит **только** доски, где у него есть `BoardMember` — никакие public-доски workspace ему не доступны. В UI он «привязан» к доске: его My Tasks, Activity, Search ограничены этим набором досок.
+
+## 3. Модель данных
+
+### 3.1 Новая модель
+
+```prisma
+model BoardMember {
+  id           String   @id @default(uuid())
+  boardId      String
+  userId       String
+  rolePresetId String?              // null = denied (явный запрет доступа)
+  addedBy      String                // userId, кто добавил
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  board      Board       @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rolePreset RolePreset? @relation(fields: [rolePresetId], references: [id])
+
+  @@unique([boardId, userId])
+  @@index([userId])
+  @@map("board_members")
+}
+```
+
+**Семантика записи `BoardMember`**:
+| `rolePresetId` | Значение |
+|----------------|----------|
+| `null`         | **DENIED** — доступ явно запрещён, перекрывает workspace role |
+| `<preset.id>`  | **OVERRIDE** — на эту доску действует указанный preset вместо workspace role |
+
+Отсутствие записи = используется workspace role (для public board) или нет доступа (для private board).
+
+### 3.2 Расширение существующих моделей
+
+```prisma
+model Board {
+  isPrivate Boolean @default(false)
+  members   BoardMember[]
+  // ...
+}
+
+model User {
+  boardMemberships BoardMember[]
+  // ...
+}
+
+model RolePreset {
+  boardMembers BoardMember[]
+  // ...
+}
+
+model WorkspaceMember {
+  // ...
+  isGuest Boolean @default(false) @map("is_guest")
+}
+```
+
+`Board.isPrivate` остаётся булевым полем, **начинает использоваться** в логике доступа.
+
+`WorkspaceMember.isGuest = true` помечает пользователей, добавленных автоматически через `BoardMember` для не-WorkspaceMember. Влияет на:
+- `canAccessBoard` — пропускает правило «public board → workspace role» (гость видит только explicit boards).
+- UI workspace — навигация, Activity, My Tasks, search ограничены доступными досками.
+- Workspace settings — гость не виден в общем списке участников; отображается отдельной секцией «Гости» (read-only для owner).
+
+## 4. Алгоритм эффективного доступа
+
+```
+canAccessBoard(userId, boardId) =>
+  user = User(userId)
+  board = Board(boardId)
+  ws   = Workspace(board.workspaceId)
+
+  // 0. superadmin / soft-deleted workspace
+  if user.isSuperadmin: return { allowed: true, role: 'system:admin' }
+  if ws.deletedAt !== null: return { allowed: false }
+
+  wsMember = WorkspaceMember(ws.id, userId)
+  if !wsMember: return { allowed: false }
+
+  bm = BoardMember(boardId, userId)
+
+  // 1. Workspace owner всегда видит все доски (включая private)
+  //    Owner не может быть guest — это проверяется на API уровне (см. R-GUEST в §9).
+  if wsMember.rolePreset.name == 'system:owner': return { allowed: true, role: wsMember.rolePresetId }
+
+  // 2. Явный per-board DENIED
+  if bm and bm.rolePresetId == null: return { allowed: false }
+
+  // 3. Явный per-board OVERRIDE
+  if bm and bm.rolePresetId: return { allowed: true, role: bm.rolePresetId }
+
+  // 4. Guest без explicit BoardMember → нет доступа (даже к public boards)
+  if wsMember.isGuest: return { allowed: false }
+
+  // 5. Private board без записи → нет доступа
+  if board.isPrivate: return { allowed: false }
+
+  // 6. Public board → workspace role
+  return { allowed: true, role: wsMember.rolePresetId }
+```
+
+`canActOnBoard(userId, boardId, permission)`:
+```
+access = canAccessBoard(userId, boardId)
+if !access.allowed: return false
+return isAllowed(userId, ws.id, permission, withRole = access.role)
+```
+
+Функция `isAllowed` из `feature-permissions.md` §5 получает аргумент `withRole?` чтобы заменить дефолтный workspace role на per-board role при проверке.
+
+### 4.1 Особые случаи
+
+| Сценарий | Результат |
+|----------|-----------|
+| User в WorkspaceMember (не guest), без BoardMember, board public | Доступ по workspace role |
+| User в WorkspaceMember (не guest), без BoardMember, board private | Нет доступа |
+| User в WorkspaceMember (`system:viewer`), BoardMember с `system:member` | На эту доску читает+пишет (override повышает) |
+| User в WorkspaceMember (`system:member`), BoardMember с `null` (denied) | На эту доску **нет** доступа (override понижает в zero) |
+| User не в WorkspaceMember, но в BoardMember | Невозможно — auto-create `WorkspaceMember(isGuest=true)` при POST на BoardMember |
+| Guest, board public, без BoardMember | Нет доступа (правило 4 блокирует public default) |
+| Guest, board с explicit BoardMember | Доступ по per-board role |
+| Owner workspace, BoardMember с `null` для себя | Доступ есть (правило 1 перекрывает) — owner нельзя «забанить» с доски |
+| Superadmin | Доступ ко всему |
+
+## 5. API контракты
+
+### 5.1 Endpoints
+
+```
+GET    /api/boards/:boardId/members
+       — список BoardMember + computed effective access для всех WS members
+       → BoardAccessRowDto[]
+
+POST   /api/boards/:boardId/members
+       { userId | email, rolePresetId | null }   // null = explicit DENY
+       — если userId не WorkspaceMember → auto-create WorkspaceMember(isGuest=true)
+       — если передан email и user не существует → создать User + invite flow
+       → BoardMemberDto
+
+PATCH  /api/boards/:boardId/members/:userId
+       { rolePresetId | null }
+       → BoardMemberDto
+
+DELETE /api/boards/:boardId/members/:userId
+       — удаляет запись BoardMember, возвращает к workspace-default (или к no-access если guest)
+       — если у user не остаётся ни одной BoardMember-записи и isGuest=true → удалить WorkspaceMember
+       → 204
+
+PATCH  /api/boards/:boardId
+       { isPrivate?: boolean, ... }
+       — toggle private/public; при переходе public→private требует minimum 1 BoardMember (или сам owner)
+```
+
+### 5.2 DTO
+
+```typescript
+type BoardMemberDto = {
+  userId: string;
+  rolePresetId: string | null;     // null = DENIED
+  rolePreset: RolePresetDto | null;
+  addedBy: string;
+  createdAt: string;
+};
+
+type BoardAccessRowDto = {
+  userId: string;
+  user: { id: string; name: string; email: string; avatar: string | null };
+  source: 'workspace' | 'board-override' | 'board-denied' | 'workspace-owner' | 'superadmin';
+  effectiveRolePresetId: string | null;     // null если denied
+  effectiveRoleDisplayName: string | null;
+  canEdit: boolean;                          // может ли текущий пользователь править эту строку
+};
+```
+
+### 5.3 RBAC на сами эндпоинты
+
+- Управлять BoardMember может пользователь с пермиссией `BOARD_MANAGE_ACL`. Эта пермиссия по умолчанию входит в `system:owner` и кастомные роли по выбору owner-а.
+- Менять `Board.isPrivate` — только `system:owner` workspace (или `BOARD_MANAGE_ACL` + `BOARD_UPDATE`).
+
+### 5.4 Коды ошибок
+
+| Код | HTTP | Когда |
+|-----|------|-------|
+| `BOARD_ACCESS_DENIED` | 403 | `canAccessBoard` = false |
+| `CANNOT_DENY_OWNER` | 409 | Попытка `POST /members` с rolePresetId=null для пользователя с workspace-ролью `system:owner` |
+| `PRIVATE_BOARD_NEEDS_MEMBER` | 409 | Попытка `isPrivate: true` без хотя бы одного BoardMember |
+| `INVALID_ROLE_SCOPE` | 400 | `rolePresetId` указывает на роль с `scope != WORKSPACE` |
+| `CANNOT_GUESTIFY_OWNER` | 409 | Попытка автосоздания WorkspaceMember с isGuest=true для user, который уже owner workspace или superadmin |
+
+## 6. UX & Accessibility
+
+### 6.1 Где появляется UI
+
+**Локация A — Board page → новая кнопка «Доступ»** (header или меню «...»)
+Открывает modal/drawer «Доступ к доске».
+
+**Локация B — WorkspaceSettings → вкладка «Участники»**
+В строке участника — кнопка «Показать доступ к доскам» → раскрывается таблица `board × role` для этого пользователя.
+
+### 6.2 Modal «Доступ к доске» (локация A)
+
+Поля:
+- Toggle «Приватная доска» (с подсказкой: «Если включено — только явно добавленные участники видят доску»)
+- Список всех `WorkspaceMember`:
+  - Аватар + имя
+  - Источник доступа (badge): «Через workspace» / «Per-board override» / «Запрещён» / «Owner»
+  - Dropdown «Роль» с системными + кастомными ролями + опция «Запретить доступ» + опция «Сбросить (как в workspace)»
+  - Disabled state для owner workspace и superadmin (нельзя изменить)
+
+### 6.3 Required UI states
+
+- [x] **Loading** — skeleton-строки списка
+- [x] **Empty** — для public board без overrides: «Все участники workspace видят эту доску по умолчанию. Добавьте override при необходимости.»
+- [x] **Error** — toast + retry; partial-fail при батч-операциях не делаем (одна мутация = одна строка)
+- [x] **Confirmation** — modal перед переключением public → private с подсчётом потенциально теряющих доступ: «35 участников потеряют доступ. Продолжить?»
+- [x] **Disabled** — для owner workspace dropdown disabled с tooltip «Owner всегда имеет доступ»
+- [x] **Optimistic** — изменение роли применяется оптимистично с rollback при ошибке (с aria-live объявлением)
+
+### 6.4 Клавиатурный сценарий
+
+- Tab по строкам списка, dropdown открывается Enter/Space
+- Esc закрывает modal с подтверждением если есть несохранённые изменения
+- Visible focus на каждой строке
+
+### 6.5 Screen reader
+
+- Список — `role="list"`, строки — `role="listitem"`
+- Dropdown — стандартная `combobox` semantics с aria-expanded/aria-activedescendant
+- При изменении роли — `aria-live="polite"`: «Роль Анны изменена на Viewer»
+- Confirmation modal — `role="alertdialog"`
+
+### 6.6 Touch / responsive
+
+- Mobile: modal становится bottom-sheet на всю высоту
+- Строка участника — высота ≥ 56 для удобного нажатия dropdown
+- Длинные имена/email обрезаются с tooltip
+
+### 6.7 Edge данные
+
+- 500+ участников в workspace → виртуальный скролл (`react-window` или существующий паттерн)
+- Поиск по имени/email в header modal
+- Фильтр «Только с per-board override» / «Все»
+
+### 6.8 UI для гостя
+
+Если у текущего пользователя `WorkspaceMember.isGuest = true` в данном workspace:
+
+- **Workspace switcher (topbar)** — показывает workspace name + badge «Гость», entry-point ведёт на единственную доступную доску (или список из 2-3 если их несколько).
+- **Сайдбар Boards** — отфильтрован: только доски с explicit BoardMember (не все public).
+- **My Tasks** — задачи только из доступных досок.
+- **Activity / Last activity feed** — события только из доступных досок (фильтр на бэкенде по `canAccessBoard`).
+- **Global search (Cmd+K)** — результаты только из доступных досок.
+- **Mentions picker** — гость видит других участников **только своей доски** (BoardMember-список), не workspace-список.
+- **WorkspaceSettings** — пункт меню скрыт целиком; даже если гость заходит по прямому URL — 403.
+
+### 6.9 UI для owner — секция «Гости»
+
+В `WorkspaceSettingsPage → Участники`:
+
+- Основной список — `WorkspaceMember WHERE isGuest = false`.
+- Отдельная свёрнутая секция «Гости (N)» — список с `isGuest = true`:
+  - Аватар, имя, email
+  - Колонка «Доступ к доскам» — список названий досок, к которым у гостя есть BoardMember
+  - Кнопка «Повысить до участника» — снимает `isGuest`, проставляет дефолтную роль (например `system:member`)
+  - Кнопка «Удалить» — каскадно удаляет WorkspaceMember и все BoardMember
+
+## 7. Стыки
+
+### Backend
+
+- `backend/src/prisma/schema.prisma` — `BoardMember` + relations + `Board.members`.
+- `backend/src/modules/boards/boards.router.ts` — endpoints из §5.1.
+- `backend/src/modules/boards/boards.service.ts`:
+  - `listByWorkspace` — теперь фильтрует по `canAccessBoard` для текущего пользователя.
+  - `getById` — проверяет `canAccessBoard`.
+  - Новые методы `listMembers`, `addMember`, `updateMember`, `removeMember`.
+- `backend/src/modules/boards/boards.dto.ts` — `addBoardMemberDto`, `updateBoardMemberDto`.
+- `backend/src/shared/utils/permissions.ts` — добавить `canAccessBoard`, `canActOnBoard`.
+- `backend/src/shared/middleware/require-board-access.ts` — новое middleware на маршрутах `/api/boards/:boardId/*` и `/api/tasks/*` (через `task.boardId`).
+- `backend/src/modules/tasks/tasks.service.ts` — все list/get методы проверяют `canAccessBoard(task.boardId)`.
+
+### Frontend
+
+- `frontend/src/api/boards.ts` — клиенты новых endpoints.
+- `frontend/src/components/BoardAccessModal.tsx` — новый компонент (локация A).
+- `frontend/src/pages/BoardPage.tsx` — кнопка «Доступ» (видна с `BOARD_MANAGE_ACL`).
+- `frontend/src/pages/WorkspaceSettingsPage.tsx` — расширить `renderMembers()` секцией «Доступ к доскам» (локация B).
+- `frontend/src/components/BoardCard.tsx` (в списке досок) — фильтрация по `canAccessBoard` уже на backend, но скрытие/полупрозрачность для досок с `denied` не нужно — они просто не приходят.
+- `frontend/src/store/boards.store.ts` — invalidate при изменении BoardMember.
+
+### Что не трогаем
+
+- `Task` модель — права на задачи косвенно через `Task.boardId`.
+- Комментарии/чеклисты — наследуют доступ от родительской задачи.
+
+## 8. Миграционный план
+
+Одна миграция, additive:
+
+1. `CREATE TABLE board_members (...)`.
+2. `ALTER TABLE workspace_members ADD COLUMN is_guest BOOLEAN NOT NULL DEFAULT false`. Все существующие WorkspaceMember → `isGuest = false`.
+3. **Никакого backfill для BoardMember** — таблица стартует пустая. Public boards (текущий дефолт `isPrivate=false`) работают как раньше через workspace role.
+4. Phase 2 (отдельный PR): включить проверки `canAccessBoard` в backend (list, get, mutations, notifications, search).
+5. Phase 3: UI «Доступ к доске» в Board page и расширение WorkspaceSettings (включая секцию «Гости»).
+
+**Backward compat**: `Board.isPrivate` уже существует, но не используется. После Phase 2 значение начинает действовать. Audit: убедиться что все существующие доски имеют `isPrivate=false` (миграция: `UPDATE boards SET is_private = false WHERE is_private IS NULL` — на всякий случай).
+
+## 9. Риски
+
+| # | Риск | Вероятность | Mitigation |
+|---|------|-------------|------------|
+| R1 | Запрос «список досок workspace» N+1 по `canAccessBoard` | Высокая | Один запрос: `JOIN BoardMember`. В сервисе — батч-расчёт effective access для списка доступных досок. |
+| R2 | Owner случайно делает private+забывает добавить себя | Низкая | Правило 1 (owner всегда видит) — спасает. Плюс UI препятствует создать private без членов (R8 ниже). |
+| R3 | Per-board роли с `WS_*` permissions (выходящими за доску) | Средняя | `RolePreset` для board override должна содержать только `BOARD_*`, `TASK_*`, `COMMENT_*`, `CHECKLIST_*`, `LABEL_READ` коды. Валидация на API: warn если preset содержит WS-коды, эффективно игнорируем для board scope. |
+| R4 | Cascading delete BoardMember при удалении Board | Низкая | `onDelete: Cascade` в схеме. |
+| R5 | Notification spam для denied users | Средняя | Notification service должен учитывать `canAccessBoard` перед отправкой (mention в задаче недоступной доски — skip). |
+| R6 | E2E тесты падают потому что user без BoardMember не видит доску | Высокая | Seed обновить: в существующих фикстурах все боарды public, как сейчас. Новые тесты для private + ACL — отдельным suite. |
+| R7 | Filter на серверной стороне не учитывает override | Средняя | Серверные фильтры досок (`gap-02 серверные фильтры`) уже работают через `boards.service`, наследуют новую проверку. Тест-кейс обязателен. |
+| R8 | Permission caching не инвалидирует при `BoardMember` мутации | Средняя | `permissions.store` уже инвалидируется на mutation; добавить эмит `board:access-changed` через WebSocket / refresh trigger. |
+| R9 | Private toggle с 0 BoardMember сделает доску невидимой никому кроме owner | Низкая | API возвращает `409 PRIVATE_BOARD_NEEDS_MEMBER` если попытка переключить в private без хотя бы одной записи. |
+| R-GUEST | Гость, повышенный до owner, остаётся isGuest=true → конфликт в правиле 1 algo | Средняя | При смене WorkspaceMember.rolePresetId на `system:owner` — автоматически `isGuest = false`. Тест-кейс. |
+| R-GUEST-2 | Гость через mention в комментарии получает уведомление о задаче на public board (не своей) | Высокая | Notification service фильтрует по `canAccessBoard` (см. R5). Для guest правило 4 блокирует public-доски — уведомление не уйдёт. Тест обязателен. |
+| R-GUEST-3 | DELETE последнего BoardMember у guest оставит «висячий» WorkspaceMember без любых досок | Средняя | API при DELETE проверяет: если у user `isGuest=true` и `BoardMember.count = 0` после удаления → каскадно удалить WorkspaceMember. Транзакция. |
+| R-GUEST-4 | Поднятие isPrivate→false делает доску видимой всем — но guest не должен её видеть | Низкая | Алгоритм правила 4 блокирует guest на public-досках всегда. Не зависит от isPrivate. |
+| R-GUEST-5 | Guest видит workspace name в topbar — leak? | Низкая | OK: name + список доступных досок — это и есть его рабочий контекст. Member list, settings, history workspace — недоступны. |
+
+## 10. Решения (зафиксированы 2026-05-18)
+
+1. **Default для новой доски** — `isPrivate = false`, **чекбокс «Приватная» в форме создания**. Если чекнут — после создания обязательное добавление creator в BoardMember (или owner workspace).
+2. **Search/Cmd+K и private boards** — **строгая серверная фильтрация по `canAccessBoard`**. Из результатов исчезают задачи/доски/комментарии из недоступных досок. Эндпоинт `/api/search` принимает `userId` из JWT, фильтрует через JOIN с `board_members + workspace_members`.
+3. **Глобальный аудитор (`*_READ`) и private boards** — **нет автоматического доступа**. Для аудита приватной доски owner workspace добавляет аудитора в BoardMember явно. Это сохраняет принцип «private = explicit allow-list».
+4. **`BoardMember` без `WorkspaceMember`** — **автосоздаём** `WorkspaceMember(isGuest=true)`. Гость видит **только** доски с explicit BoardMember; public-доски workspace ему недоступны. В UI workspace «привязан» к доске. Это новый кейс «гость к одной доске».
+5. **Удаление из workspace и BoardMember** — **не каскадно**. История overrides сохраняется. При возврате `WorkspaceMember` — overrides сразу в силе. Каскадное удаление только при удалении `User` целиком из системы (CASCADE на FK userId в BoardMember).
+
+---

--- a/docs/design/feature-permissions.md
+++ b/docs/design/feature-permissions.md
@@ -1,0 +1,508 @@
+# SDD: Системные feature-permissions
+
+> Status: **APPROVED** (G2-1, 2026-05-18)
+> Owner: jackrescuer-gif
+> Дата: 2026-05-18
+> Связанные документы: [board-acl.md](./board-acl.md) (G2-2, отдельно)
+
+## 1. Цель
+
+Заменить плоскую модель ролей `OWNER / MEMBER / VIEWER` на двухуровневую систему: глобальные feature-toggles + гранулярные пермиссии с пресетами ролей и индивидуальными overrides — по образцу `moex-portal`.
+
+Эта SDD покрывает **системный уровень** (superadmin) и **workspace-уровень** (owner). Per-board ACL — в отдельной SDD ([board-acl.md](./board-acl.md)).
+
+## 2. Контекст
+
+### Что есть сейчас
+
+- `WorkspaceMember.role: OWNER | MEMBER | VIEWER` — одна плоская роль на воркспейс.
+- `User.isSuperadmin: Boolean` — глобальный флаг.
+- Проверки разбросаны по сервисам в виде `if (member.role !== 'OWNER') throw forbidden`.
+- В админке есть только: список пользователей, создание, заявки на регистрацию, audit log, `updateConfig.registrationDomain`.
+- Никаких системных feature-toggles нет. Никаких настраиваемых ролей нет.
+
+### Что нужно
+
+1. **Системные toggle (superadmin)** — включить/выключить целиком модули продукта (local registration, MFA, email, feedback, integrations и т.д.) для всей инсталляции.
+2. **Workspace toggle (owner)** — owner workspace включает/выключает разрешённые фичи (комментарии, чеклисты, mentions, bulk, экспорт, history-UI и т.д.) для своих участников.
+3. **Гранулярные permission codes** — какие действия может делать конкретный пользователь с включёнными фичами.
+4. **Role presets** — именованные роли (Owner / Member / Viewer / кастомные) как пакеты пермиссий.
+5. **User overrides** — индивидуальные GRANT/REVOKE поверх роли.
+
+## 3. Инвентарь фич
+
+### Уровень 0 — ядро (не toggleable)
+
+| Фича | Модуль |
+|------|--------|
+| Auth (login/logout/refresh/password reset) | `auth` |
+| Workspaces (CRUD своих) | `workspaces` |
+| Boards (CRUD) | `boards` |
+| Tasks (CRUD, subtasks, materialized path) | `tasks` |
+| Workflows (статусы и переходы) | `workflows` |
+
+### Уровень 1 — системные toggle (superadmin)
+
+Хранятся в новой таблице `system_features`. Дефолт — все `enabled = true`.
+
+| Код | UI-название | Что выключает |
+|-----|-------------|----------------|
+| `LOCAL_REGISTRATION` | Локальная регистрация | Endpoint `POST /api/auth/register` + UI-кнопка |
+| `SSO` | SSO / Keycloak | Endpoints `/api/auth/sso/*` + UI-кнопка |
+| `MFA` | MFA / TOTP | UI настроек безопасности workspace + middleware enforcement |
+| `EMAIL_NOTIFICATIONS` | Email-уведомления | `NotificationService.sendEmail` (no-op) + UI настроек |
+| `FEEDBACK_WIDGET` | Feedback виджет | Модуль `feedback` (router отвечает 404) |
+| `API_KEYS` | API-ключи / integrations | Модуль `integrations` |
+| `GLOBAL_SEARCH` | Global search (Cmd+K) | Модуль `search` + UI-открытие палитры |
+| `REGISTRATION_REQUESTS` | Заявки на регистрацию | Flow «заявка → одобрение superadmin» |
+
+### Уровень 2 — workspace toggle (owner)
+
+Хранятся в новой таблице `workspace_features` (по записи `(workspaceId, featureCode, enabled)`). Дефолт — все `enabled = true`. **Каскад:** если системно выключено — owner не может включить.
+
+| Код | UI-название | Что выключает |
+|-----|-------------|----------------|
+| `WS_COMMENTS` | Комментарии | Comment editor в drawer + notifications о новых комментариях |
+| `WS_CHECKLISTS` | Чеклисты | Чеклист-секция в drawer |
+| `WS_MENTIONS` | @mentions | Mention-picker в comment editor |
+| `WS_LABELS` | Метки | Label-picker + фильтрация по меткам |
+| `WS_BULK_OPS` | Массовые операции | Bulk action bar |
+| `WS_EXPORT` | Экспорт CSV | Кнопки экспорта |
+| `WS_TRASH` | Корзина / soft-delete restore | Кнопка восстановления (purge всегда работает) |
+| `WS_HISTORY_UI` | History UI в drawer и workspace | UI-видимость (аудит в БД пишется всегда) |
+| `WS_ONBOARDING_TOUR` | Onboarding tour | Туториал при первом входе |
+
+**Subtasks намеренно нет** — выключение сломает materialized path.
+
+### Уровень 3 — permission codes (что пользователь может делать)
+
+Хранятся в `permission_codes` enum в Prisma. ~40 кодов. Используются в пресетах ролей (`RolePermission`) и индивидуальных overrides (`UserPermission`).
+
+```
+// READ
+TASK_READ
+TASK_READ_ALL              // включая private boards (override workspace-уровня)
+BOARD_READ
+WORKFLOW_READ
+LABEL_READ
+COMMENT_READ
+CHECKLIST_READ
+HISTORY_READ
+WORKSPACE_READ
+
+// WRITE — tasks
+TASK_CREATE
+TASK_UPDATE
+TASK_DELETE
+TASK_REASSIGN
+TASK_BULK_EDIT
+TASK_EXPORT
+
+// WRITE — boards / workflows
+BOARD_CREATE
+BOARD_UPDATE
+BOARD_DELETE
+BOARD_MANAGE_COLUMNS
+WORKFLOW_CREATE
+WORKFLOW_UPDATE
+WORKFLOW_DELETE
+
+// WRITE — labels / comments / checklists
+LABEL_CREATE
+LABEL_UPDATE
+LABEL_DELETE
+COMMENT_CREATE
+COMMENT_UPDATE_OWN
+COMMENT_DELETE_OWN
+COMMENT_DELETE_ANY
+CHECKLIST_WRITE
+
+// WORKSPACE
+WS_INVITE_MEMBER
+WS_REMOVE_MEMBER
+WS_CHANGE_MEMBER_ROLE
+WS_EDIT_SETTINGS
+WS_EDIT_SECURITY
+WS_TOGGLE_FEATURES         // включать/выключать workspace-фичи
+WS_DELETE
+WS_RESTORE_FROM_TRASH
+
+// BOARD ACL (детали в board-acl.md)
+BOARD_MANAGE_ACL
+
+// ADMIN (только для глобальных ролей)
+ADMIN_USERS
+ADMIN_ROLES
+ADMIN_PERMISSIONS
+ADMIN_AUDIT
+ADMIN_FEATURE_FLAGS
+ADMIN_SYSTEM_CONFIG
+```
+
+## 4. Модель данных (Prisma additions)
+
+### 4.1 Enums
+
+```prisma
+enum PermissionCode {
+  // ... 40 кодов из раздела 3 уровень 3
+}
+
+enum PermissionType {
+  GRANT
+  REVOKE
+}
+
+enum FeatureScope {
+  SYSTEM
+  WORKSPACE
+}
+```
+
+### 4.2 Models
+
+```prisma
+model SystemFeature {
+  code      String   @id                      // например "LOCAL_REGISTRATION"
+  enabled   Boolean  @default(true)
+  updatedAt DateTime @updatedAt
+  updatedBy String?                            // userId
+
+  @@map("system_features")
+}
+
+model WorkspaceFeature {
+  id          String   @id @default(uuid())
+  workspaceId String
+  code        String                            // например "WS_COMMENTS"
+  enabled     Boolean  @default(true)
+  updatedAt   DateTime @updatedAt
+  updatedBy   String?
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@unique([workspaceId, code])
+  @@map("workspace_features")
+}
+
+model RolePreset {
+  id          String   @id @default(uuid())
+  name        String   @unique                 // системные: "system:owner", "system:member", "system:viewer"
+  displayName String
+  scope       FeatureScope                     // SYSTEM (для админки) или WORKSPACE (для участников)
+  isSystem    Boolean  @default(false)         // системные нельзя удалить
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  permissions RolePermission[]
+  members     WorkspaceMember[]                // FK с WorkspaceMember.rolePresetId
+  globalUsers User[]                           // для SYSTEM-роли
+
+  @@map("role_presets")
+}
+
+model RolePermission {
+  id         String         @id @default(uuid())
+  presetId   String
+  permission PermissionCode
+
+  preset RolePreset @relation(fields: [presetId], references: [id], onDelete: Cascade)
+
+  @@unique([presetId, permission])
+  @@map("role_permissions")
+}
+
+model UserPermission {
+  id          String         @id @default(uuid())
+  userId      String
+  workspaceId String?                           // null = глобальный override
+  permission  PermissionCode
+  type        PermissionType                    // GRANT или REVOKE
+  grantedBy   String?
+  createdAt   DateTime       @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, workspaceId, permission])
+  @@index([userId, workspaceId])
+  @@map("user_permissions")
+}
+```
+
+### 4.3 Изменения в существующих моделях
+
+```prisma
+model User {
+  // ...
+  globalRolePresetId String?
+  globalRolePreset   RolePreset? @relation("UserGlobalRole", fields: [globalRolePresetId], references: [id])
+  userPermissions    UserPermission[]
+  // isSuperadmin сохраняем для bootstrap — superadmin = неявная роль "ADMIN_*"
+}
+
+model WorkspaceMember {
+  // ...
+  rolePresetId String?
+  rolePreset   RolePreset? @relation(fields: [rolePresetId], references: [id])
+  isGuest      Boolean     @default(false) @map("is_guest")  // см. board-acl.md §2 принцип 6
+  // role: WorkspaceRole оставляем DEPRECATED на одну фазу для backward compat
+}
+```
+
+## 5. Эффективная пермиссия — алгоритм
+
+```
+isAllowed(userId, workspaceId, permission) =>
+  if user.isSuperadmin and permission.startsWith("ADMIN_"): return true
+
+  systemEnabled = SystemFeature(deriveFeatureCode(permission)).enabled ?? true
+  if !systemEnabled: return false
+
+  if workspaceId:
+    wsEnabled = WorkspaceFeature(workspaceId, deriveFeatureCode(permission)).enabled ?? true
+    if !wsEnabled: return false
+
+  // 1. ищем явный REVOKE на (user, workspace)
+  if UserPermission(userId, workspaceId, permission, type=REVOKE): return false
+  if UserPermission(userId, null, permission, type=REVOKE): return false
+
+  // 2. явный GRANT на (user, workspace) или global
+  if UserPermission(userId, workspaceId, permission, type=GRANT): return true
+  if UserPermission(userId, null, permission, type=GRANT): return true
+
+  // 3. через role preset
+  if workspaceId:
+    preset = WorkspaceMember(userId, workspaceId)?.rolePreset
+    if preset?.permissions.includes(permission): return true
+
+  preset = User(userId).globalRolePreset
+  if preset?.permissions.includes(permission): return true
+
+  return false
+```
+
+**Каскад выключения (3): system off → ws off независимо → user override игнорируется** (фича недоступна никому).
+
+## 6. API контракты
+
+### 6.1 Admin endpoints (superadmin only)
+
+```
+GET    /api/admin/system-features                  → SystemFeatureDto[]
+PATCH  /api/admin/system-features/:code            { enabled }
+                                                   → SystemFeatureDto
+
+GET    /api/admin/role-presets?scope=SYSTEM|WORKSPACE
+                                                   → RolePresetDto[]
+POST   /api/admin/role-presets                    { name, displayName, scope, permissions }
+                                                   → RolePresetDto
+PATCH  /api/admin/role-presets/:id                { displayName?, permissions? }
+                                                   → RolePresetDto
+DELETE /api/admin/role-presets/:id                — 409 если isSystem=true
+
+GET    /api/admin/users/:id/permissions            → { rolePreset, overrides: UserPermissionDto[] }
+PATCH  /api/admin/users/:id/role                  { rolePresetId }
+POST   /api/admin/users/:id/permissions           { permission, type, workspaceId? }
+DELETE /api/admin/users/:id/permissions/:permId
+```
+
+### 6.2 Workspace endpoints (workspace owner)
+
+```
+GET    /api/workspaces/:id/features                → WorkspaceFeatureDto[]
+PATCH  /api/workspaces/:id/features/:code         { enabled }
+
+GET    /api/workspaces/:id/members/:userId/permissions
+                                                   → { rolePreset, overrides }
+PATCH  /api/workspaces/:id/members/:userId        { rolePresetId? }
+POST   /api/workspaces/:id/members/:userId/permissions
+                                                   { permission, type }   // только WORKSPACE-scope
+```
+
+### 6.3 DTO
+
+```typescript
+type SystemFeatureDto = {
+  code: string;
+  enabled: boolean;
+  updatedAt: string;     // ISO
+  updatedBy: string | null;
+};
+
+type WorkspaceFeatureDto = {
+  code: string;
+  enabled: boolean;
+  systemEnabled: boolean;  // computed — если false, owner не может включить
+  updatedAt: string;
+};
+
+type RolePresetDto = {
+  id: string;
+  name: string;
+  displayName: string;
+  scope: 'SYSTEM' | 'WORKSPACE';
+  isSystem: boolean;
+  permissions: string[];   // PermissionCode[]
+};
+
+type UserPermissionDto = {
+  id: string;
+  permission: string;
+  type: 'GRANT' | 'REVOKE';
+  workspaceId: string | null;
+  grantedBy: string | null;
+  createdAt: string;
+};
+```
+
+### 6.4 Формат ошибок (как сейчас)
+
+```typescript
+{ error: { code: string; message: string; details?: unknown } }
+```
+
+Новые коды:
+- `FEATURE_DISABLED` — 403, попытка использовать выключенную фичу
+- `INSUFFICIENT_PERMISSION` — 403, нет требуемого PermissionCode
+- `SYSTEM_ROLE_PROTECTED` — 409, попытка изменить/удалить системную роль
+
+## 7. Миграционный план
+
+### Phase 1 — additive (одна миграция)
+
+1. Создать enum `PermissionCode`, `PermissionType`, `FeatureScope`.
+2. Создать таблицы `system_features`, `workspace_features`, `role_presets`, `role_permissions`, `user_permissions`.
+3. Добавить FK `User.globalRolePresetId`, `WorkspaceMember.rolePresetId` — **nullable**, не ломает существующее.
+4. Seed:
+   - `SystemFeature`: все коды с `enabled = true`.
+   - `RolePreset`: три системные роли с фиксированными `name`:
+     - `system:owner` (scope=WORKSPACE) — все WORKSPACE-пермиссии включая `WS_*` и `BOARD_MANAGE_ACL`.
+     - `system:member` (scope=WORKSPACE) — read + create/update tasks/comments/checklists. Без `WS_*`, без `BOARD_DELETE`, без `TASK_DELETE`.
+     - `system:viewer` (scope=WORKSPACE) — только `*_READ`.
+     - `system:admin` (scope=SYSTEM) — все `ADMIN_*`.
+   - Migrate данные: для каждого `WorkspaceMember.role`:
+     - `OWNER` → `rolePresetId = system:owner.id`
+     - `MEMBER` → `system:member.id`
+     - `VIEWER` → `system:viewer.id`
+   - `User.isSuperadmin = true` → `globalRolePresetId = system:admin.id` (но `isSuperadmin` оставляем как fallback на одну фазу).
+
+### Phase 2 — switch checks (отдельный PR)
+
+Заменить проверки `if (member.role !== 'OWNER')` на `if (!isAllowed(userId, wsId, 'WS_EDIT_SETTINGS'))`. Делается по модулям. `WorkspaceMember.role` пока остаётся как deprecated.
+
+### Phase 3 — drop legacy (через 2-3 релиза)
+
+Удалить колонку `WorkspaceMember.role`, удалить `WorkspaceRole` enum.
+
+## 8. UX & Accessibility
+
+**Целевой WCAG-уровень**: AA. Админка безопасности → AAA для критичных flow (роли, пермиссии).
+
+### Required UI states
+
+**AdminUsersPage → новая вкладка «Роли»**
+- [x] Loading — skeleton-строки списка
+- [x] Empty — «Системные роли не удаляются, кастомных пока нет» + CTA «Создать роль»
+- [x] Error — «Не удалось загрузить роли» + retry
+- [x] Disabled — для `isSystem` ролей кнопка «Удалить» disabled с tooltip
+- [x] Confirmation — modal перед удалением кастомной роли с подсчётом затронутых пользователей
+
+**AdminUsersPage → вкладка «Системные фичи»**
+- [x] Loading — skeleton-таблица
+- [x] Error — toast + retry
+- [x] Confirmation — modal «Выключить LOCAL_REGISTRATION? Это запретит regiter endpoint для всех» с предупреждением о побочных эффектах
+
+**AdminUsersPage → user detail → блок «Permissions»**
+- [x] Dropdown «Роль» + список текущих overrides
+- [x] Empty overrides — «Нет индивидуальных правок»
+- [x] Удаление override — confirmation с пометкой какая роль вернётся в силу
+
+**WorkspaceSettingsPage → новая вкладка «Фичи»**
+- [x] Toggle-список фич уровня 2
+- [x] Если `systemEnabled = false` — toggle disabled + бейдж «Выключено администратором»
+- [x] Confirmation при выключении фичи которая используется (например `WS_COMMENTS` если есть >0 комментариев) — «У вас 12 комментариев останутся видны, но новые добавить нельзя»
+
+**WorkspaceSettingsPage → вкладка «Участники» → расширение**
+- Колонка «Роль» = dropdown с RolePreset списком (вместо текущего OWNER/MEMBER/VIEWER)
+- Кнопка «Настроить пермиссии» → modal с overrides
+
+### Клавиатурный сценарий
+
+- Tab order: nav → toggle-список → save
+- Focus visible на всех interactive (toggle, button, dropdown)
+- Esc закрывает confirmation modal
+- Enter подтверждает confirmation
+- Toggle переключается Space или Enter (стандарт role="switch")
+
+### Screen reader
+
+- Каждый toggle: `role="switch"` + `aria-checked` + `aria-describedby` (описание что выключится)
+- При смене состояния — `aria-live="polite"` объявляет «Комментарии включены / выключены»
+- При confirmation — `role="alertdialog"` с фокусом на cancel
+
+### Touch targets
+
+Все toggle ≥ 44×44, кнопки строк ≥ 44×44.
+
+### Responsive
+
+- Desktop: двухколоночная (nav + content)
+- Tablet ≤ 1024: nav collapsable
+- Mobile ≤ 640: nav → top tabs, контент в полную ширину; modal в bottom-sheet
+
+### Performance budget
+
+Admin страницы: LCP < 2.5s (списки до 500 пользователей), INP < 200ms на toggle.
+
+## 9. Стыки
+
+### Файлы для модификации
+
+**Backend**:
+- `backend/src/prisma/schema.prisma` — добавить модели и enums.
+- `backend/src/modules/admin/admin.router.ts` — endpoints из 6.1.
+- `backend/src/modules/admin/admin.service.ts` — логика role/permission CRUD.
+- `backend/src/modules/admin/admin.dto.ts` — Zod схемы.
+- `backend/src/modules/workspaces/workspaces.router.ts` — endpoints из 6.2.
+- `backend/src/shared/middleware/` — новый `requirePermission(code: PermissionCode)`.
+- `backend/src/shared/utils/permissions.ts` — `isAllowed()` функция.
+- Все существующие сервисы — замена `requireOwner` → `requirePermission`.
+
+**Frontend**:
+- `frontend/src/api/admin.ts` — клиент новых endpoints.
+- `frontend/src/api/permissions.ts` — новый клиент.
+- `frontend/src/pages/AdminUsersPage.tsx` — добавить вкладки «Роли», «Системные фичи».
+- `frontend/src/pages/WorkspaceSettingsPage.tsx` — добавить вкладку «Фичи», расширить «Участники».
+- `frontend/src/store/permissions.store.ts` — Zustand store эффективных пермиссий пользователя.
+- `frontend/src/hooks/usePermission.ts` — `usePermission('TASK_DELETE')` → boolean для conditional rendering.
+
+### Что не трогаем
+
+- `auth/*` — login/logout без изменений.
+- `notifications/*` — только проверка `SystemFeature.EMAIL_NOTIFICATIONS` перед отправкой.
+- E2E тесты MFA/SSO — отдельный pass после Phase 2.
+
+## 10. Риски
+
+| # | Риск | Вероятность | Mitigation |
+|---|------|-------------|------------|
+| R1 | Миграция оставит пользователей без роли | Низкая | Backfill в той же миграции по `WorkspaceMember.role`. Тест на пустой `WorkspaceMember.rolePresetId` после миграции. |
+| R2 | Сломаем проверки в существующих сервисах | Высокая | Phase 2 отдельным PR, по модулям, с тестами для каждого. На Phase 1 `WorkspaceMember.role` остаётся работать. |
+| R3 | Кэш-инвалидация пермиссий | Средняя | Все мутации (role/override/feature toggle) — инкремент `User.permissionsRev` или Redis pub/sub. Frontend `permissions.store` ловит и рефрешит. |
+| R4 | Owner отключит себе `WS_TOGGLE_FEATURES` и заблокирует | Средняя | Backend отказывает: «Нельзя выключить свою последнюю роль с `WS_EDIT_SETTINGS`». Тест на этот сценарий. |
+| R5 | Superadmin выключит `LOCAL_REGISTRATION` пока сам не логинился | Низкая | UI confirmation с предупреждением. Tehnical lockout восстанавливается через прямую запись в БД (документировать в runbook). |
+| R6 | Большой рост числа `UserPermission` строк | Низкая | Индекс `(userId, workspaceId)`. Pagination на UI. |
+| R7 | Кастомные роли позволят owner workspace создать роль с `ADMIN_*` пермиссиями | Средняя | Валидация: `RolePreset.scope = WORKSPACE` → запрещены все `ADMIN_*` коды. |
+| R8 | Backward compat сломается для интеграций по API | Высокая | DTO `WorkspaceMemberDto` сохраняет поле `role` (computed из `rolePreset.name`) на одну major-версию. CHANGELOG + deprecation note. |
+
+## 11. Решения (зафиксированы 2026-05-18)
+
+1. **Кастомные роли scope=WORKSPACE** — owner workspace **может** создавать свои роли. Валидация: только WORKSPACE-permissions, все `ADMIN_*` запрещены на API-уровне (`role_presets` с scope=WORKSPACE не принимают ADMIN-коды).
+2. **`User.isSuperadmin`** — **оставляем** как fallback в Phase 1+2 («isSuperadmin=true → ADMIN_* всегда true»). Удаление флага вынесено в Phase 3 (отдельная миграция через 2–3 релиза).
+3. **`User.globalRolePresetId`** — **добавляем**. Используется для кросс-workspace ролей вроде «Глобальный аудитор» (`*_READ` везде без add member в каждый workspace).
+4. **`system:viewer` пермиссии** — только `*_READ` (без `COMMENT_CREATE`, без `CHECKLIST_WRITE`, без любых WRITE-кодов). Совпадает с текущим поведением `WorkspaceRole.VIEWER`.
+5. **Endpoint visibility при выключенной фиче**:
+   - Если модуль выключен целиком (`SystemFeature.FEEDBACK_WIDGET = false`) — модуль не подключается к роутеру → **404**.
+   - Если фича доступна, но конкретное действие выключено для пользователя/workspace — **403 `FEATURE_DISABLED`** или **403 `INSUFFICIENT_PERMISSION`** в зависимости от причины.
+
+---

--- a/specs/board-acl.feature
+++ b/specs/board-acl.feature
@@ -1,0 +1,338 @@
+# Gherkin specs для per-board ACL и гостевого доступа
+# Связанные SDD: docs/design/board-acl.md (G2-2, approved 2026-05-18)
+# Покрытие: 5 flow × 6 категорий (happy/empty/loading/error/keyboard/edge-data)
+
+# ─── Feature 1: Board access modal (owner / BOARD_MANAGE_ACL) ─────────────────
+
+Feature: Owner управляет доступом к доске
+  Как владелец workspace я хочу выдавать и забирать доступ к конкретной доске
+
+  Background:
+    Given workspace "Команда А" с 30 участниками
+    And я owner
+    And существует public board "DEV" в этом workspace
+
+  # Happy
+  Scenario: Открыть modal и увидеть все workspace members
+    When я открываю board "DEV"
+    And нажимаю кнопку "Доступ" в header
+    Then modal "Доступ к доске" открывается
+    And список содержит все 30 workspace members
+    And для каждого виден badge источника:
+      | Я (Owner)            | owner       |
+      | Боб (system:member)  | workspace   |
+      | Аня (BoardMember override system:viewer) | board-override |
+      | Костя (BoardMember null) | board-denied |
+
+  # Happy: апгрейд роли для участника
+  Scenario: Дать Боре роль system:owner только на эту доску
+    Given Боря — system:member в workspace
+    When в modal я выбираю в dropdown Бори → "system:owner"
+    Then POST /api/boards/DEV/members { userId:Боря, rolePresetId:system:owner.id } → 201
+    And строка обновляется, badge меняется на "board-override"
+    And optimistic UI отражает изменение мгновенно
+    And aria-live polite "Роль Бори на доске изменена на Owner"
+
+  # Happy: запрет доступа
+  Scenario: Явно запретить Маше доступ
+    Given Маша — system:member в workspace
+    When я выбираю в её dropdown "Запретить доступ"
+    Then POST /api/boards/DEV/members { userId:Маша, rolePresetId:null } → 201
+    And badge меняется на "board-denied"
+    And после refresh Маша больше не видит board "DEV" в sidebar
+
+  # Empty
+  Scenario: Свежая public доска без overrides
+    Given у board "DEV" ноль записей в board_members
+    When я открываю modal
+    Then 30 строк показаны
+    And у каждой источник="workspace"
+    And баннер empty-info "Все участники видят доску по умолчанию. Добавьте override чтобы изменить роль или запретить доступ."
+
+  # Loading
+  Scenario: Skeleton при открытии modal
+    Given медленная сеть
+    When я кликаю "Доступ"
+    Then modal открывается с 10 skeleton-строк
+    And фокус trap активирован
+    And dropdown-ы disabled
+
+  # Error
+  Scenario: Сохранение роли падает
+    When я меняю роль у Бори
+    And бэкенд возвращает 500
+    Then dropdown откатывает selection
+    And inline-toast "Не удалось сохранить роль для Бори"
+    And строка не меняется в БД (никакой partial-state)
+
+  # Keyboard
+  Scenario: Полная клавиатурная навигация
+    When я открываю modal
+    Then фокус на input "Поиск"
+    When я нажимаю Tab
+    Then фокус переходит на dropdown первой строки
+    When я нажимаю Enter
+    Then dropdown открывается
+    When я нажимаю Arrow Down 2 раза → Enter
+    Then выбирается второй вариант
+    When я нажимаю Escape
+    Then если есть unsaved confirmation → modal "Закрыть без сохранения?"
+    Then если нет — modal закрывается
+
+  # Edge: 500+ участников
+  Scenario: Виртуальный скролл и поиск
+    Given workspace с 500 участниками
+    When я открываю modal
+    Then рендерится только видимое окно (react-window pattern)
+    When я ввожу "ан" в поиск
+    Then список фильтруется до участников с "ан" в name или email
+    And пустой результат → empty-state "Никого не найдено"
+
+  # Edge: owner нельзя забанить
+  Scenario: Попытка denied для другого owner workspace
+    Given Леша — second owner workspace
+    When я выбираю в его dropdown "Запретить доступ"
+    Then POST возвращает 409 c code="CANNOT_DENY_OWNER"
+    And dropdown откатывает selection
+    And toast "Owner workspace всегда имеет доступ"
+
+# ─── Feature 2: Private board toggle ──────────────────────────────────────────
+
+Feature: Переключение public/private
+
+  Background:
+    Given workspace с board "FIN"
+    And я owner
+
+  # Happy: public → private с подтверждением
+  Scenario: Сделать доску приватной с подтверждением
+    Given в FIN сейчас isPrivate=false и 50 workspace members имеют доступ
+    And я добавил себя + 2 коллег в BoardMember (3 explicit member)
+    When я переключаю toggle "Приватная доска" в modal "Доступ"
+    Then confirmation alertdialog "47 участников потеряют доступ. Продолжить?"
+    And фокус на кнопке "Отмена"
+    When я подтверждаю
+    Then PATCH /api/boards/FIN { isPrivate:true } → 200
+    And после refresh у тех 47 board "FIN" исчезает из sidebar
+
+  # Error: переключение в private без members
+  Scenario: Private без BoardMember блокируется
+    Given в FIN ноль board_members
+    When я переключаю "Приватная доска" в on
+    Then PATCH возвращает 409 c code="PRIVATE_BOARD_NEEDS_MEMBER"
+    And toggle откатывается
+    And toast "Сначала добавьте хотя бы одного участника"
+
+  # Happy: создать сразу приватную через форму
+  Scenario: Чекбокс "Приватная" при создании доски
+    Given я открыл форму "Создать доску"
+    When я отмечаю чекбокс "Приватная"
+    And ввожу name="Секреты", prefix="SEC"
+    And нажимаю "Создать"
+    Then POST /api/workspaces/:id/boards { isPrivate:true, ... } → 201
+    And в той же транзакции creator добавлен в board_members с rolePresetId=system:owner
+    And остальные workspace members не видят "Секреты" в sidebar
+
+  # Edge: переключение private→public
+  Scenario: Снять приватность
+    Given board "FIN" isPrivate=true с 3 board_members
+    When я переключаю toggle в off
+    Then PATCH возвращает 200
+    And confirmation "Доска станет видна всем участникам workspace"
+    And board_members остаются (для возможного возврата в private)
+
+# ─── Feature 3: Гость к одной доске (auto-create WorkspaceMember) ─────────────
+
+Feature: Owner добавляет внешнего пользователя как гостя к одной доске
+
+  Background:
+    Given workspace "Команда А"
+    And я owner
+    And в системе уже есть user Лена с email="lena@external.com" но она НЕ в workspace
+    And я открыл modal "Доступ" board "DEV"
+
+  # Happy: добавление по email
+  Scenario: Добавить гостя по email
+    When я ввожу "lena@external.com" в поиск
+    And нажимаю "Добавить как гостя" в результатах
+    And выбираю роль "system:member"
+    Then POST /api/boards/DEV/members { email:"lena@external.com", rolePresetId:system:member.id } → 201
+    And в транзакции:
+      | таблица            | действие                                       |
+      | workspace_members  | INSERT (userId=Лена, isGuest=true)             |
+      | board_members      | INSERT (boardId=DEV, userId=Лена, role=member) |
+    And email-уведомление с приглашением отправлено Лене
+    And строка появляется в списке с бейджем "Гость"
+
+  # Happy: гость залогинился — видит только свою доску
+  Scenario: Гость видит ограниченный workspace
+    Given Лена залогинилась
+    When она открывает приложение
+    Then GET /api/workspaces возвращает workspace "Команда А" с пометкой isGuest=true
+    And в sidebar Boards отображается только "DEV"
+    And public boards "OPS", "QA" не видны
+    And в topbar нет ссылки "Настройки workspace"
+    And попытка прямого перехода на /workspaces/:id/settings → 403
+
+  # Happy: My Tasks гостя
+  Scenario: Гость в My Tasks
+    Given Лена назначена исполнителем 3 задач на board "DEV"
+    And ещё 5 задач назначено ей на boards к которым доступа нет (но в FIN gap случай — но раз она guest, она не должна быть assigneeId там — но если кто-то это сделал)
+    When она открывает /my-tasks
+    Then список содержит только 3 задачи с board "DEV"
+    And задачи с других досок отфильтрованы серверным GET /api/tasks/my (через canAccessBoard)
+
+  # Loading: skeleton sidebar гостя
+  Scenario: Загрузка интерфейса гостя
+    Given медленная сеть
+    When Лена открывает приложение
+    Then sidebar отображает 1 skeleton-строку (а не дефолтные 5 для обычного member)
+    And после загрузки видна только "DEV"
+
+  # Error: гость пытается зайти на закрытую доску по URL
+  Scenario: Прямой URL на чужую доску
+    When Лена открывает /boards/OPS-id
+    Then GET /api/boards/OPS-id возвращает 403 c code="BOARD_ACCESS_DENIED"
+    And UI показывает страницу "У вас нет доступа к этой доске"
+    And ссылка "Вернуться к моей доске"
+
+  # Keyboard: invite-flow
+  Scenario: Owner добавляет гостя через клавиатуру
+    Given фокус на input поиска в modal
+    When я ввожу email и нажимаю Enter
+    Then в dropdown появляется опция "Добавить как гостя — lena@external.com"
+    When я нажимаю Tab → Enter
+    Then открывается role-picker с фокусом на первой роли
+    When я нажимаю Enter на system:member
+    Then гость создан, фокус возвращается на input
+
+  # Edge: активность гостя
+  Scenario: Activity feed гостя ограничен
+    Given Лена — guest на board "DEV"
+    And в "Команда А" есть события на boards OPS, QA (за пределами доступа)
+    When она открывает workspace activity feed
+    Then GET /api/workspaces/:id/events?userId=Лена возвращает только события связанные с board "DEV"
+    And события tasks/comments на других досках не приходят даже если она была упомянута
+
+  # Edge: notification suppression
+  Scenario: Mention в недоступной доске не создаёт notification
+    Given Аня (member) пишет на board "OPS" комментарий "@Лена посмотри"
+    Then create-notification проверяет canAccessBoard(Лена, OPS-id) = false
+    And запись в notifications НЕ создаётся
+    And email-уведомление НЕ отправляется
+    And аудит-запись (security log) "skipped notification due to ACL" пишется
+
+# ─── Feature 4: Жизненный цикл гостя ──────────────────────────────────────────
+
+Feature: Повышение и удаление гостя
+
+  Background:
+    Given Лена — guest в workspace "Команда А" с BoardMember на board "DEV"
+    And я owner
+
+  # Happy: promote
+  Scenario: Повысить гостя до полноценного участника
+    Given в WorkspaceSettings → Участники → секция "Гости"
+    When я нажимаю "Повысить до участника" у Лены
+    And выбираю роль system:member в confirmation
+    Then PATCH /api/workspaces/:id/members/Лена { isGuest:false, rolePresetId:system:member.id } → 200
+    And Лена теперь видит все public boards workspace
+    And её BoardMember на "DEV" остаётся (override продолжает действовать если другая роль)
+
+  # Happy: повышение в owner снимает isGuest автоматически
+  Scenario: Promote to owner auto-clears isGuest
+    When я меняю Лене роль на system:owner
+    Then isGuest автоматически = false
+    And запись логируется в audit
+
+  # Edge: удаление последнего BoardMember у гостя
+  Scenario: Снятие последнего board-доступа удаляет гостя
+    Given у Лены ровно одна BoardMember-запись (на "DEV")
+    When я открываю modal "Доступ к DEV"
+    And удаляю Лену через "Удалить override"
+    Then DELETE /api/boards/DEV/members/Лена → 204
+    And в той же транзакции:
+      | таблица            | действие                                    |
+      | board_members      | DELETE                                      |
+      | workspace_members  | DELETE (т.к. isGuest=true и 0 BoardMember)  |
+    And toast "Гость Лена удалена из workspace (доступа к доскам больше нет)"
+
+  # Edge: удаление одного из нескольких BoardMember у гостя
+  Scenario: Снятие промежуточного board-доступа гостя
+    Given у Лены 3 BoardMember-записи (DEV, OPS, QA)
+    When я удаляю её из "DEV"
+    Then DELETE → 204
+    And workspace_members остаётся (т.к. ещё 2 board-доступа)
+    And в sidebar Лены остаются OPS и QA
+
+  # Edge: history overrides при удалении не-guest
+  Scenario: Удаление обычного member сохраняет историю BoardMember
+    Given Боря — обычный member workspace (isGuest=false)
+    And у него 2 BoardMember-overrides (DEV:viewer, FIN:owner)
+    When owner удаляет Борю из workspace
+    Then DELETE /api/workspaces/:id/members/Боря → 204
+    And workspace_members DELETE
+    And board_members записи Бори ОСТАЮТСЯ (история)
+    And canAccessBoard для Бори теперь false (нет workspace membership)
+    When owner добавляет Борю обратно с ролью system:viewer
+    Then его BoardMember-overrides снова в силе
+    And он сразу видит DEV как viewer и FIN как owner
+
+# ─── Feature 5: Эффективная роль — комбинации ────────────────────────────────
+
+Feature: Алгоритм canAccessBoard покрывает все правила
+
+  # Правило 1: workspace owner всегда видит
+  Scenario: Owner с BoardMember null для себя — всё равно доступ
+    Given Лёша — owner workspace
+    And в БД board_members содержит запись (boardId=FIN, userId=Лёша, rolePresetId=null)
+    When canAccessBoard(Лёша, FIN) вызывается
+    Then возвращается { allowed:true, role:system:owner.id }
+    And rule 1 срабатывает раньше rule 2 (denied)
+
+  # Правило 2: explicit denied
+  Scenario: Member с denied
+    Given Маша — system:member workspace
+    And board_members содержит (boardId=DEV, userId=Маша, rolePresetId=null)
+    When canAccessBoard(Маша, DEV)
+    Then { allowed:false }
+
+  # Правило 3: override повышает
+  Scenario: Viewer с board-override system:member
+    Given Аня — system:viewer workspace
+    And board_members содержит (boardId=DEV, userId=Аня, rolePresetId=system:member.id)
+    Then canAccessBoard(Аня, DEV) = { allowed:true, role:system:member.id }
+    And canActOnBoard(Аня, DEV, "TASK_CREATE") = true (т.к. member может создавать)
+
+  # Правило 4: guest без BoardMember на public — нет доступа
+  Scenario: Guest не видит public boards без явного BoardMember
+    Given Лена — guest workspace (isGuest=true)
+    And board "OPS" — public, ноль board_members для Лены
+    Then canAccessBoard(Лена, OPS) = { allowed:false }
+    And в её sidebar "OPS" не появляется
+
+  # Правило 5: private без BoardMember — нет доступа
+  Scenario: Обычный member и private board
+    Given Боря — system:member workspace (isGuest=false)
+    And board "FIN" — private, ноль board_members для Бори
+    Then canAccessBoard(Боря, FIN) = { allowed:false }
+
+  # Правило 6: public + workspace role
+  Scenario: Обычный поток — member видит public board
+    Given Боря — system:member workspace
+    And board "DEV" — public, ноль board_members для Бори
+    Then canAccessBoard(Боря, DEV) = { allowed:true, role:system:member.id }
+
+  # Соблюдение каскада feature toggles
+  Scenario: Workspace выключил WS_COMMENTS — write на доске не работает
+    Given Аня имеет board-override system:member на DEV
+    And workspace_features (workspace, WS_COMMENTS, enabled=false)
+    When Аня пытается POST /api/tasks/:id/comments
+    Then 403 с code="FEATURE_DISABLED"
+    And алгоритм canActOnBoard сначала проходит проверку canAccessBoard (true), затем isAllowed находит выключение фичи
+
+  # Cross-cutting: superadmin обходит всё
+  Scenario: Superadmin видит private board без BoardMember
+    Given Дима — User.isSuperadmin=true, не в workspace
+    Then canAccessBoard(Дима, любой board) = { allowed:true, role:system:admin.id }
+    And rule 0 срабатывает раньше всех остальных

--- a/specs/feature-permissions.feature
+++ b/specs/feature-permissions.feature
@@ -1,0 +1,273 @@
+# Gherkin specs для системного feature-permissions
+# Связанные SDD: docs/design/feature-permissions.md (G2-1, approved 2026-05-18)
+# Покрытие: 4 пользовательских flow × 6 категорий (happy/empty/loading/error/keyboard/edge-data)
+
+# ─── Feature 1: Системные feature toggles (superadmin) ────────────────────────
+
+Feature: Системные feature toggles в админке
+  Как суперадмин я хочу включать и выключать модули продукта
+  для всей инсталляции
+
+  Background:
+    Given я залогинен как пользователь с isSuperadmin=true
+    And я открыл "/admin" → вкладка "Системные фичи"
+
+  # Happy path
+  Scenario: Выключить локальную регистрацию
+    Given таблица system_features содержит запись LOCAL_REGISTRATION с enabled=true
+    When я переключаю toggle "Локальная регистрация" в off
+    And подтверждаю в confirmation modal
+    Then PATCH /api/admin/system-features/LOCAL_REGISTRATION возвращает 200 c {enabled:false}
+    And toast "Фича выключена" появляется
+    And запрос POST /api/auth/register возвращает 404
+    And UI-кнопка "Зарегистрироваться" на /login исчезает после next page load
+
+  # Empty state
+  Scenario: Первый заход — все фичи включены
+    Given таблица system_features пустая (свежая инсталляция)
+    When страница загружается
+    Then GET /api/admin/system-features возвращает все 8 кодов с enabled=true (defaults)
+    And все 8 toggle отображаются в положении on
+
+  # Loading state
+  Scenario: Skeleton при загрузке
+    Given медленная сеть (>500ms)
+    When страница вкладки "Системные фичи" открывается
+    Then 8 skeleton-строк отображаются
+    And toggle disabled пока запрос не завершился
+    And после ответа skeleton заменяется на реальные строки
+
+  # Error state
+  Scenario: PATCH падает — toggle откатывается
+    Given фича MFA сейчас enabled=true
+    When я переключаю toggle "MFA / TOTP" в off
+    And бэкенд возвращает 500
+    Then toggle возвращается в положение on (optimistic rollback)
+    And toast "Не удалось сохранить, попробуйте ещё раз" появляется
+    And аудит-запись об ошибке записана в audit_log
+
+  # Keyboard
+  Scenario: Tab + Space навигация
+    When я нажимаю Tab несколько раз
+    Then фокус последовательно проходит через все 8 toggle
+    And visible focus ring виден на каждом
+    When я нажимаю Space на focused toggle
+    Then confirmation modal открывается
+    And фокус автоматически переходит на кнопку "Отмена"
+    When я нажимаю Escape
+    Then modal закрывается без сохранения
+    And toggle остаётся в исходном состоянии
+
+  # Edge data: confirmation для зависимостей
+  Scenario: Выключение MFA с активными пользователями
+    Given 12 пользователей имеют активную TOTP-настройку
+    When я переключаю "MFA / TOTP" в off
+    Then confirmation modal показывает "12 пользователей потеряют возможность входа через TOTP"
+    And aria-live polite объявляет содержимое modal'я
+    And кнопка "Подтвердить" имеет aria-describedby с этим текстом
+
+# ─── Feature 2: Role presets (superadmin) ─────────────────────────────────────
+
+Feature: Управление пресетами ролей
+  Как суперадмин я хочу создавать кастомные роли с гибким набором пермиссий
+
+  Background:
+    Given я залогинен как суперадмин
+    And я открыл "/admin" → вкладка "Роли"
+
+  # Happy
+  Scenario: Создание кастомной WORKSPACE-роли
+    When я нажимаю "Создать роль"
+    And ввожу name="qa-reviewer", displayName="QA Reviewer", scope="WORKSPACE"
+    And отмечаю чекбоксы TASK_READ, TASK_UPDATE, COMMENT_CREATE, COMMENT_READ
+    And нажимаю "Сохранить"
+    Then POST /api/admin/role-presets возвращает 201
+    And новая роль появляется в списке с isSystem=false
+    And видна badge "WORKSPACE"
+
+  # Empty
+  Scenario: Только системные роли при первом заходе
+    Given БД содержит только 4 системные роли (system:owner/member/viewer/admin)
+    When страница "Роли" открывается
+    Then 4 строки отображаются с замочком isSystem
+    And empty-state-баннер "Кастомных ролей пока нет — создайте первую" + CTA
+
+  # Loading
+  Scenario: Skeleton списка ролей
+    Given медленная сеть
+    When страница открывается
+    Then 5 skeleton-строк отображаются
+    And "Создать роль" кнопка disabled
+
+  # Error: duplicate name
+  Scenario: Имя занято
+    Given существует роль с name="qa-reviewer"
+    When я создаю новую с тем же name
+    Then POST возвращает 409 с code="DUPLICATE_ROLE_NAME"
+    And inline-ошибка под полем name "Имя занято"
+    And aria-invalid="true" на input
+    And focus переходит на input
+
+  # Keyboard: permission grid
+  Scenario: Навигация по чекбоксам пермиссий
+    Given форма создания роли открыта
+    When я нажимаю Tab до permission grid
+    Then фокус на первом чекбоксе TASK_READ
+    When я нажимаю Arrow Down 3 раза
+    Then фокус на TASK_DELETE
+    When я нажимаю Space
+    Then чекбокс отмечается
+    And aria-checked="true" обновляется
+
+  # Edge: system role protection
+  Scenario: Системную роль нельзя удалить
+    Given фокус на строке "system:owner"
+    Then кнопка "Удалить" в этой строке disabled
+    And tooltip "Системные роли защищены от удаления"
+    And aria-disabled="true"
+
+  # Edge: scope WORKSPACE не принимает ADMIN_*
+  Scenario: Запрет ADMIN-пермиссий в WORKSPACE-роли
+    When я создаю роль с scope="WORKSPACE" и пытаюсь отметить ADMIN_USERS
+    Then чекбокс ADMIN_USERS отсутствует в гриде для scope=WORKSPACE
+    And фильтр пермиссий показывает только WORKSPACE-scoped коды (~30 из 40)
+
+# ─── Feature 3: User permission overrides (superadmin) ────────────────────────
+
+Feature: Индивидуальные пермиссии поверх роли
+
+  Background:
+    Given пользователь Аня имеет globalRolePresetId=system:member
+    And я залогинен как суперадмин на /admin → User detail (Аня)
+
+  # Happy
+  Scenario: GRANT override
+    When я нажимаю "Добавить override"
+    And выбираю permission=TASK_DELETE, type=GRANT, workspaceId=null (global)
+    And нажимаю "Сохранить"
+    Then POST /api/admin/users/Аня/permissions возвращает 201
+    And строка появляется в списке overrides с бейджем "GRANT global"
+    And эффективная пермиссия Аня.TASK_DELETE = true (через GRANT)
+
+  # Empty
+  Scenario: Нет overrides
+    Given у Ани в user_permissions ноль записей
+    Then блок "Overrides" показывает empty-state "Индивидуальных правок нет — действует роль"
+
+  # Loading
+  Scenario: Загрузка user detail
+    When страница пользователя открывается
+    Then блок "Роль" + блок "Overrides" показывают skeleton параллельно
+
+  # Error
+  Scenario: Conflict при дубликате
+    Given Аня уже имеет override TASK_DELETE GRANT global
+    When я пытаюсь добавить ещё один TASK_DELETE GRANT global
+    Then POST возвращает 409 с code="DUPLICATE_OVERRIDE"
+    And toast "Этот override уже существует"
+
+  # Keyboard
+  Scenario: Удаление override через клавиатуру
+    Given фокус на строке overrides
+    When я нажимаю Delete
+    Then confirmation alertdialog открывается
+    And фокус на кнопке "Отмена"
+    When я нажимаю Tab → Enter на "Подтвердить"
+    Then DELETE возвращает 204
+    And строка исчезает с aria-live polite "Override удалён"
+
+  # Edge: REVOKE того что не дано
+  Scenario: REVOKE пермиссии которой нет в роли — no-op
+    Given Аня в роли system:viewer (без COMMENT_CREATE)
+    When я добавляю REVOKE COMMENT_CREATE
+    Then запись создаётся (для аудита) но эффективная пермиссия не меняется
+    And badge "no effect" появляется рядом с записью
+    And tooltip "Этой пермиссии и так нет в текущей роли"
+
+# ─── Feature 4: Workspace feature toggles (owner) ─────────────────────────────
+
+Feature: Workspace owner управляет фичами своего пространства
+
+  Background:
+    Given workspace "Команда А" существует
+    And я залогинен как owner этого workspace
+    And я открыл WorkspaceSettings → вкладка "Фичи"
+
+  # Happy
+  Scenario: Выключить комментарии в workspace
+    Given фича WS_COMMENTS включена
+    When я переключаю toggle "Комментарии" в off
+    And подтверждаю в confirmation modal
+    Then PATCH /api/workspaces/:id/features/WS_COMMENTS возвращает 200
+    And toast "Комментарии выключены"
+    And в task drawer comment editor исчезает
+    And существующие комментарии остаются видимыми (read-only)
+
+  # Empty
+  Scenario: Новый workspace — все фичи on
+    Given свежий workspace без записей workspace_features
+    When страница "Фичи" открывается
+    Then все 9 toggle отображаются в положении on (defaults)
+
+  # Loading
+  Scenario: Skeleton фич workspace
+    When страница "Фичи" открывается
+    Then 9 skeleton-строк
+    And "Сохранить" disabled
+
+  # Error
+  Scenario: PATCH падает
+    When я переключаю "Метки" в off
+    And бэкенд возвращает 500
+    Then toggle возвращается в on
+    And toast "Не удалось сохранить" с retry кнопкой
+
+  # Keyboard
+  Scenario: Toggle через Space
+    When фокус на toggle "Bulk операции"
+    And я нажимаю Space
+    Then confirmation modal открывается
+    When я нажимаю Escape
+    Then modal закрывается, toggle не меняется
+
+  # Edge: system-disabled overrides workspace
+  Scenario: Системно выключенная фича блокирует workspace toggle
+    Given системно SystemFeature.EMAIL_NOTIFICATIONS = false
+    When страница "Фичи" workspace открывается
+    Then в этом списке нет WS-toggle EMAIL (или toggle disabled с бейджем "Выключено администратором")
+    And tooltip "Свяжитесь с администратором инсталляции чтобы включить"
+    And aria-disabled="true"
+
+  # Edge: бизнес-логика последствий
+  Scenario: Выключить экспорт с активными задачами
+    Given в workspace 1200 задач
+    When я выключаю "Экспорт CSV"
+    Then confirmation modal показывает "Пользователи больше не смогут экспортировать данные. 1200 задач остаются в системе."
+    And кнопки "Отмена" и "Подтвердить" в фокус-trap
+
+# ─── Feature 5: Назначение роли участнику workspace (owner) ────────────────────
+
+Feature: Owner назначает RolePreset участнику workspace
+
+  Background:
+    Given workspace "Команда Б" с 5 участниками
+    And я owner
+    And в БД есть кастомная роль "qa-reviewer" (scope=WORKSPACE)
+    And я открыл WorkspaceSettings → Участники
+
+  # Happy
+  Scenario: Изменить роль участника
+    When я кликаю на dropdown "Роль" у участника Бориса
+    Then список содержит: system:owner, system:member, system:viewer, qa-reviewer
+    When я выбираю "qa-reviewer"
+    Then PATCH /api/workspaces/:id/members/Борис { rolePresetId } возвращает 200
+    And строка обновляется с новым названием роли
+    And aria-live polite "Роль Бориса изменена на QA Reviewer"
+
+  # Edge: нельзя выключить себе последнюю owner-роль
+  Scenario: Защита от самоблокировки
+    Given я единственный owner workspace
+    When я пытаюсь изменить свою роль на system:member
+    Then PATCH возвращает 409 с code="LAST_OWNER_PROTECTED"
+    And dropdown откатывает selection
+    And toast "Назначьте другого owner перед сменой своей роли"

--- a/tasks/feature-permissions-acl/code-review.md
+++ b/tasks/feature-permissions-acl/code-review.md
@@ -1,0 +1,587 @@
+# Code Review: Feature-Permissions + Board ACL (Phase 1, Steps 1.1–1.5)
+
+> Reviewer: code-reviewer (Claude Sonnet 4.6)
+> Date: 2026-05-18
+> Branch: claude/jack-readable-activity-feed
+> Scope: backend/src/shared/utils/permissions{,.ts,-loader.ts,-cache.ts},
+>        backend/src/shared/middleware/require-permission.ts,
+>        backend/src/prisma/migrations/20260518143122_*/migration.sql,
+>        backend/src/prisma/schema.prisma (new models/enums),
+>        backend/src/__tests__/permissions/*.test.ts
+> References: security-review.md (already filed), SDD §5 + §4, plan.md
+>
+> Note: The security-reviewer agent has already filed a separate review
+> (tasks/feature-permissions-acl/security-review.md) covering H1–H3, M1–M5, L1–L8, I1–I4.
+> This code-review covers code quality, TypeScript strictness, algorithm correctness,
+> test quality, and migration correctness — complementing, not duplicating, the security review.
+> Cross-references to security findings are noted where relevant.
+
+---
+
+## CRITICAL — 0 findings
+
+---
+
+## HIGH
+
+---
+
+### [HIGH-1] `presetPermissionsById` is never populated by the DB loader — `canActOnBoard` board-override role is silently bypassed
+
+**File:** `backend/src/shared/utils/permissions-loader.ts` (no fetch for presetPermissionsById)
+**File:** `backend/src/shared/utils/permissions.ts` lines 114–118
+**File:** `backend/src/shared/utils/permissions-cache.ts` line 38
+
+`PermissionContext.presetPermissionsById` is declared as `Record<string, Set<string>> | undefined` and marked "present only when canActOnBoard needs it." However, `loadPermissionContextFromDb` never fetches or populates this field. `decide()` uses it at Rule 5:
+
+```ts
+const roleSet = opts.withRole
+  ? ctx.presetPermissionsById?.[opts.withRole]
+  : ctx.workspaceRolePermissions;
+if (roleSet?.has(permission)) return true;
+```
+
+When `opts.withRole` is set (the board-override path via `canActOnBoard`) and `presetPermissionsById` is `undefined`, `roleSet` is `undefined`, the check evaluates to `false`, and execution falls through to Rule 6 (global role). This means any board-scoped role restriction is silently ignored and the user's global role applies instead.
+
+Concrete impact: a user with a `system:admin` global role added to a board with `system:viewer` override passes `ADMIN_*` permission checks on that board because Rule 5 is skipped and Rule 6 returns their global permissions.
+
+**Algorithm correctness vs SDD §5:** The SDD says `withRole` replaces the workspace role in Rule 5. The current implementation cannot do this because the data is never loaded.
+
+**Fix:** Either (a) load all referenced preset permissions inside `loadPermissionContextFromDb` (or in a board-context-specific loader), or (b) add a fail-closed guard:
+
+```ts
+// permissions.ts, decide(), after deriving roleSet:
+if (opts.withRole !== undefined && roleSet === undefined) {
+  // Preset data not loaded. Fail closed — do not fall through to global role.
+  // Log a warning for diagnostics.
+  console.warn(`[permissions] presetPermissionsById missing for withRole=${opts.withRole}`);
+  return false;
+}
+if (roleSet?.has(permission)) return true;
+// Only reach global role when withRole was NOT set:
+if (!opts.withRole && ctx.globalRolePermissions.has(permission)) return true;
+return false;
+```
+
+Option (b) is the minimal safe fix; option (a) is required for correctness once custom presets are used in Phase 2. Both should be applied.
+
+**Tests:** The `withRole` tests in `is-allowed.test.ts` (lines 234–260) mock `presetPermissionsById` directly, so they test the algorithm with data that is never actually loaded. There is no test covering the "withRole set, presetPermissionsById undefined" path — which is the production case today. Add:
+
+```ts
+it('withRole set but presetPermissionsById not loaded → denies (fail-closed)', async () => {
+  mockedGet.mockResolvedValue(
+    makeCtx({
+      globalRolePermissions: new Set(['TASK_DELETE']),
+      // presetPermissionsById NOT set (undefined)
+    }),
+  );
+  expect(
+    await isAllowed('u1', 'ws1', 'TASK_DELETE', { withRole: 'some-preset' }),
+  ).toBe(false);
+});
+```
+
+Also cross-referenced in security-review.md §M2.
+
+---
+
+### [HIGH-2] Race condition: `invalidateUser` and `invalidateWorkspace` do not cancel in-flight DB promises — stale data can re-populate the cache after invalidation
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` lines 159–178
+
+The `inflight` Map is cleared only in `invalidateSystem` (line 182). The partial invalidation functions `invalidateUser` and `invalidateWorkspace` delete entries from `cache` and the secondary indexes but do **not** remove the corresponding entry from `inflight`.
+
+Race scenario:
+1. `getPermissionContext('u1', 'ws1')` is called — no cache hit, so a DB query starts and `inflight['u1:ws1'] = p` is stored.
+2. Before the DB returns, `invalidateUser('u1')` is called — it runs `cache.delete('u1:ws1')` (nothing to delete yet) and calls `byUser.delete('u1')`. The `inflight` entry is not touched.
+3. The DB query completes — `.then()` fires, writing `cache.set('u1:ws1', { value: staleData, expiresAt: ... })` and calling `indexInsert('u1', 'ws1', 'u1:ws1')`.
+4. The next call to `getPermissionContext('u1', 'ws1')` returns the stale cache entry.
+
+This is a correctness bug. Under normal load (permission changes are infrequent), the window is short and the stale data expires within TTL. However, for security-sensitive permission changes (e.g. revoking access), there is a window where the old context is served.
+
+**Fix:** Track a "generation" counter per cache key. When invalidation fires, increment the generation; the in-flight promise checks its generation on resolution and discards the write if it has been superseded:
+
+```ts
+const generations = new Map<string, number>(); // key → current generation
+
+// In getPermissionContext:
+const gen = (generations.get(key) ?? 0);
+const p = loadPermissionContextFromDb(userId, workspaceId)
+  .then((value) => {
+    if ((generations.get(key) ?? 0) === gen) { // generation still current
+      cache.set(key, { value, expiresAt: Date.now() + DEFAULT_TTL_MS });
+      indexInsert(userId, workspaceId, key);
+    }
+    return value;
+  })
+  .finally(() => { inflight.delete(key); });
+
+// In invalidateUser/invalidateWorkspace, after cache.delete(key):
+generations.set(key, (generations.get(key) ?? 0) + 1);
+```
+
+Alternatively (simpler): add the key to an `invalidated` Set, check it in the `.then()`, and clear it from the Set after the check.
+
+**Tests:** The `cache.test.ts` concurrent-reads test (lines 158–175) confirms coalescing but does not test invalidation during in-flight. Add:
+
+```ts
+it('invalidateUser during in-flight does not re-cache stale result', async () => {
+  let resolve!: (v: unknown) => void;
+  fetchFromDb.mockImplementation(() => new Promise(r => { resolve = r; }));
+  const p = getPermissionContext('u1', 'ws1');
+  invalidateUser('u1');
+  resolve({ permissionsRev: 1, systemRev: 1, marker: 'stale' });
+  await p;
+  // Next normal call must re-fetch, not return the stale value
+  fetchFromDb.mockResolvedValueOnce({ permissionsRev: 2, systemRev: 1, marker: 'fresh' });
+  const result = await getPermissionContext('u1', 'ws1');
+  expect(readMarker(result)).toBe('fresh');
+  expect(fetchFromDb).toHaveBeenCalledTimes(2);
+});
+```
+
+---
+
+## MEDIUM
+
+---
+
+### [MED-1] `requirePermission` calls `getPermissionContext` twice on the denial path — unnecessary double await
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 55–82
+
+When a permission check fails, the middleware calls `isAllowed()` (which internally calls `getPermissionContext`) and then separately calls `getPermissionContext()` again to diagnose the reason. With the cache, the second call is a fast cache hit, but it is still an extra `await` and adds code complexity. The first call should be redesigned to return both the boolean and enough context for diagnosis, or the diagnosis context should be derived from the `isAllowed` internal call.
+
+More practically: `isAllowed` calls `getPermissionContext` and calls `decide()`. The `decide()` function is pure and already has the context. The middleware could call `getPermissionContext` once and call a hypothetical `decideWithContext` directly, reusing the result:
+
+```ts
+const ctx = await getPermissionContext(req.user.userId, workspaceId);
+const ok = decide(ctx, workspaceId, permission, {});
+if (ok) return next();
+// use ctx for diagnosis — no second fetch needed
+const featureCode = deriveFeatureCode(permission);
+...
+```
+
+This requires `decide` to be exported (see INFO-1 below, also noted as I2 in security-review.md).
+
+---
+
+### [MED-2] `featureGate` uses the authenticated user's context to check system features — system features are user-independent and this conflates two concerns
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 108–133
+
+System feature flags (Level 1 in SDD §3) are global — they do not vary per user. `featureGate` loads the full per-user permission context (`getPermissionContext(userId, ...)`) just to read `ctx.systemFeatures[featureCode]`. This is unnecessary: `systemFeatures` is identical for all users (it comes from the `system_features` table which has no per-user filtering). Loading the full user context for a user-independent check pollutes the per-user cache and causes unnecessary DB queries for unauthenticated users (the `'anonymous'` fallback issue, covered in security-review.md §H1).
+
+The cleanest fix is a separate `getSystemFeatures()` function that caches system features independently of the user:
+
+```ts
+// permissions-cache.ts
+let systemFeaturesCache: { value: Record<string, boolean>; expiresAt: number } | null = null;
+
+export async function getSystemFeatures(): Promise<Record<string, boolean>> {
+  if (systemFeaturesCache && systemFeaturesCache.expiresAt > Date.now()) {
+    return systemFeaturesCache.value;
+  }
+  const rows = await prisma.systemFeature.findMany({ select: { code: true, enabled: true } });
+  const value = Object.fromEntries(rows.map(r => [r.code, r.enabled]));
+  systemFeaturesCache = { value, expiresAt: Date.now() + DEFAULT_TTL_MS };
+  return value;
+}
+```
+
+`featureGate` with `scope='system'` would use this instead.
+
+---
+
+### [MED-3] `indexRemove` is O(all users × all workspaces) on every expired-entry eviction
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` lines 91–98
+
+`indexRemove(key)` is called on every cache miss when an expired entry is evicted (line 126). It iterates ALL entries in `byUser` and ALL entries in `byWorkspace` to find and remove the key. Under load with a large number of active users and workspaces, this becomes an O(U + W) operation on every TTL expiry — which happens naturally every 5 minutes per cached key.
+
+```ts
+function indexRemove(key: string): void {
+  for (const [userId, set] of byUser) {       // O(U)
+    if (set.delete(key) && set.size === 0) byUser.delete(userId);
+  }
+  for (const [wsId, set] of byWorkspace) {   // O(W)
+    if (set.delete(key) && set.size === 0) byWorkspace.delete(wsId);
+  }
+}
+```
+
+**Fix:** Store `userId` and `workspaceId` in the `CacheEntry` to allow O(1) index removal:
+
+```ts
+interface CacheEntry {
+  value: PermissionContext;
+  expiresAt: number;
+  userId: string;          // add
+  workspaceId: string | null; // add
+}
+
+function indexRemove(key: string): void {
+  const entry = cache.get(key); // peek before delete
+  if (!entry) return;
+  const { userId, workspaceId } = entry;
+  const uSet = byUser.get(userId);
+  if (uSet) { uSet.delete(key); if (uSet.size === 0) byUser.delete(userId); }
+  if (workspaceId) {
+    const wSet = byWorkspace.get(workspaceId);
+    if (wSet) { wSet.delete(key); if (wSet.size === 0) byWorkspace.delete(workspaceId); }
+  }
+}
+```
+
+Also cross-referenced in security-review.md §L5.
+
+---
+
+### [MED-4] `loadBoardWorkspaceId` uses a dynamic `import()` inside a hot middleware path — breaks tree-shaking and adds latency
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 190–198
+
+```ts
+async function loadBoardWorkspaceId(boardId: string): Promise<string> {
+  const { prisma } = await import('../../prisma/client.js');
+  ...
+}
+```
+
+Dynamic `import()` inside a request handler forces the module loader to resolve on every invocation. While Node.js caches module resolution after the first load, the `await import()` still adds a microtask boundary on every call. More importantly, this pattern indicates that `prisma` should be a static import at the top of the file. The reason it is dynamic is likely to avoid circular dependencies, but the cleaner fix is to extend `BoardAccessContext` with `workspaceId` and eliminate `loadBoardWorkspaceId` entirely (covered in security-review.md §H2).
+
+The minimal fix for this PR: move `prisma` to a static top-level import. The proper fix: surface `workspaceId` in `BoardAccessResult` and remove the extra DB call.
+
+---
+
+## LOW
+
+---
+
+### [LOW-1] `PermissionCode` type alias is `string` — Prisma-generated enum is already available
+
+**File:** `backend/src/shared/utils/permissions.ts` line 20
+
+```ts
+export type PermissionCode = string; // narrows once Prisma enum is generated
+```
+
+The Prisma schema already defines `enum PermissionCode`. The generated client exports `PermissionCode` as a string enum union. The comment says "narrows once Prisma enum is generated" but the generation has already happened. Until this is updated, callers can pass any string (e.g. `'ADMIN_USER'` instead of `'ADMIN_USERS'`) and get a silent `false` from the engine.
+
+**Fix:**
+```ts
+import type { PermissionCode } from '@prisma/client';
+export type { PermissionCode };
+```
+
+Also cross-referenced in security-review.md §L1.
+
+---
+
+### [LOW-2] `makeCtx` in `is-allowed.test.ts` uses `as never` to suppress type errors caused by missing required fields
+
+**File:** `backend/src/__tests__/permissions/is-allowed.test.ts` lines 38–54, 241, 254
+
+`PermissionContext` requires `permissionsRev: number` and `systemRev: number`, but `makeCtx` does not set them. The TypeScript error is suppressed with `as never` (lines 53, 241, 254). Using `as never` is stronger than `as any` in that it disables all type checking for the cast value — any property access on the result has type `never` in inference, which can mask real errors.
+
+**Fix:** Add `permissionsRev: 0, systemRev: 0` to the base object in `makeCtx`:
+
+```ts
+function makeCtx(overrides: Partial<PermissionContext> = {}): PermissionContext {
+  return {
+    isSuperadmin: false,
+    isGuest: false,
+    workspaceRolePermissions: new Set<string>(),
+    globalRolePermissions: new Set<string>(),
+    grants: new Set<string>(),
+    revokes: new Set<string>(),
+    systemFeatures: { /* ... */ },
+    workspaceFeatures: {},
+    permissionsRev: 0,
+    systemRev: 0,
+    ...overrides,
+  };
+}
+```
+
+Remove all three `as never` casts. The type annotation can become `PermissionContext` directly.
+
+---
+
+### [LOW-3] `makeCtxDefaults()` is defined after the `describe` blocks that reference it — hoisting works but is confusing
+
+**File:** `backend/src/__tests__/permissions/is-allowed.test.ts` lines 88, 99, 263
+
+`makeCtxDefaults()` is declared at line 263 (after all `describe` blocks) but called at lines 88 and 99. In TypeScript compiled to ESM, function declarations are hoisted but function expressions assigned to `const` are not. `makeCtxDefaults` uses `function` declaration syntax (line 263) so hoisting applies and there is no runtime error. However, placing a helper used throughout the file below all its call sites is a readability anti-pattern. Move `makeCtxDefaults` to just below `makeCtx`.
+
+---
+
+### [LOW-4] `user_permissions` unique constraint on `(userId, workspaceId, permission)` does not enforce uniqueness when `workspaceId` is NULL — PostgreSQL treats each NULL as distinct
+
+**File:** `backend/src/prisma/migrations/20260518143122_.../migration.sql` line 101
+**File:** `backend/src/prisma/schema.prisma` line 628
+
+```sql
+CREATE UNIQUE INDEX "user_permissions_userId_workspaceId_permission_key"
+  ON "user_permissions"("userId", "workspaceId", "permission");
+```
+
+In standard PostgreSQL (including PG 16), a UNIQUE index on a nullable column does NOT treat two NULL values as equal — so two rows `(u1, NULL, COMMENT_CREATE, GRANT)` and `(u1, NULL, COMMENT_CREATE, REVOKE)` can coexist. The unique constraint is violated only when `workspaceId` is non-null and both rows have the same non-null value. This allows a user to have both a GLOBAL GRANT and a GLOBAL REVOKE for the same permission simultaneously.
+
+The algorithm (REVOKE wins Rule 3) handles this correctly at read time, but the inconsistent data is silent and will confuse admin tooling and audit logs.
+
+**Fix:** On PG 15+, add `NULLS NOT DISTINCT`:
+
+```sql
+-- new migration
+DROP INDEX "user_permissions_userId_workspaceId_permission_key";
+CREATE UNIQUE INDEX "user_permissions_userId_workspaceId_permission_key"
+  ON "user_permissions"("userId", "workspaceId", "permission") NULLS NOT DISTINCT;
+```
+
+Since the project targets PG 16 (per CLAUDE.md), this is available. Also cross-referenced in security-review.md §M4.
+
+---
+
+### [LOW-5] `UserPermission.workspaceId` has no FK to `workspaces` — orphaned override rows accumulate when a workspace is deleted
+
+**File:** `backend/src/prisma/schema.prisma` (UserPermission model, no workspace relation)
+**File:** `backend/src/prisma/migrations/20260518143122_.../migration.sql`
+
+`WorkspaceMember` rows are cascade-deleted when their workspace is deleted (via `Workspace → WorkspaceMember` cascade). However, `UserPermission` rows with `workspaceId` referencing the same workspace are NOT deleted — there is no FK from `UserPermission.workspaceId` to `workspaces.id`. These rows become orphans: they reference a deleted workspace and can never be loaded (the `loadPermissionContextFromDb` query filters by `workspaceId`, so they would be included in future workspace-less queries only if `workspaceId=NULL` is queried — but they have a non-null value, so they would only appear in the context of the long-deleted workspace).
+
+Under normal operation these rows are harmless (they are filtered by workspaceId and the workspace is gone), but they accumulate as garbage and can mislead audit tools.
+
+**Fix:** Add the FK:
+
+```prisma
+// schema.prisma — UserPermission model
+workspace Workspace? @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+```
+
+This requires adding `userPermissions UserPermission[]` to the `Workspace` model and a migration to add the constraint.
+
+---
+
+### [LOW-6] `WorkspaceMember → RolePreset` and `BoardMember → RolePreset` FKs use `ON DELETE SET NULL` — deleting a custom preset silently locks out all affected members
+
+**File:** `backend/src/prisma/migrations/20260518143122_.../migration.sql` lines 113, 131
+
+When a non-system `RolePreset` is deleted:
+- `WorkspaceMember.role_preset_id` is set to NULL for all affected rows.
+- `BoardMember.role_preset_id` is set to NULL for all affected rows.
+
+For `BoardMember`, `NULL` means explicit DENY (by design — see `decideBoardAccess` rule 2). So deleting a custom preset used on a board silently **bans every board member** who held that preset, with no notification and no error.
+
+The plan (Step 1.6, R14) documents that the deletion service should return `409 ROLE_IN_USE`, but the FK-level `ON DELETE SET NULL` means this protection is bypassed by direct DB writes (Prisma Studio, admin SQL, future migrations).
+
+**Fix:** Change both FKs to `ON DELETE RESTRICT` in the schema, with a migration:
+
+```prisma
+// BoardMember
+rolePreset RolePreset? @relation(fields: [rolePresetId], references: [id], onDelete: Restrict)
+// WorkspaceMember
+rolePreset RolePreset? @relation(fields: [rolePresetId], references: [id], onDelete: Restrict)
+```
+
+The service-level `409` remains needed for user-friendly messaging, but `RESTRICT` provides the DB-level safety net. Also cross-referenced in security-review.md §H3.
+
+---
+
+### [LOW-7] `featureGate` with an unauthenticated caller uses `'anonymous'` as userId and writes a stale empty context to the cache
+
+**File:** `backend/src/shared/middleware/require-permission.ts` line 110
+
+```ts
+const userId = req.user?.userId ?? 'anonymous';
+```
+
+When an unauthenticated request hits `featureGate`, `getPermissionContext('anonymous', workspaceId)` is called. The DB returns no user (id `'anonymous'` does not exist), so `emptyContext()` is returned. The in-flight coalescing then **caches this empty context** under the key `'anonymous:<wsId>'`. This wastes cache entries and creates a confusing invariant.
+
+Additionally, `emptyContext().systemFeatures` is `{}`. The check `ctx.systemFeatures[featureCode] === false` evaluates to `undefined === false` which is `false` — so the gate silently passes for unauthenticated users even when the system feature is disabled.
+
+**Minimal fix:** Do not use `'anonymous'` as a real cache key. Add an early auth check at the top of `featureGate`:
+
+```ts
+if (!req.user?.userId) {
+  // System features do not depend on the user — load them directly
+  // or, simpler: let authenticate() downstream reject the request.
+  // featureGate should not attempt per-user context for unauthenticated callers.
+  return next(new AppError(401, 'Не авторизован'));
+}
+```
+
+Or use the dedicated system-features cache proposed in MED-2. Also cross-referenced in security-review.md §H1.
+
+---
+
+### [LOW-8] Migration step 9 sanity check references wrong column case — `"isPrivate"` vs actual column name
+
+**File:** `backend/src/prisma/migrations/20260518143122_.../migration.sql` lines 234–235
+
+```sql
+-- 9. Sanity: ensure no board has NULL is_private
+UPDATE "boards" SET "isPrivate" = false WHERE "isPrivate" IS NULL;
+```
+
+The column on the `boards` table was created by migration `20260422120301_add_is_private_to_workspace_and_board` as `"isPrivate" BOOLEAN NOT NULL DEFAULT false`. The column is stored in PostgreSQL with the quoted camelCase name `"isPrivate"` (not snake_case `is_private`), and the `ALTER TABLE ... ADD COLUMN "isPrivate"` confirms this. So the SQL in step 9 uses the correct quoted name and is valid.
+
+However, the comment says `is_private` (snake_case) while the statement uses `"isPrivate"` (camelCase). This is a minor documentation inconsistency. More importantly, since the column was defined `NOT NULL DEFAULT false`, it can never be NULL in practice — making step 9 a no-op with misleading intent. If the goal was to guard against pre-migration NULL rows, the guard belongs in the migration that originally added the column.
+
+**Fix:** Remove the no-op step 9 or replace the comment with `-- No-op guard: "isPrivate" is NOT NULL DEFAULT false; retained for defensive safety`.
+
+---
+
+### [LOW-9] `PermissionContext.presetPermissionsById` field is optional — should be required (always populated) or removed and loaded on demand
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` line 38
+
+```ts
+presetPermissionsById?: Record<string, Set<string>>;
+```
+
+Optional fields in types that are required for correct operation create silent failures (the HIGH-1 finding is a consequence of this design). If `presetPermissionsById` should always be present in the `PermissionContext`, remove the `?`. If it is intentionally absent from the current implementation and will be added in Phase 2, document this with a `// TODO(Phase 2)` comment and pair it with the fail-closed fix from HIGH-1 to ensure the absence is safe.
+
+**Fix:** Either:
+- Make it required: `presetPermissionsById: Record<string, Set<string>>` and initialize to `{}` in `emptyContext()` and `loadPermissionContextFromDb`.
+- Keep it optional and add the fail-closed guard from HIGH-1 immediately, with a clear TODO comment.
+
+---
+
+## INFO / NIT
+
+---
+
+### [INFO-1] `decide()` is private — the pure synchronous algorithm cannot be unit-tested directly
+
+**File:** `backend/src/shared/utils/permissions.ts` lines 85–124
+
+The `decide()` function is the pure core of the permission engine. All current tests go through `isAllowed()` (async, requires mocking `getPermissionContext`). Exporting `decide` would allow synchronous tests with zero mocking overhead. This was noted as I2 in the security review and is reinforced here from a test-quality perspective.
+
+**Fix:** Export `decide` (optionally prefixed as `_decideSync` for test-only usage, or via a test barrel file).
+
+---
+
+### [INFO-2] `__clearCacheForTests` is exported from the production module without any environment guard
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` lines 187–190
+
+The `__` naming convention signals test-only intent, but the function is exported from the production module. A future refactor that imports all exports from the module (e.g. via `import * as cache from './permissions-cache'`) could accidentally call it in non-test code.
+
+**Fix:** Add a guard:
+```ts
+export function __clearCacheForTests(): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('__clearCacheForTests must not be called in production');
+  }
+  invalidateSystem();
+}
+```
+Or move to a separate `permissions-cache.test-helpers.ts` file. Also cross-referenced in security-review.md §I1.
+
+---
+
+### [INFO-3] Seed step comments are inconsistent — TASK_EXPORT exclusion from `system:member` is undocumented
+
+**File:** `backend/src/prisma/migrations/20260518143122_.../migration.sql` lines 167–181
+
+The migration seed step 4 for `system:member` does not include `TASK_EXPORT`. The plan §Open Q1 documents the intentional exclusion, but there is no inline SQL comment. Future developers comparing the member and owner seeds will not immediately understand why `TASK_EXPORT` appears only in the owner set.
+
+**Fix:** Add a comment:
+```sql
+-- 4. Seed RolePermission for system:member
+-- Note: TASK_EXPORT is intentionally excluded from Member (plan §Open Q1 — export is an owner privilege).
+```
+
+Also cross-referenced in security-review.md §I3.
+
+---
+
+### [INFO-4] `loadBoardAccessContextFromDb` defaults `boardIsPrivate: false` when the user record is not found — conservative default should be `true`
+
+**File:** `backend/src/shared/utils/permissions-loader.ts` lines 113–124
+
+When `!user`, the function returns `boardIsPrivate: false`. Rule 0c in `decideBoardAccess` (`isWorkspaceMember: false`) catches this and returns `denied` before reaching rule 5 (private board check), so the current code is safe. However the conservative default for an unknown board privacy should be `true` (private), not `false` (public). If rule ordering ever changes in a future refactor, a false `boardIsPrivate: false` could cause a private board to appear accessible.
+
+**Fix:**
+```ts
+boardIsPrivate: board?.isPrivate ?? true, // conservative: unknown = treat as private
+```
+
+Also cross-referenced in security-review.md §L7.
+
+---
+
+### [INFO-5] `WS_MENTIONS`, `WS_TRASH`, and `WS_ONBOARDING_TOUR` are in SDD Level 2 but absent from `FEATURE_CODE_BY_PERMISSION`
+
+**File:** `backend/src/shared/utils/permissions.ts` lines 26–52
+
+The SDD §3 lists `WS_MENTIONS`, `WS_TRASH`, and `WS_ONBOARDING_TOUR` as workspace toggle codes. None of them appear in `FEATURE_CODE_BY_PERMISSION` because there are no corresponding `PermissionCode` enum values for these features (they gate UI behaviour only, not permission codes). This is correct by design. However, the absence is not documented — a reader of `FEATURE_CODE_BY_PERMISSION` might wonder if the mapping is incomplete.
+
+**Fix:** Add a comment at the top of `FEATURE_CODE_BY_PERMISSION`:
+```ts
+// Note: WS_MENTIONS, WS_TRASH, WS_ONBOARDING_TOUR are workspace feature codes
+// that control UI behaviour only — they do not gate any PermissionCode.
+// They are enforced via featureGate() middleware, not via FEATURE_CODE_BY_PERMISSION.
+const FEATURE_CODE_BY_PERMISSION: Record<string, string> = {
+```
+
+---
+
+### [INFO-6] `TASK_READ_ALL` mentioned in SDD §3 is absent from the `PermissionCode` enum in schema and migration
+
+**File:** `backend/src/prisma/schema.prisma` (PermissionCode enum)
+**File:** `backend/src/prisma/migrations/20260518143122_.../migration.sql` (CreateEnum PermissionCode)
+
+The SDD §3 includes `TASK_READ_ALL` in its permission code listing ("including private boards (override workspace-level)"). This code does not appear in the `PermissionCode` enum in either the schema or the migration. If this is deferred to a later phase, add a comment in the SDD or the enum definition. If it was omitted accidentally, it needs to be added.
+
+**Fix:** Verify with the SDD author whether `TASK_READ_ALL` is in scope for Phase 1 or deferred. Add a TODO comment if deferred.
+
+---
+
+## Summary Table
+
+| ID | Severity | Area | File | Finding |
+|----|----------|------|------|---------|
+| HIGH-1 | HIGH | Algorithm correctness | permissions.ts, permissions-loader.ts | `presetPermissionsById` never populated — board-override role silently bypassed, global role used instead |
+| HIGH-2 | HIGH | Cache correctness | permissions-cache.ts | In-flight promises not cancelled on invalidation — stale data re-populates cache after `invalidateUser/Workspace` |
+| MED-1 | MEDIUM | Code quality | require-permission.ts | `requirePermission` calls `getPermissionContext` twice on denial path |
+| MED-2 | MEDIUM | Architecture | require-permission.ts | `featureGate` loads per-user context for a user-independent system feature check |
+| MED-3 | MEDIUM | Performance | permissions-cache.ts | `indexRemove` is O(U+W) on every TTL eviction; should be O(1) via reverse index |
+| MED-4 | MEDIUM | Code quality | require-permission.ts | Dynamic `import()` inside hot middleware path |
+| LOW-1 | LOW | TypeScript strictness | permissions.ts | `PermissionCode` typed as `string` instead of Prisma-generated enum |
+| LOW-2 | LOW | Test quality | is-allowed.test.ts | `as never` casts due to missing `permissionsRev`/`systemRev` in `makeCtx` |
+| LOW-3 | LOW | Test quality | is-allowed.test.ts | `makeCtxDefaults` defined after call sites (hoisting dependency) |
+| LOW-4 | LOW | DB correctness | migration.sql, schema.prisma | UNIQUE index on `(userId, NULL, permission)` allows duplicate GLOBAL overrides on PG 15 without NULLS NOT DISTINCT |
+| LOW-5 | LOW | DB integrity | schema.prisma | `UserPermission.workspaceId` has no FK to `workspaces` — orphaned rows on workspace deletion |
+| LOW-6 | LOW | DB integrity | migration.sql, schema.prisma | `WorkspaceMember/BoardMember → RolePreset` FKs are SET NULL, not RESTRICT — silent mass ban on preset deletion |
+| LOW-7 | LOW | Security/cache | require-permission.ts | `featureGate` with unauthenticated user caches empty context under `'anonymous'` key and silently passes disabled features |
+| LOW-8 | LOW | Migration | migration.sql | Step 9 comment says `is_private` (snake_case) but SQL uses `"isPrivate"` (camelCase); step is a no-op on NOT NULL DEFAULT false column |
+| LOW-9 | LOW | TypeScript design | permissions-cache.ts | `presetPermissionsById` optional field is the root cause of HIGH-1; should be required or explicitly documented as deferred |
+| INFO-1 | INFO | Test quality | permissions.ts | `decide()` not exported — pure algorithm cannot be unit-tested without async mocking |
+| INFO-2 | INFO | Code hygiene | permissions-cache.ts | `__clearCacheForTests` exported from production module without env guard |
+| INFO-3 | INFO | Migration docs | migration.sql | Missing inline comment explaining `TASK_EXPORT` exclusion from `system:member` seed |
+| INFO-4 | INFO | Defensiveness | permissions-loader.ts | `boardIsPrivate` defaults to `false` when user not found — should default to `true` |
+| INFO-5 | INFO | Documentation | permissions.ts | `WS_MENTIONS/TRASH/ONBOARDING_TOUR` absence from `FEATURE_CODE_BY_PERMISSION` undocumented |
+| INFO-6 | INFO | Spec alignment | schema.prisma | `TASK_READ_ALL` in SDD §3 but absent from `PermissionCode` enum — deferred or oversight? |
+
+---
+
+## Review Summary
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| CRITICAL | 0 | pass |
+| HIGH | 2 | warn |
+| MEDIUM | 4 | warn |
+| LOW | 9 | info |
+| INFO/NIT | 6 | note |
+
+**Verdict: BLOCK on HIGH-1.** The `presetPermissionsById` field is never populated, meaning `canActOnBoard` board-override role restrictions are silently bypassed and the user's global role is used instead. This is an algorithm correctness failure against SDD §5 and a security regression once Phase 2 endpoints go live. HIGH-2 (in-flight race condition) should also be fixed before the cache is used in production.
+
+**All HIGHs must be resolved before merge.** MEDs should be resolved in this PR (MED-1 to MED-4). LOWs and INFOs are individually small but collectively represent measurable tech debt; each should either be fixed or explicitly deferred with a ticket reference in the commit message or PR description per the project's All-Severity Fix Rule.
+
+### Items covered by the existing security-review.md that are NOT duplicated here
+
+The following findings from security-review.md are relevant but not duplicated in this review, as they were already comprehensively covered by the security-reviewer agent: H1 (anonymous featureGate cache write / feature bypass), H2 (second uncached DB round-trip / TOCTOU in requireBoardAction), H3 (SET NULL vs RESTRICT FK integrity), M1 (featureCode string type / typo bypass), M2 (presetPermissionsById / board override bypass — fully overlaps HIGH-1 here), M3 (BoardMember mutation missing permissionsRev increment), M4 (NULLS NOT DISTINCT — overlaps LOW-4 here), M5 (attacker-controlled workspaceId in featureGate), L2 (addedBy no FK), L3 (audit log targetId untyped), L4 (featureGate 404 before auth), L6 (TASK_EXPORT seed comment), L8 (requirePermission + requireBoardAction composition contract), I1 (clearCacheForTests env guard), I2 (decide not exported), I3 (seed inheritance comment), I4 (withRole warning on undefined preset).

--- a/tasks/feature-permissions-acl/plan.md
+++ b/tasks/feature-permissions-acl/plan.md
@@ -1,0 +1,663 @@
+# Implementation Plan: Feature-Permissions + Per-Board ACL
+
+> Owner: jackrescuer-gif
+> Дата: 2026-05-18
+> SDD: `docs/design/feature-permissions.md` (G2-1 approved), `docs/design/board-acl.md` (G2-2 approved)
+> BDD: `specs/feature-permissions.feature` (~25 сценариев), `specs/board-acl.feature` (~30 сценариев)
+> Размер: **XL** (~150 идеальных часов на все три фазы)
+
+## Overview
+
+Двухслойное изменение модели прав:
+
+1. Заменить плоскую `WorkspaceRole = OWNER|MEMBER|VIEWER` на двухуровневую систему «feature-toggles (system+workspace) + RolePreset + PermissionCode + UserPermission overrides».
+2. Поверх неё — per-board ACL через `BoardMember` (override / DENY) + `WorkspaceMember.isGuest` для гостей одной доски.
+
+После фичи: `if (member.role !== 'OWNER')` ⟶ `await isAllowed(userId, wsId, 'WS_EDIT_SETTINGS')`. `boards.service.listByWorkspace` ⟶ фильтр через `canAccessBoard`. Появляется admin UI «Системные фичи / Роли», workspace UI «Фичи / Расширенные роли», board UI «Доступ к доске».
+
+## Что входит в этот conversation
+
+**Только Phase 1** (additive миграция + admin/owner CRUD endpoints + базовый UI «можно настроить»). Reasoning:
+
+- Phase 2 (замена `assertOwner` → `requirePermission` в ~10 модулях) — большой риск регресса; требует своих G2 / G4 / G7 циклов после стабилизации Phase 1.
+- Phase 3 — отдельный PR через 2–3 релиза.
+
+Между Phase 1 и Phase 2 — релиз с feature-flag `PERMISSIONS_V2=false`. Когда `PERMISSIONS_V2=true`, новые проверки активируются — даёт быстрый rollback.
+
+## Requirements
+
+- Сохранить backward compat на API: `WorkspaceMember.role` остаётся в response пока Phase 3.
+- Все existing тесты (`backend/src/__tests__/*.test.ts`, 18 файлов) должны проходить без изменений на Phase 1.
+- Backfill `rolePresetId` для всех существующих WorkspaceMember в той же миграции.
+- Системные роли защищены: `isSystem=true`, удалять/переименовывать нельзя.
+- Каскад: `User` → CASCADE `UserPermission`, `BoardMember`; `Workspace` → CASCADE `WorkspaceFeature`; `RolePreset` (custom) → RESTRICT если используется в `WorkspaceMember` или `BoardMember`.
+
+---
+
+## Architecture Changes
+
+### Prisma schema (`backend/src/prisma/schema.prisma`)
+
+| Изменение | Тип |
+|-----------|-----|
+| `enum PermissionCode` (~46 кодов) | NEW |
+| `enum PermissionType { GRANT, REVOKE }` | NEW |
+| `enum FeatureScope { SYSTEM, WORKSPACE }` | NEW |
+| `model SystemFeature` | NEW |
+| `model WorkspaceFeature` | NEW |
+| `model RolePreset` | NEW |
+| `model RolePermission` | NEW |
+| `model UserPermission` | NEW |
+| `model BoardMember` (board-acl) | NEW |
+| `User.globalRolePresetId` (nullable FK) | ADD |
+| `User.permissionsRev Int @default(0)` (для cache-invalidation) | ADD |
+| `WorkspaceMember.rolePresetId` (nullable FK) | ADD |
+| `WorkspaceMember.isGuest Boolean @default(false)` | ADD |
+| `WorkspaceMember.role: WorkspaceRole` | KEEP (deprecated до Phase 3) |
+| `Board.members BoardMember[]` (back-relation) | ADD |
+| `enum WorkspaceRole` | KEEP (deprecated до Phase 3) |
+
+### Backend модули
+
+| Файл | Изменение |
+|------|-----------|
+| `backend/src/shared/utils/permissions.ts` | NEW: `isAllowed`, `canAccessBoard`, `canActOnBoard`, `deriveFeatureCode`, `getEffectivePermissions`, `bulkCanAccessBoards` |
+| `backend/src/shared/middleware/require-permission.ts` | NEW: `requirePermission(code)`, `requireBoardAccess()`, `requireBoardAction(perm)`, `featureGate(code, scope)` |
+| `backend/src/shared/utils/permissions-cache.ts` | NEW: in-memory LRU + Redis invalidation на `permissionsRev` |
+| `backend/src/modules/permissions/` | NEW МОДУЛЬ: `permissions.router.ts`, `permissions.service.ts`, `permissions.dto.ts` — admin endpoints из SDD §6.1 |
+| `backend/src/modules/workspaces/workspace-features.router.ts` | NEW |
+| `backend/src/modules/workspaces/workspace-features.service.ts` | NEW |
+| `backend/src/modules/boards/board-members.router.ts` | NEW |
+| `backend/src/modules/boards/board-members.service.ts` | NEW |
+| `backend/src/modules/boards/boards.dto.ts` | EXTEND: `addBoardMemberDto`, `updateBoardMemberDto`, isPrivate в `createBoardDto` |
+| `backend/src/modules/boards/boards.service.ts` | EXTEND (Phase 2): `listBoards`, `getBoard`, `getRoadmapTasks` через `canAccessBoard` |
+| `backend/src/modules/admin/admin.router.ts` | EXTEND: mount `/system-features`, `/role-presets`, `/users/:id/permissions` |
+| `backend/src/modules/admin/admin.dto.ts` | EXTEND |
+| `backend/src/index.ts` | EXTEND: `featureGate(FEEDBACK_WIDGET)`, etc. + module-level skip |
+| `backend/src/shared/openapi/routes/permissions.ts` | NEW |
+| `backend/src/shared/openapi/routes/board-members.ts` | NEW |
+| `backend/src/prisma/seed.ts` | EXTEND: seed 4 системных RolePreset + 8 SystemFeature; backfill для demo workspace |
+
+### Frontend
+
+| Файл | Изменение |
+|------|-----------|
+| `frontend/src/api/permissions.ts` | NEW |
+| `frontend/src/api/admin.ts` | EXTEND: listSystemFeatures, toggleSystemFeature, role-presets, user-overrides |
+| `frontend/src/api/boards.ts` | EXTEND: list/add/update/remove BoardMember |
+| `frontend/src/api/workspaces.ts` | EXTEND: list/toggleWorkspaceFeature |
+| `frontend/src/store/permissions.store.ts` | NEW: Zustand store эффективных пермиссий + permissionsRev poll |
+| `frontend/src/hooks/usePermission.ts` | NEW |
+| `frontend/src/hooks/useFeatureEnabled.ts` | NEW |
+| `frontend/src/components/PermissionGate.tsx` | NEW |
+| `frontend/src/components/BoardAccessModal.tsx` | NEW |
+| `frontend/src/pages/AdminUsersPage.tsx` | EXTEND: вкладки «Системные фичи», «Роли», блок Overrides в user-detail |
+| `frontend/src/pages/WorkspaceSettingsPage.tsx` | EXTEND: вкладка «Фичи», секция «Гости», расширенный role-dropdown |
+| `frontend/src/pages/BoardPage.tsx` | EXTEND: кнопка «Доступ» (Phase 2) |
+| `frontend/src/types/index.ts` | EXTEND: PermissionCode union, RolePresetDto, BoardMemberDto |
+
+---
+
+## Implementation Steps
+
+### Phase 1 — Additive (in scope, ~96 ideal hours)
+
+#### Step 1.1: Prisma schema + migration ★ critical-path
+
+- **File**: `backend/src/prisma/schema.prisma`
+- **Action**: добавить 3 enum, 6 моделей, расширить `User`, `WorkspaceMember`, `Board`.
+- **Migration name**: `add_feature_permissions_and_board_acl`
+- **Backfill в `migration.sql`** (ручное дополнение к auto-generated DDL):
+  - INSERT 8 `SystemFeature` records (default enabled=true).
+  - INSERT 4 `RolePreset` records с `isSystem=true`.
+  - INSERT `RolePermission` для каждой системной роли.
+  - `UPDATE workspace_members SET role_preset_id = system:owner.id WHERE role = 'OWNER'` (аналогично MEMBER/VIEWER).
+  - `UPDATE users SET global_role_preset_id = system:admin.id WHERE is_superadmin = true`.
+- **Risk**: High — Backfill в одной транзакции с DDL. Mitigation: миграция идемпотентна (`ON CONFLICT DO NOTHING`); тест-сценарий «миграция дважды подряд = no-op».
+- **Verification**: `prisma migrate diff` показывает только additive; integration test: 0 строк `workspace_members WHERE role_preset_id IS NULL`; 4 строки `role_presets WHERE is_system=true`.
+
+#### Step 1.2: PermissionCode enum + seed pack
+
+- **File**: `backend/src/prisma/seed.ts`
+- **Action**: вынести seed системных ролей в `seedSystemRolesAndFeatures()` (используется из migration backfill и dev seed).
+
+**Permission seeds (закрытый список)**:
+
+`system:viewer` (WORKSPACE scope) — **8 кодов**, только *_READ:
+```
+TASK_READ, BOARD_READ, WORKFLOW_READ, LABEL_READ,
+COMMENT_READ, CHECKLIST_READ, HISTORY_READ, WORKSPACE_READ
+```
+
+`system:member` (WORKSPACE scope) — viewer + writes без destructive:
+```
++ TASK_CREATE, TASK_UPDATE, TASK_REASSIGN, TASK_BULK_EDIT, TASK_EXPORT
++ BOARD_CREATE, BOARD_UPDATE
++ LABEL_CREATE, LABEL_UPDATE
++ COMMENT_CREATE, COMMENT_UPDATE_OWN, COMMENT_DELETE_OWN
++ CHECKLIST_WRITE
+```
+Без: TASK_DELETE, BOARD_DELETE, BOARD_MANAGE_COLUMNS, BOARD_MANAGE_ACL, COMMENT_DELETE_ANY, WS_*.
+
+`system:owner` (WORKSPACE scope) — все WORKSPACE-permissions:
+```
+всё из member +
+TASK_DELETE, BOARD_DELETE, BOARD_MANAGE_COLUMNS, BOARD_MANAGE_ACL,
+LABEL_DELETE, COMMENT_DELETE_ANY,
+WORKFLOW_CREATE, WORKFLOW_UPDATE, WORKFLOW_DELETE,
+WS_INVITE_MEMBER, WS_REMOVE_MEMBER, WS_CHANGE_MEMBER_ROLE,
+WS_EDIT_SETTINGS, WS_EDIT_SECURITY, WS_TOGGLE_FEATURES,
+WS_DELETE, WS_RESTORE_FROM_TRASH
+```
+
+`system:admin` (SYSTEM scope):
+```
+ADMIN_USERS, ADMIN_ROLES, ADMIN_PERMISSIONS,
+ADMIN_AUDIT, ADMIN_FEATURE_FLAGS, ADMIN_SYSTEM_CONFIG
+```
+
+- **Risk**: Medium — несоответствие enum и seed → FK violation. Mitigation: tsc-проверка `Object.values(PermissionCode)` ⊆ seed; runtime check на startup.
+- **Test**: unit-test «`system:viewer` НЕ содержит ни одного write-кода».
+
+#### Step 1.3: Permission engine
+
+- **File**: `backend/src/shared/utils/permissions.ts`
+- **Action**: алгоритм из feature-permissions §5 + board-acl §4.
+  - `isAllowed(userId, workspaceId?, permission, opts?: { withRole?: presetId })`
+  - `canAccessBoard(userId, boardId)` → `{ allowed, role, source: 'workspace'|'board-override'|'workspace-owner'|'superadmin'|'denied' }`
+  - `canActOnBoard(userId, boardId, permission)` → boolean
+  - `deriveFeatureCode(permission)` — map `COMMENT_CREATE` → `WS_COMMENTS`, `TASK_EXPORT` → `WS_EXPORT`, и т.д. Глобальные коды (`TASK_READ`) → `null`.
+  - `bulkCanAccessBoards(userId, boardIds[])` — для list-эндпоинтов (R1-ACL).
+- **Risk**: High — лажа в алгоритме → security regression. Mitigation: 100% unit-coverage на таблицу истинности из board-acl §4.1 + feature-permissions §5.
+- **Verification**: 30+ unit-тестов по табличной матрице из SDD.
+
+#### Step 1.4: Permission cache layer
+
+- **File**: `backend/src/shared/utils/permissions-cache.ts`
+- **Action**: in-memory LRU (`lru-cache` npm), ключ `{userId}:{workspaceId}:rev{permissionsRev}`, TTL 5 мин, capacity 10000.
+  - `getEffectivePermissions(userId, workspaceId)` — кэш-aware враппер с aggregate-SQL (см. **Caching strategy** ниже).
+  - Инвалидация: любая мутация (role/override/feature toggle/BoardMember) → `prisma.user.update({ permissionsRev: { increment: 1 } })`.
+  - `WorkspaceFeature` мутация → инкремент `permissionsRev` для всех members workspace одним UPDATE.
+  - `SystemFeature` → отдельный glob counter `systemRev`.
+  - Redis pub/sub channel `permissions:changed:{userId}` для frontend refetch.
+- **Risk**: Medium — несвоевременная инвалидация = user видит «старые права». Mitigation: bypass cache на security-changing endpoints (`fresh: true`).
+- **Verification**: integration-test «owner меняет роль → следующий запрос видит новую роль».
+
+#### Step 1.5: requirePermission middleware
+
+- **File**: `backend/src/shared/middleware/require-permission.ts`
+- **Action**: фабрика:
+  ```
+  requirePermission(code, opts?: { workspaceParam?: 'id'|'workspaceId' })
+  requireBoardAccess()                       // 403 BOARD_ACCESS_DENIED
+  requireBoardAction(perm)                   // 403 INSUFFICIENT_PERMISSION
+  featureGate(featureCode, scope)            // 404 для system off, 403 FEATURE_DISABLED для ws off
+  ```
+- В Phase 1 — только на новых endpoints (admin, workspace-features, board-members). В Phase 2 — заменяет `assertOwner` в существующих сервисах.
+
+#### Step 1.6: Admin permissions endpoints (SDD §6.1)
+
+- **Files**: `backend/src/modules/permissions/permissions.router.ts`, `.service.ts`, `.dto.ts`
+- **Routes**:
+  - `GET /api/admin/system-features`, `PATCH /api/admin/system-features/:code`
+  - `GET /api/admin/role-presets?scope=`, `POST`, `PATCH /:id`, `DELETE /:id`
+  - `GET /api/admin/users/:id/permissions`, `PATCH /api/admin/users/:id/role`
+  - `POST /api/admin/users/:id/permissions`, `DELETE /api/admin/users/:id/permissions/:permId`
+- **Guard**: `authenticate → requireSuperadmin` (Phase 1). Phase 2 → `requirePermission('ADMIN_ROLES')`.
+- **Validation**:
+  - `RolePreset.scope=WORKSPACE` → Zod refinement отвергает все `ADMIN_*` коды.
+  - `isSystem=true` → `PATCH` allowed только для `displayName`; `DELETE` → 409 `SYSTEM_ROLE_PROTECTED`.
+  - DELETE custom role с активными users/members → 409 `ROLE_IN_USE` с count (R14).
+- **OpenAPI**: `backend/src/shared/openapi/routes/permissions.ts`.
+
+#### Step 1.7: Workspace features endpoints (SDD §6.2)
+
+- **Files**: `backend/src/modules/workspaces/workspace-features.router.ts` + service.
+- **Routes**:
+  - `GET /api/workspaces/:id/features` → 9 WS-кодов с `enabled` + computed `systemEnabled`.
+  - `PATCH /api/workspaces/:id/features/:code` { enabled }
+  - `GET /api/workspaces/:id/members/:userId/permissions`
+  - `PATCH /api/workspaces/:id/members/:userId` { rolePresetId? } — расширяет existing endpoint.
+  - `POST /api/workspaces/:id/members/:userId/permissions` { permission, type } — WORKSPACE-scoped overrides.
+- **Guard**: Phase 1 — `assertOwner`; Phase 2 → `requirePermission('WS_TOGGLE_FEATURES')`, etc.
+- **R8 backward compat**: `WorkspaceMemberDto` содержит и `role` (legacy, computed из `rolePreset.name`: `system:owner` → `OWNER`), и `rolePresetId`, `rolePreset`. CHANGELOG отмечает `role` deprecated.
+
+#### Step 1.8: Board members endpoints (board-acl SDD §5)
+
+- **Files**: `backend/src/modules/boards/board-members.router.ts` + service.
+- **Routes**:
+  - `GET /api/boards/:boardId/members` → `BoardAccessRowDto[]` (батч через `bulkCanAccessBoards`).
+  - `POST /api/boards/:boardId/members` { userId | email, rolePresetId | null }
+  - `PATCH /api/boards/:boardId/members/:userId` { rolePresetId | null }
+  - `DELETE /api/boards/:boardId/members/:userId`
+- **Guard**: `requirePermission('BOARD_MANAGE_ACL')`. Phase 1 — fallback на assertOwner (новые endpoints — без регрессий).
+- **Guest auto-create**: `POST` с `email`: user не существует → invite flow; не в WorkspaceMember → `WorkspaceMember(isGuest=true)` + BoardMember в одной `prisma.$transaction({ isolationLevel: Serializable })`.
+- **Edge errors**: `CANNOT_DENY_OWNER`, `CANNOT_GUESTIFY_OWNER`, `INVALID_ROLE_SCOPE`, `PRIVATE_BOARD_NEEDS_MEMBER`.
+- **DELETE cascade guest** (R-GUEST-3): isGuest=true + count BoardMember = 0 после DELETE → CASCADE WorkspaceMember. Одна транзакция.
+
+#### Step 1.9: `Board.isPrivate` toggle + create-board расширение
+
+- **File**: `backend/src/modules/boards/boards.service.ts`
+- **Action**: в `updateBoard` при `isPrivate=true` → проверить `boardMember.count >= 1` иначе 409 `PRIVATE_BOARD_NEEDS_MEMBER`.
+- **createBoard**: опциональный `isPrivate` в DTO. Если `true` → в транзакции вставить `BoardMember(creatorId, rolePresetId=system:owner.id)` + `Board`.
+
+#### Step 1.10: Защита от самоблокировки + auto-clear isGuest
+
+- **File**: `backend/src/modules/workspaces/workspace-features.service.ts`
+- **Last-owner protection**: если targetUserId == requesterId, target.role = `system:owner`, new.role != `system:owner` → count owners > 1 ? allow : 409 `LAST_OWNER_PROTECTED`.
+- **R-GUEST**: при role=`system:owner` → `isGuest=false` автоматически. Триггер в service.
+
+#### Step 1.11: Audit logging
+
+- **File**: `backend/src/shared/utils/audit-logger.ts` (existing)
+- **Actions**:
+  - `permissions.system_feature.toggled`, `permissions.role_preset.{created,updated,deleted}`
+  - `permissions.user_override.{granted,revoked}`
+  - `permissions.workspace_feature.toggled`
+  - `acl.board_member.{added,updated,removed}`
+  - `acl.board.isPrivate.toggled`
+  - Skipped notifications (R-GUEST-2): `acl.notification.skipped { reason: 'BOARD_ACCESS_DENIED' }`.
+
+#### Step 1.12: Frontend — admin UI
+
+- **File**: `frontend/src/pages/AdminUsersPage.tsx`
+- 2 новые вкладки: «Системные фичи», «Роли». User detail extension: блок «Permissions» с dropdown + overrides.
+- Новые компоненты:
+  - `frontend/src/components/admin/SystemFeaturesTable.tsx`
+  - `frontend/src/components/admin/RolePresetsTable.tsx`
+  - `frontend/src/components/admin/RolePresetEditor.tsx` (permission grid)
+  - `frontend/src/components/admin/UserOverridesPanel.tsx`
+- **A11y**: toggle `role="switch"` + `aria-checked` + `aria-describedby`, confirmation `role="alertdialog"`, Tab/Space/Esc, visible focus.
+
+#### Step 1.13: Frontend — workspace UI
+
+- **File**: `frontend/src/pages/WorkspaceSettingsPage.tsx`
+- Новая вкладка «Фичи». Расширить «Участники»:
+  - dropdown с RolePresets (system + custom).
+  - кнопка «Настроить пермиссии».
+  - секция «Гости (N)» — collapsed (на Phase 1 пустая если board-members ещё не используется).
+- Новые компоненты:
+  - `frontend/src/components/workspace/FeatureTogglesPanel.tsx`
+  - `frontend/src/components/workspace/MemberPermissionsModal.tsx`
+  - `frontend/src/components/workspace/GuestsSection.tsx`
+
+#### Step 1.14: Frontend — permissions store + hooks
+
+- **File**: `frontend/src/store/permissions.store.ts`
+- Zustand store:
+  ```
+  effectivePermissions: Record<workspaceId, Set<PermissionCode>>
+  systemFeatures: Record<string, boolean>
+  workspaceFeatures: Record<workspaceId, Record<string, boolean>>
+  rev: number
+  refresh(workspaceId?)
+  isAllowed(workspaceId, code) → boolean
+  ```
+- Hooks: `usePermission('TASK_DELETE')`, `useFeatureEnabled('WS_COMMENTS', wsId)`.
+- Component: `<PermissionGate code="TASK_DELETE" workspaceId={...}>{...}</PermissionGate>`.
+
+#### Step 1.15: Tests (см. Test Strategy)
+
+#### Step 1.16: OpenAPI sync
+
+- **Files**: `backend/src/shared/openapi/routes/permissions.ts`, `board-members.ts`.
+- Зарегистрировать новые DTO и path. `npm run openapi:generate` без ошибок.
+
+---
+
+### Phase 2 — Switch checks to isAllowed (separate PR, ~45 hours)
+
+**Принцип**: один модуль = один PR. Между PR — деплой на staging, smoke, и только тогда следующий.
+
+Порядок (от низкого риска к высокому):
+
+| # | Модуль | Файл | Изменение | Риск |
+|---|--------|------|-----------|------|
+| P2-1 | labels | `labels.service.ts` | role checks → `requirePermission('LABEL_*')` | Low |
+| P2-2 | checklists | `checklists.service.ts` | role checks → `requirePermission('CHECKLIST_WRITE')` | Low |
+| P2-3 | comments | `comments.service.ts` | role checks → `requirePermission('COMMENT_*')` + canActOnBoard | Medium |
+| P2-4 | workflows | `workflows.service.ts` | role checks → `requirePermission('WORKFLOW_*')` | Medium |
+| P2-5 | tasks | `tasks.service.ts` (~25 мест) | Все role checks → `canActOnBoard` (учитывает board-override) | **High** |
+| P2-6 | boards | `boards.service.ts` | `listBoards`/`getBoard`/`getRoadmapTasks` → `canAccessBoard`/`bulkCanAccessBoards` | **High** |
+| P2-7 | search | `search.service.ts` | `viewerWorkspaceIds` фильтр → JOIN с `board_members` + canAccessBoard | High |
+| P2-8 | notifications | `notifications.service.ts` | `emitMentionNotifications` — фильтр по `canAccessBoard` (R-GUEST-2) | Medium |
+| P2-9 | workspaces | `workspaces.service.ts` | `assertOwner` → `requirePermission('WS_*')`; member list возвращает rolePreset | Medium |
+| P2-10 | admin | `admin.router.ts` | `requireSuperadmin` → `requirePermission('ADMIN_*')` (с fallback на `isSuperadmin=true` в `isAllowed` rule 0) | Low |
+
+После P2-6, P2-7: обязательный E2E pass для гостевого flow (board-acl Feature 3).
+
+### Phase 3 — Drop legacy (~10 hours)
+
+- Удалить `WorkspaceMember.role`, `enum WorkspaceRole`.
+- Удалить fallback `User.isSuperadmin` в `isAllowed`.
+- Удалить `WorkspaceMemberDto.role` (legacy).
+- CHANGELOG: breaking change для внешних API consumers.
+
+---
+
+## Permission middleware design
+
+`requirePermission(code, opts?)` (pseudocode):
+
+```
+function requirePermission(code, opts) {
+  return async (req, res, next) => {
+    const wsId = opts?.workspaceParam ? req.params[opts.workspaceParam] : null;
+    const ok = await isAllowed(req.user.userId, wsId, code);
+    if (!ok) {
+      const cause = await diagnoseDenial(req.user.userId, wsId, code);
+      // cause: 'feature_disabled_system' | 'feature_disabled_ws' | 'no_permission'
+      return next(new AppError(403, msg, { code: 'INSUFFICIENT_PERMISSION' | 'FEATURE_DISABLED' }));
+    }
+    next();
+  };
+}
+```
+
+Lifecycle для board endpoints:
+```
+authenticate → req.user
+requireBoardAccess  → req.boardAccess = { allowed, role } или 403 BOARD_ACCESS_DENIED
+requireBoardAction(perm) → 403 INSUFFICIENT_PERMISSION или FEATURE_DISABLED
+controller
+```
+
+Lifecycle для module-gate (feedback):
+```
+featureGate('FEEDBACK_WIDGET', 'system')   → 404 если выключено
+authenticate → ...
+```
+
+---
+
+## Caching strategy
+
+**Проблема**: `isAllowed` потенциально делает 4–5 DB lookup. На bulk-операциях N×5 запросов.
+
+**Решение**:
+
+1. **Aggregate SQL** одним запросом: возвращает system_features, ws_features, ws_role_perms, global_role_perms, overrides, is_superadmin, permissions_rev, is_guest — всё за 1 round-trip.
+
+2. **In-memory LRU** (`lru-cache`): ключ `{userId}:{workspaceId}:rev{permissionsRev}`, TTL 5 мин, capacity 10000 (~1.5GB max). Hit-rate ожидается 90%+.
+
+3. **Invalidation**:
+   - Любая мутация → `prisma.user.update({ where: { id }, data: { permissionsRev: { increment: 1 } } })`. Старые ключи в LRU естественно вытолкнутся.
+   - `WorkspaceFeature` мутация → инкремент `permissionsRev` для всех members workspace одним UPDATE.
+   - `SystemFeature` → отдельный glob `systemRev`.
+
+4. **Frontend invalidation**: Redis pub/sub `permissions:changed:{userId}` → SSE/WS на frontend → `permissions.store.refresh()`.
+
+5. **Bulk variant**: `bulkCanAccessBoards(userId, [boardIds])` — один SQL JOIN, возвращает Map<boardId, accessRow>. Использует `listBoards`.
+
+---
+
+## Test Strategy
+
+### Unit tests (Vitest, `backend/src/__tests__/`)
+
+| File | Coverage |
+|------|----------|
+| `permissions/is-allowed.test.ts` | NEW — 30+ кейсов из feature-permissions §5 (superadmin, system-off, ws-off, REVOKE, GRANT, role-fallback, global-fallback). @mocks Prisma. |
+| `permissions/can-access-board.test.ts` | NEW — 9 особых случаев board-acl §4.1 + рекурсивные комбинации (private + guest + override). @mocks Prisma. |
+| `permissions/derive-feature-code.test.ts` | NEW — mapping 40+ кодов. |
+| `permissions/cache.test.ts` | NEW — инвалидация по permissionsRev, LRU eviction, concurrent reads. |
+
+### Integration tests (Vitest + real DB)
+
+| File | Coverage |
+|------|----------|
+| `__tests__/admin-permissions.test.ts` | NEW — BDD FP Feature 1, 2, 3: happy, empty, error, edge (duplicate, system protected). |
+| `__tests__/workspace-features.test.ts` | NEW — BDD FP Feature 4: happy, system cascade, owner self-block. |
+| `__tests__/workspace-members-roles.test.ts` | NEW — BDD FP Feature 5: change role, last-owner-protected. |
+| `__tests__/board-acl.test.ts` | NEW — BDD ACL Feature 1, 2, 5: modal, private toggle, эффективные роли. |
+| `__tests__/board-acl-guest.test.ts` | NEW — BDD ACL Feature 3, 4: guest lifecycle, promote, cascading delete (R-GUEST-3), mention suppression (R-GUEST-2). |
+| `__tests__/permissions-cache-invalidation.test.ts` | NEW — mutation → permissionsRev increment → fresh state. |
+
+### Migration tests
+
+| File | Coverage |
+|------|----------|
+| `__tests__/migration-backfill.test.ts` | NEW — после миграции: 0 rows `role_preset_id IS NULL`; 4 system roles; OWNER→system:owner mapping. |
+
+### Regression tests (existing 18 files)
+
+На Phase 1 все должны проходить **без изменений** (legacy `WorkspaceMember.role` остаётся). Если ломаются — баг в backfill или DTO. R13: audit все тесты после Step 1.1 — некоторые могут проверять shape WorkspaceMemberDto.
+
+### E2E (Playwright, отдельная suite, Phase 2+)
+
+| File | Coverage |
+|------|----------|
+| `e2e/admin-permissions.spec.ts` | NEW |
+| `e2e/workspace-features.spec.ts` | NEW |
+| `e2e/board-acl.spec.ts` | NEW (Phase 2+) |
+| `e2e/guest-flow.spec.ts` | NEW (Phase 2+) |
+
+### Coverage target
+
+≥80% lines/branches на новых файлах. На existing после Phase 2 — не падать.
+
+---
+
+## Detailed Migration Steps
+
+**Migration name**: `backend/src/prisma/migrations/2026MMDDHHMMSS_add_feature_permissions_and_board_acl/migration.sql`
+
+```sql
+-- 1. Enums
+CREATE TYPE "PermissionCode" AS ENUM (...); -- 46 values
+CREATE TYPE "PermissionType" AS ENUM ('GRANT', 'REVOKE');
+CREATE TYPE "FeatureScope" AS ENUM ('SYSTEM', 'WORKSPACE');
+
+-- 2. Tables (auto-generated)
+CREATE TABLE "system_features" (...);
+CREATE TABLE "workspace_features" (...);
+CREATE TABLE "role_presets" (...);
+CREATE TABLE "role_permissions" (...);
+CREATE TABLE "user_permissions" (...);
+CREATE TABLE "board_members" (...);
+
+-- 3. Indices
+CREATE UNIQUE INDEX ON workspace_features(workspaceId, code);
+CREATE UNIQUE INDEX ON role_permissions(presetId, permission);
+CREATE UNIQUE INDEX ON user_permissions(userId, workspaceId, permission);
+CREATE INDEX ON user_permissions(userId, workspaceId);
+CREATE UNIQUE INDEX ON board_members(boardId, userId);
+CREATE INDEX ON board_members(userId);
+
+-- 4. Alter existing
+ALTER TABLE users ADD COLUMN global_role_preset_id TEXT REFERENCES role_presets(id);
+ALTER TABLE users ADD COLUMN permissions_rev INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE workspace_members ADD COLUMN role_preset_id TEXT REFERENCES role_presets(id);
+ALTER TABLE workspace_members ADD COLUMN is_guest BOOLEAN NOT NULL DEFAULT false;
+
+-- 5. Seed RolePresets с фиксированными UUID
+INSERT INTO role_presets (id, name, display_name, scope, is_system, created_at, updated_at) VALUES
+  ('00000000-0000-0000-0000-000000000001', 'system:owner',  'Owner',  'WORKSPACE', true, NOW(), NOW()),
+  ('00000000-0000-0000-0000-000000000002', 'system:member', 'Member', 'WORKSPACE', true, NOW(), NOW()),
+  ('00000000-0000-0000-0000-000000000003', 'system:viewer', 'Viewer', 'WORKSPACE', true, NOW(), NOW()),
+  ('00000000-0000-0000-0000-000000000004', 'system:admin',  'Admin',  'SYSTEM',    true, NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+-- 6. Seed RolePermission (~70 rows). Явный INSERT для каждой связи preset×permission.
+
+-- 7. Seed SystemFeature — 8 records
+INSERT INTO system_features (code, enabled, updated_at) VALUES
+  ('LOCAL_REGISTRATION', true, NOW()), ('SSO', true, NOW()), ('MFA', true, NOW()),
+  ('EMAIL_NOTIFICATIONS', true, NOW()), ('FEEDBACK_WIDGET', true, NOW()),
+  ('API_KEYS', true, NOW()), ('GLOBAL_SEARCH', true, NOW()), ('REGISTRATION_REQUESTS', true, NOW())
+ON CONFLICT (code) DO NOTHING;
+
+-- 8. BACKFILL workspace_members.role_preset_id
+UPDATE workspace_members SET role_preset_id = '00000000-0000-0000-0000-000000000001' WHERE role = 'OWNER';
+UPDATE workspace_members SET role_preset_id = '00000000-0000-0000-0000-000000000002' WHERE role = 'MEMBER';
+UPDATE workspace_members SET role_preset_id = '00000000-0000-0000-0000-000000000003' WHERE role = 'VIEWER';
+
+-- 9. BACKFILL users.global_role_preset_id
+UPDATE users SET global_role_preset_id = '00000000-0000-0000-0000-000000000004' WHERE is_superadmin = true;
+
+-- 10. Sanity: ensure boards.is_private no NULL
+UPDATE boards SET is_private = false WHERE is_private IS NULL;
+```
+
+### Rollback strategy
+
+Prisma не делает auto-rollback на проде. Manual:
+```sql
+ALTER TABLE workspace_members DROP COLUMN role_preset_id, DROP COLUMN is_guest;
+ALTER TABLE users DROP COLUMN global_role_preset_id, DROP COLUMN permissions_rev;
+DROP TABLE board_members, user_permissions, role_permissions, role_presets, workspace_features, system_features;
+DROP TYPE "PermissionCode", "PermissionType", "FeatureScope";
+```
+
+Поскольку legacy `WorkspaceMember.role` сохранён — приложение работает после rollback без code changes.
+
+---
+
+## Risks & Mitigations (синтез из обеих SDD + новые)
+
+| # | Риск | Probability | Severity | Mitigation | Plan-step |
+|---|------|-------------|----------|------------|-----------|
+| R1 (FP) | Backfill оставляет members без роли | Low | High | Идемпотентная миграция; test 0 NULL после миграции | Step 1.1, 1.2 |
+| R2 (FP) | Регрессия в существующих сервисах при Phase 2 | High | Critical | Phase 2 = отдельный PR per модуль; staging deploy между PR; обязательный E2E | Phase 2 |
+| R3 (FP) | Cache stale → user видит чужие права | Medium | High | `permissionsRev` + bypass на security-changing; integration test | Step 1.4 |
+| R4 (FP) | Owner self-lock (последняя owner-роль) | Medium | High | API-level `LAST_OWNER_PROTECTED`; UI-warning | Step 1.10 |
+| R5 (FP) | Superadmin выключает LOCAL_REGISTRATION пока не залогинен | Low | Medium | UI confirmation; runbook для SQL восстановления | Step 1.6 |
+| R6 (FP) | Inflation user_permissions | Low | Low | Index (userId, workspaceId); UI pagination | Step 1.1 |
+| R7 (FP) | Workspace-owner создаёт role с ADMIN_* | Medium | High | Zod refinement: scope=WORKSPACE запрещает ADMIN_*; integration test | Step 1.6 |
+| R8 (FP) | Backward compat сломает API consumers | High | High | DTO сохраняет `role` (computed из rolePreset.name); CHANGELOG; deprecation 6 мес | Step 1.7 |
+| R1 (ACL) | N+1 на listBoards | High | High | `bulkCanAccessBoards` через JOIN; benchmark 100+ досок | Step 1.3, Phase 2 P2-6 |
+| R2 (ACL) | Owner создаёт private без себя | Low | Low | Algorithm rule 1 + UI validation | Step 1.9 |
+| R3 (ACL) | Per-board роль содержит WS_* permissions | Medium | Medium | API filter ADMIN_*; warn если WS_*; canActOnBoard игнорирует WS-permissions для board scope | Step 1.6, 1.3 |
+| R4 (ACL) | Cascade BoardMember при удалении Board | Low | Low | `onDelete: Cascade` в schema | Step 1.1 |
+| R5 (ACL) | Notification spam для denied users | Medium | Medium | `emitMentionNotifications` фильтр через canAccessBoard | Phase 2 P2-8 |
+| R6 (ACL) | Existing E2E падают (user не видит доску) | High | Medium | Seed: все boards isPrivate=false; canAccessBoard rule 6 возвращает true | Step 1.2, Phase 2 |
+| R7 (ACL) | Server filter не учитывает per-board override | Medium | High | Test обязателен; реализация через canAccessBoard | Phase 2 P2-7 |
+| R8 (ACL) | Cache не invalidates на BoardMember change | Medium | Medium | `permissionsRev` increment + Redis pub/sub | Step 1.4 |
+| R9 (ACL) | isPrivate toggle без members → invisible | Low | Low | 409 `PRIVATE_BOARD_NEEDS_MEMBER` | Step 1.9 |
+| R-GUEST-1 (ACL) | Guest повышен в owner, isGuest=true остаётся | Medium | Medium | Triggered: role=system:owner → isGuest=false автоматически | Step 1.10 |
+| R-GUEST-2 (ACL) | Guest получает уведомление о mention в другой доске | High | Medium | Notification фильтр через canAccessBoard; audit-log "skipped" | Phase 2 P2-8 |
+| R-GUEST-3 (ACL) | DELETE последнего BoardMember у guest оставит висячий WS member | Medium | Medium | Транзакция: count=0 + isGuest=true → CASCADE WorkspaceMember | Step 1.8 |
+| **NEW R10** | Двойная транзакция в POST /boards/:id/members может частично провалиться | Medium | High | `prisma.$transaction({ isolationLevel: Serializable })`; integration test «middle step throws» | Step 1.8 |
+| **NEW R11** | Performance: `isAllowed` без кэша — DB I/O рост 5–10× | High | High | Step 1.4 cache layer ОБЯЗАТЕЛЕН до P2 deploy; benchmark p95 < 50ms | Step 1.4 |
+| **NEW R12** | Frontend conditional rendering flaps при rev poll | Medium | Low | Кэшировать в store; обновлять только при WS push/explicit refresh | Step 1.14 |
+| **NEW R13** | Existing tests падают из-за нового shape DTO | Medium | Medium | Audit всех тестов после Step 1.1; backward compat DTO с `role` | Step 1.15 |
+| **NEW R14** | RolePreset deletion с активными users → orphan | High | High | Prisma `onDelete: Restrict`; 409 `ROLE_IN_USE` с count | Step 1.6 |
+| **NEW R15** | Migration race на проде (rolling deploy) | Medium | High | Migration additive-only; Phase 1 код не использует новые поля для проверок | Step 1.1 |
+
+---
+
+## Pre-G7 Risk Closure
+
+**Skills которые ОБЯЗАНЫ быть подгружены до implementation, не до G7:**
+
+- [x] `vercel-web-design-guidelines` — для всех UI компонент (admin / workspace / board access modal).
+- [x] `ux-designer` — для accessibility (toggle role="switch", alertdialog, focus management, screen reader announcements).
+- [x] `vercel-react-best-practices` + `vercel-composition-patterns` — для permission gates, custom hooks, store design.
+- [x] **Security threat model** записан в plan.md (см. секцию ниже) **ДО** первой строки backend кода.
+
+**Plan risks closure**: каждый риск (25 items) получает одно из полей перед G7:
+- `addressed_in: <file:lines + test_name>` — конкретный фикс
+- `deferred_to: <PR/issue>` — для Phase 2/3 рисков
+- `accepted_because: <reason>` — для R5, R6, R9 (low-impact edge cases)
+
+**Smoke**: skill `feature-smoke` после Step 1.16. Проверки:
+- curl POST /api/admin/role-presets happy + 400 (invalid scope) + 401 (no auth) + 409 (duplicate name)
+- curl PATCH /api/admin/system-features/LOCAL_REGISTRATION {enabled:false} → check POST /api/auth/register returns 404 next
+- UI handoff на `e2e-runner`: открыть /admin, проверить рендеринг вкладок.
+- Verdict в `tasks/feature-permissions-acl/smoke-report.md` = `green`.
+
+---
+
+## Security Threat Model (mandatory before implementation)
+
+| Threat | Vector | Mitigation |
+|--------|--------|------------|
+| **Privilege escalation via custom role** | Owner создаёт role с ADMIN_USERS → видит чужие workspaces | Zod refinement on scope=WORKSPACE rejects all ADMIN_* codes; integration test |
+| **IDOR на role-preset CRUD** | `PATCH /api/admin/role-presets/:id` без проверки → подмена системной | `requireSuperadmin` (Phase 1) / `requirePermission('ADMIN_ROLES')` (Phase 2); isSystem=true → 409 PATCH/DELETE |
+| **IDOR на BoardMember** | Member вызывает POST /api/boards/&lt;not-his&gt;/members → добавляет себя | `requirePermission('BOARD_MANAGE_ACL')` + canAccessBoard pre-check |
+| **TOCTOU**: canAccessBoard → board становится private → mutation проходит | Между check и mutation проходит время | Single `prisma.$transaction` для всей цепочки check+write |
+| **Cache poisoning** | Attacker инжектит permissionsRev через PATCH | `permissionsRev` НЕ принимается из API; только server-side increment |
+| **Mass override insertion** | DDoS через POST /users/:id/permissions 10000× | Rate limit на /api/admin/* (existing) + ADMIN_PERMISSIONS |
+| **Guest information disclosure** | Guest видит других users в mention picker | Mention picker фильтруется через BoardMember для guest (board-acl §6.8) |
+| **Notification side-channel** | Mention в недоступной доске → guest узнаёт что задача существует | `emitMentionNotifications` фильтр (Phase 2 P2-8); skipped audit log |
+| **Audit log gap** | После toggle SystemFeature → нет следа кто это сделал | Каждая мутация → `auditLog({ actorId, action, meta })` (Step 1.11) |
+| **Default-allow bypass** | SystemFeature.MFA отсутствует в БД → код считает enabled=true → MFA off | Migration seed заливает все 8 records; integration test «empty system_features = defaults work» |
+
+---
+
+## Acceptance Criteria for G6 (implementation review)
+
+Перед запуском three-agent review:
+
+**Backend**:
+- [ ] `prisma migrate dev` проходит. Backfill корректен (0 null role_preset_id).
+- [ ] `npm run build` зелёный, tsc strict.
+- [ ] Все existing tests проходят без изменений (Phase 1 — additive only).
+- [ ] `is-allowed.test.ts` и `can-access-board.test.ts` покрывают 100% алгоритмических веток.
+- [ ] Integration-тесты admin / workspace-features / board-members — зелёные.
+- [ ] `npm run check:rbac` (existing) 0 нарушений на новых endpoints.
+- [ ] OpenAPI generated без ошибок, все новые routes описаны.
+- [ ] Coverage новых файлов ≥ 80%.
+
+**Frontend**:
+- [ ] `tsc --noEmit` зелёный, `npm run lint` зелёный.
+- [ ] AdminUsersPage отображает 3 вкладки (Users / Системные фичи / Роли).
+- [ ] WorkspaceSettingsPage отображает вкладку «Фичи» и расширенный members-dropdown.
+- [ ] `usePermission`, `useFeatureEnabled`, `<PermissionGate>` smoke-проверены.
+- [ ] A11y axe-core: 0 violations на новых страницах.
+
+**Smoke** (`tasks/feature-permissions-acl/smoke-report.md` = green):
+- [ ] curl happy на каждом новом endpoint.
+- [ ] curl negative: 401, 403 (INSUFFICIENT_PERMISSION), 409 (DUPLICATE_ROLE_NAME, SYSTEM_ROLE_PROTECTED), 400 (INVALID_ROLE_SCOPE).
+- [ ] UI handoff: Playwright скриншоты admin/workspace страниц.
+
+**Plan risks (25 items)**: у каждого заполнено addressed_in / deferred_to / accepted_because.
+
+---
+
+## Effort Estimate (ideal hours)
+
+| Phase | Module | Hours |
+|-------|--------|-------|
+| Phase 1 | Prisma + migration + seed (Step 1.1–1.2) | 8 |
+| Phase 1 | Permission engine + cache (Step 1.3–1.4) | 10 |
+| Phase 1 | Middleware (Step 1.5) | 4 |
+| Phase 1 | Admin endpoints (Step 1.6) | 8 |
+| Phase 1 | Workspace features endpoints (Step 1.7) | 6 |
+| Phase 1 | Board members endpoints (Step 1.8) | 10 |
+| Phase 1 | isPrivate + last-owner (Step 1.9–1.10) | 4 |
+| Phase 1 | Audit logging (Step 1.11) | 2 |
+| Phase 1 | Frontend admin UI (Step 1.12) | 12 |
+| Phase 1 | Frontend workspace UI (Step 1.13) | 10 |
+| Phase 1 | Frontend store + hooks + gate (Step 1.14) | 6 |
+| Phase 1 | Tests (Step 1.15) | 14 |
+| Phase 1 | OpenAPI (Step 1.16) | 2 |
+| **Phase 1 total** | | **~96** (~3 недели при 1 dev) |
+| Phase 2 | P2-1 … P2-10 (10 модулей × 3–5h) | ~35 |
+| Phase 2 | Phase 2 tests + E2E | ~10 |
+| **Phase 2 total** | | **~45** (~2 недели) |
+| Phase 3 | Drop legacy | ~10 |
+| **GRAND TOTAL** | | **~150 ideal hours** (very XL) |
+
+---
+
+## Sequencing notes
+
+1. **Step 1.1 (schema+migration)** — критический путь. Merged + deployed на staging до всего остального.
+2. **Step 1.3 (engine)** и **Step 1.4 (cache)** параллельны с **Step 1.12/1.13 (frontend UI)**.
+3. **Step 1.6 / 1.7 / 1.8** независимы между собой — могут параллельно после Step 1.3, 1.5.
+4. **Phase 2 строго последовательно** — каждый модуль может сломать другой (search использует boards, tasks использует boards, notifications использует tasks). P2-1 … P2-10 = от листьев к корням.
+
+---
+
+## Open Questions (для PO до начала implementation)
+
+SDD §11 и §10 заявляют что open questions зафиксированы. Новые вопросы, возникшие при планировании:
+
+1. **TASK_EXPORT в `system:viewer`** — SDD §11 решение 4 «только *_READ», но TASK_EXPORT — read-операция. Plan решение: **ИСКЛЮЧИТЬ** TASK_EXPORT из viewer. Подтвердить?
+2. **`Workspace.isPrivate`** — legacy поле, используется в search и list workspaces для VIEWER-hide. После Phase 2 — оставляем как UX-маркировку «приватный workspace», не использовать в RBAC проверках. Подтвердить?
+3. **`Board.isPrivate` toggle**: по board-acl §5.3 «только system:owner или BOARD_MANAGE_ACL+BOARD_UPDATE». Plan решение: **`BOARD_MANAGE_ACL` достаточно**. Подтвердить?
+4. **Member видит custom workspace роли в dropdown?** BDD Feature 5 показывает — да. Подтвердить?
+5. **`WS_HISTORY_UI=false` блокирует только UI** — API `/api/tasks/:id/history` остаётся открытым. Подтвердить?
+
+⏸ **G4: Plan approved**. Ждёт явного подтверждения PO перед переходом к G5 (Failing tests).

--- a/tasks/feature-permissions-acl/security-review.md
+++ b/tasks/feature-permissions-acl/security-review.md
@@ -1,0 +1,517 @@
+# Security Review: Feature-Permissions + Board ACL
+
+> Reviewer: security-reviewer agent
+> Date: 2026-05-18
+> Branch: claude/jack-readable-activity-feed
+> Scope: Phase 1 additive — engine, cache, middleware, migration (new code, no existing endpoints modified yet)
+> Threat model reference: tasks/feature-permissions-acl/plan.md §Security Threat Model
+
+---
+
+## Executive Summary
+
+The permission engine algorithm is architecturally sound. The layered decision model (superadmin shortcut → feature gates → revoke → grant → role → global role → default deny) is correct and well-tested. The cache invalidation model is safe for single-node deployments. No hardcoded secrets or SQL injection vectors were found. However, several issues of HIGH and MEDIUM severity require attention before Phase 2 goes live — one of them (the anonymous cache read in `featureGate`) needs to be fixed in this PR.
+
+---
+
+## Findings
+
+### CRITICAL — 0 findings
+
+---
+
+### HIGH
+
+---
+
+#### H1 — Anonymous cache read in `featureGate` can load and cache permission context for unauthenticated requests
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 108–133
+
+**Description:**
+When a request arrives without a valid JWT, `req.user` is `undefined`. The middleware falls back to:
+
+```ts
+const userId = req.user?.userId ?? 'anonymous';
+```
+
+It then calls `getPermissionContext('anonymous', workspaceId)`, which calls `loadPermissionContextFromDb('anonymous', ...)`. The DB call returns `emptyContext()` (because `findUnique` finds no user with id `'anonymous'`), and that empty context **is written into the in-memory cache** under the key `anonymous:null`. This is benign for anonymous users themselves, but it creates a confusing invariant: the cache is supposed to hold contexts for real authenticated users. If a future code path ever re-uses `'anonymous'` as a legitimate userId (unlikely but possible), it would hit a stale cached empty context. More practically, the `featureGate` logic then continues past the `systemFeatures` check even when no auth has been established, because `emptyContext().systemFeatures` is `{}` and the check `ctx.systemFeatures[featureCode] === false` evaluates to `false` (the feature appears enabled). This means a disabled system feature does NOT produce a 404 for unauthenticated requests — unauthenticated callers bypass feature gates.
+
+**Reproduction path:**
+1. Disable `FEEDBACK_WIDGET` in `system_features`.
+2. Send `GET /api/feedback` without Authorization header.
+3. `featureGate('FEEDBACK_WIDGET', 'system')` reads `ctx.systemFeatures['FEEDBACK_WIDGET']` which is `undefined` (not `false`).
+4. `undefined === false` is `false`, so the gate does not fire, `next()` is called.
+5. The request proceeds to the next middleware (authenticate), which will reject it — but the wrong error is produced (401 rather than 404), and if authenticate is ordered after featureGate, the 404 guarantee is broken by design.
+
+**Root cause:** Two intertwined issues — (a) the `?? 'anonymous'` fallback should not be used for cache lookups, and (b) the `=== false` check fails to treat `undefined` (feature missing from DB/context) the same as `false`.
+
+**Fix (this PR):**
+In `featureGate`, replace:
+
+```ts
+const userId = req.user?.userId ?? 'anonymous';
+const ctx = await getPermissionContext(userId, workspaceId);
+if (ctx.systemFeatures[featureCode] === false) { ... }
+```
+
+with a hard-coded fast path for the system-feature check. `SystemFeature` data does not depend on the authenticated user — load it via a dedicated call or expose `getSystemFeatureContext()` that reads only `system_features` from cache. Short-term fix:
+
+```ts
+// featureGate does not need per-user context — only system/ws feature flags
+const userId = req.user?.userId;
+// if unauthenticated, let authenticate middleware reject; featureGate only needs the flags
+const ctx = userId
+  ? await getPermissionContext(userId, workspaceId)
+  : await getSystemFeaturesOnly(workspaceId); // new thin helper
+
+// treat undefined as "assume enabled" is documented, but treat absence of feature
+// from the loaded set as "not explicitly disabled" — this is acceptable when the
+// seed guarantees all known features exist. Document this assumption explicitly.
+if (ctx.systemFeatures[featureCode] === false) { ... }
+```
+
+Alternatively — and more robustly — move `featureGate` to always sit AFTER `authenticate` in the middleware chain and remove the `?? 'anonymous'` fallback entirely.
+
+**Where to fix:** This PR.
+
+---
+
+#### H2 — `requireBoardAction` makes a second uncached DB round-trip to resolve `workspaceId`
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 161–198, specifically `loadBoardWorkspaceId` (lines 190–198)
+
+**Description:**
+`requireBoardAction` calls `canAccessBoard` (which calls `loadBoardAccessContextFromDb`, itself doing 2–3 DB queries), then immediately calls `loadBoardWorkspaceId` which issues an additional `prisma.board.findUnique`. The board's `workspaceId` is already available in `BoardAccessContext` (the `board` record is fetched in `loadBoardAccessContextFromDb`), but it is not surfaced in the `BoardAccessResult` or `BoardAccessContext` public types.
+
+This is primarily a performance issue but has a security implication: there is a window between `canAccessBoard` reading the board and `loadBoardWorkspaceId` reading it again. If the board is deleted between these two reads (soft-delete or hard-delete), `loadBoardWorkspaceId` throws a 404 while the access check passed, which is inconsistent. More critically, if the board's `workspaceId` changes (unlikely but possible via a schema migration or data fix), the `isAllowed` call uses a different workspace than the one `canAccessBoard` evaluated — effectively checking permissions in the wrong workspace context.
+
+**Fix (this PR, low effort):**
+Extend `BoardAccessContext` and `BoardAccessResult` to include `workspaceId: string | null`, populate it in `loadBoardAccessContextFromDb`, surface it in `decideBoardAccess`, and eliminate `loadBoardWorkspaceId`. This also eliminates the dynamic `import()` inside the middleware function body.
+
+**Where to fix:** This PR (the types are not yet used by any Phase 2 code).
+
+---
+
+#### H3 — `WorkspaceMember → RolePreset` FK uses `ON DELETE SET NULL`, not `RESTRICT`; deleted preset leaves members with null rolePresetId silently
+
+**File:** `backend/src/prisma/migrations/20260518143122_.../migration.sql` line 113; `backend/src/prisma/schema.prisma` line 165
+
+**Description:**
+The migration creates:
+
+```sql
+ALTER TABLE "workspace_members" ADD CONSTRAINT "workspace_members_role_preset_id_fkey"
+  FOREIGN KEY ("role_preset_id") REFERENCES "role_presets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+```
+
+And identically for `BoardMember → RolePreset` (line 131). This means deleting a custom `RolePreset` silently sets `rolePresetId = NULL` for all members using it. A `WorkspaceMember` with `rolePresetId = NULL` and `role = MEMBER` (legacy) will fall back to the legacy role enum path during Phase 1; but once Phase 3 removes that fallback, all affected members lose access entirely — silently and without notification.
+
+The plan (Step 1.6, R14) calls for `RESTRICT` + `409 ROLE_IN_USE`. But the *migration itself* does not implement `RESTRICT` — it implements `SET NULL`. This contradicts the documented threat model. The `RESTRICT` behaviour must be enforced in the deletion service endpoint, not at the FK level, which is a weaker guarantee. A direct `DELETE FROM role_presets` via a DB console, Prisma Studio, or a future raw query bypasses the service check entirely.
+
+**Fix (separate migration or this PR if possible):**
+Change the FK to `ON DELETE RESTRICT` in the schema:
+
+```prisma
+// WorkspaceMember
+rolePreset RolePreset? @relation(fields: [rolePresetId], references: [id], onDelete: Restrict)
+
+// BoardMember
+rolePreset RolePreset? @relation(fields: [rolePresetId], references: [id], onDelete: Restrict)
+```
+
+A `Restrict` FK still needs the service-level `409 ROLE_IN_USE` (for a user-friendly error), but it also guarantees DB-level integrity as a backstop. Because the Prisma schema marks `rolePresetId` as optional and the relation as nullable, Prisma will accept `Restrict` semantics. Re-generate the migration to add `ALTER TABLE ... ALTER CONSTRAINT ... DEFERRABLE INITIALLY DEFERRED` if needed for the backfill scenario.
+
+**Where to fix:** This PR (new migration or alter the existing one before it is deployed).
+
+---
+
+### MEDIUM
+
+---
+
+#### M1 — Default-allow semantics for absent feature codes leak through to `featureGate` workspace check
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 115–127
+
+**Description:**
+Both `featureGate` and `requirePermission` use the pattern:
+
+```ts
+if (ctx.systemFeatures[featureCode] === false) { ... }
+if (ctx.workspaceFeatures[featureCode] === false) { ... }
+```
+
+If a feature code is queried that was never inserted into `system_features` (e.g. a typo in the call site like `featureGate('FEEDBAK_WIDGET', 'system')`), the lookup returns `undefined`, the comparison `undefined === false` is `false`, and the gate is silently skipped — the feature appears enabled. This is the documented "default-allow" design (plan §Open Q, threat model row 10), but it offers no protection against typos in the feature code string at call sites, since `featureCode` is typed as `string` not as the enum.
+
+**Fix (this PR):**
+Add a TypeScript type for the known system feature codes and workspace feature codes:
+
+```ts
+type SystemFeatureCode = 'LOCAL_REGISTRATION' | 'SSO' | 'MFA' | 'EMAIL_NOTIFICATIONS'
+  | 'FEEDBACK_WIDGET' | 'API_KEYS' | 'GLOBAL_SEARCH' | 'REGISTRATION_REQUESTS';
+
+type WorkspaceFeatureCode = 'WS_COMMENTS' | 'WS_CHECKLISTS' | 'WS_LABELS' | 'WS_BULK_OPS'
+  | 'WS_EXPORT' | 'WS_HISTORY_UI' | ...;
+```
+
+Change `featureGate(featureCode: string, ...)` to accept the typed union. This catches typos at compile time and makes the default-allow assumption explicit.
+
+**Where to fix:** This PR.
+
+---
+
+#### M2 — `presetPermissionsById` is optional and not populated by `loadPermissionContextFromDb`; `canActOnBoard` with board-override role silently falls back to workspace role
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` line 38; `backend/src/shared/utils/permissions.ts` lines 114–118
+
+**Description:**
+`PermissionContext.presetPermissionsById` is typed as `Record<string, Set<string>> | undefined`. It is an "optional lookup" comment: "present only when `canActOnBoard` needs it." However, `loadPermissionContextFromDb` does NOT populate it — no query fetches role preset permissions keyed by preset ID. The `decide()` function uses it at Rule 5:
+
+```ts
+const roleSet = opts.withRole
+  ? ctx.presetPermissionsById?.[opts.withRole]
+  : ctx.workspaceRolePermissions;
+if (roleSet?.has(permission)) return true;
+```
+
+When `opts.withRole` is set (the board-override case) and `presetPermissionsById` is `undefined`, `roleSet` is `undefined`, `roleSet?.has(permission)` is `undefined` (falsy), and Rule 5 is silently skipped. Execution falls through to Rule 6 (global role). This means a board member with a board-override role preset that has fewer permissions than their global role will actually get more permissions than intended — the board override is silently ignored and the global role fallback kicks in.
+
+**Example:** A user has a global `system:admin` role (with `ADMIN_*` permissions) and is added to a private board with `system:viewer` override. `canActOnBoard` calls `isAllowed(..., { withRole: 'system:viewer-uuid' })`. `presetPermissionsById` is `undefined` → Rule 5 skipped → Rule 6 checks `globalRolePermissions` which contains `ADMIN_*`. The viewer restriction is bypassed.
+
+**Fix (this PR):**
+Either (a) populate `presetPermissionsById` in `loadPermissionContextFromDb` by fetching all `RolePermission` rows for the presets that are referenced in `opts.withRole`, or (b) explicitly fail-closed when `presetPermissionsById` is undefined but `withRole` is set:
+
+```ts
+const roleSet = opts.withRole
+  ? ctx.presetPermissionsById?.[opts.withRole] // if undefined → no permissions from this preset
+  : ctx.workspaceRolePermissions;
+
+// CRITICAL: if withRole is set but preset not loaded, do NOT fall through to global role.
+// The board-override role is the authoritative role for this board context.
+if (opts.withRole && roleSet === undefined) {
+  // preset data not loaded — deny to fail-closed, log a warning
+  return false;
+}
+if (roleSet?.has(permission)) return true;
+
+// Only fall through to global role if withRole was NOT set
+if (!opts.withRole && ctx.globalRolePermissions.has(permission)) return true;
+```
+
+Option (b) is the minimal safe fix for this PR. Option (a) is needed for correctness in Phase 2 when board overrides carry real custom presets.
+
+**Where to fix:** This PR (the fallback path is wrong by design and will manifest in Phase 2).
+
+---
+
+#### M3 — Cache invalidation does not cover `BoardMember` mutations; board-level access results stay stale for up to 5 minutes
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` lines 147–155
+
+**Description:**
+`getBoardAccessContext` explicitly bypasses the cache ("for now skip caching"). This means every `canAccessBoard` call always hits the DB — which is correct for correctness. However, the `PermissionContext` cache (used by `isAllowed`) is keyed on `(userId, workspaceId)` and is invalidated via `permissionsRev`. The plan states that `BoardMember` mutations should increment `permissionsRev` (plan R8-ACL: "Cache not invalidates on BoardMember change"). But in Phase 1 the board-members endpoints are not yet wired, so no `permissionsRev` increment will happen after `BoardMember` changes.
+
+When Phase 2 wires `requireBoardAction`, the path is: `canAccessBoard` (always-fresh, correct) → `isAllowed(..., withRole)` (uses cached context). If the user's workspace role or overrides changed since the cache was last populated, `isAllowed` will use stale data even though `canAccessBoard` returned fresh access. The net effect: correct access gating on the board level, but potentially wrong permission level for the action.
+
+**Fix (Phase 2, document now):**
+The Phase 2 board-members service must increment `permissionsRev` for the affected user any time a `BoardMember` is inserted, updated, or deleted — exactly as documented in the plan for workspace-level mutations. Document this as a hard requirement in the board-members service implementation note.
+
+**Where to fix:** Document the requirement in this PR; implement in the board-members service (Step 1.8).
+
+---
+
+#### M4 — `UserPermission` unique constraint does not include `workspaceId=NULL` as distinct from `workspaceId=<value>`; GLOBAL and WS overrides for the same permission are conflated at DB level
+
+**File:** `backend/src/prisma/schema.prisma` line 628; `backend/src/prisma/migrations/.../migration.sql` line 101
+
+**Description:**
+The unique constraint is:
+
+```sql
+CREATE UNIQUE INDEX "user_permissions_userId_workspaceId_permission_key"
+  ON "user_permissions"("userId", "workspaceId", "permission");
+```
+
+In PostgreSQL, `NULL != NULL` in unique indexes — two rows with `(userId, NULL, COMMENT_CREATE)` and `(userId, 'ws1', COMMENT_CREATE)` are both allowed, and a second row with `(userId, NULL, COMMENT_CREATE)` would violate the constraint. This is the desired behaviour (one GLOBAL override, one WS-specific override per user per permission). However, the unique constraint includes `workspaceId` which is nullable. PostgreSQL treats multiple NULLs as distinct by default in unique indexes (prior to PG 15 `NULLS NOT DISTINCT`). This means a user could theoretically have two GLOBAL overrides for the same permission code (e.g. one GRANT and one REVOKE), since two rows with `workspaceId=NULL` do NOT violate the uniqueness in PostgreSQL's standard behaviour.
+
+On PostgreSQL 15+, you can use `NULLS NOT DISTINCT` to close this. On older versions, you need a partial index or a functional index. If the application currently runs on PG 16 (per CLAUDE.md), this is available.
+
+**Impact:** If a user has both `(userId, NULL, COMMENT_CREATE, GRANT)` and `(userId, NULL, COMMENT_CREATE, REVOKE)`, the `loadPermissionContextFromDb` query retrieves both and adds the same key to both `grants` and `revokes`. Since revoke wins over grant in the algorithm (Rule 3 before Rule 4), the user is correctly denied — but the data inconsistency is silent and can confuse audit tooling.
+
+**Fix (this PR or a follow-up migration):**
+Add `NULLS NOT DISTINCT` to the unique index on PG 16:
+
+```sql
+CREATE UNIQUE INDEX "user_permissions_userId_workspaceId_permission_key"
+  ON "user_permissions"("userId", "workspaceId", "permission") NULLS NOT DISTINCT;
+```
+
+Or add a service-level check that rejects creating a second override of any type for the same `(userId, workspaceId, permission)` when `workspaceId` is null.
+
+**Where to fix:** Separate migration (not blocking Phase 2, but should be done before the override management UI ships).
+
+---
+
+#### M5 — `featureGate` for `scope='system'` does not verify `workspaceId` origin; workspace-scoped check uses an untrusted route param
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 108–133
+
+**Description:**
+For `scope='workspace'`, the middleware reads `workspaceId` from `req.params[workspaceParam]`. There is no check that the authenticated user is a member of that workspace before calling `getPermissionContext`. The cache lookup for an arbitrary workspaceId provided by the attacker will call `loadPermissionContextFromDb(userId, attackerWorkspaceId)`. The DB call itself is safe (Prisma parameterized queries), and the returned context will have `workspaceFeatures: {}` for a workspace the user doesn't belong to (the user would have no `WorkspaceMember` row). This means features appear enabled by default for foreign workspaces.
+
+This is lower-risk in isolation because the real business endpoints should independently check workspace membership. But as a principle, `featureGate` should not be callable with attacker-controlled workspaceIds that yield trust in the default-allow path.
+
+**Fix (this PR, low effort):**
+In `featureGate`, when `scope='workspace'` and the user is authenticated, load the context and additionally check that `ctx.isGuest !== undefined` or better verify workspace membership by checking `wsMember !== null` from the loaded context. Alternatively, only call `getPermissionContext` if the userId is set, and fail-closed if it's not.
+
+**Where to fix:** This PR.
+
+---
+
+### LOW
+
+---
+
+#### L1 — `PermissionCode` is typed as `string` in engine and middleware, not as the Prisma-generated enum
+
+**File:** `backend/src/shared/utils/permissions.ts` line 20
+
+```ts
+export type PermissionCode = string; // narrows once Prisma enum is generated
+```
+
+This comment suggests the type will be updated once Prisma generates the enum, but the Prisma schema already defines `enum PermissionCode`. Prisma generates the corresponding TypeScript union. The engine should now import and use `Prisma.PermissionCode` or the Prisma-generated type. Keeping it as `string` means call sites can pass any arbitrary string (e.g. `isAllowed(userId, wsId, 'ADMIN_USER')` — note the typo — compiles fine) and fails silently with `false` at runtime. Given the security sensitivity of this engine, this compile-time safety is not optional.
+
+**Fix (this PR):**
+Replace:
+```ts
+export type PermissionCode = string;
+```
+with:
+```ts
+import type { PermissionCode } from '@prisma/client';
+export type { PermissionCode };
+```
+
+**Where to fix:** This PR.
+
+---
+
+#### L2 — `addedBy` field in `BoardMember` is not validated at the engine level; it is a free-text `String`, not an FK to `users`
+
+**File:** `backend/src/prisma/schema.prisma` lines 638–639; `backend/src/prisma/migrations/.../migration.sql` lines 80–86
+
+`BoardMember.addedBy` is `String @map("added_by")` with no FK constraint. The migration creates the table with `added_by TEXT NOT NULL` but no `REFERENCES users(id)`. If the service layer is ever bypassed (direct DB write, future migration bug), `addedBy` can hold any arbitrary value — an orphaned string that has no audit trail. This also means that if a user is deleted (`onDelete: Cascade` on `BoardMember.userId`), the `addedBy` field is left with the deleted user's ID (as a dangling reference, not a DB error) — the audit record loses its actor.
+
+**Fix (separate issue):**
+Add a FK: `addedByUser User? @relation("BoardMemberAddedBy", fields: [addedBy], references: [id], onDelete: SetNull)`. Mark `addedBy` as `String?` (nullable). If the business requirement is that `addedBy` must always be known, use `onDelete: Restrict` and handle deletion of users who have added board members first.
+
+**Where to fix:** Separate issue / follow-up migration before Phase 2 ships the board-members endpoints.
+
+---
+
+#### L3 — Audit log entries for permission operations reference `actorId` but not the affected `userId`; makes user-centric audit queries impossible
+
+**File:** `backend/src/shared/utils/audit-logger.ts` (existing); referenced in plan Step 1.11
+
+The `AuditLog` schema has `actorId` (who did it) and `targetId?` (what was affected). For permission mutations like `permissions.user_override.granted`, the convention should be `targetId = affectedUserId`. However, the schema does not distinguish between entity types (`targetId` is untyped `String?`). If `targetId` is used for both `userId` and `rolePresetId` in different events, querying "all permission changes for user X" requires filtering by both `action` and `targetId`, which is fragile.
+
+**Fix (low effort, this PR or Step 1.11):**
+Ensure the audit log calls in Step 1.11 always include `{ affectedUserId, rolePresetId }` in the `meta: Json` field. Document this convention in the `AuditLog` model's comment.
+
+**Where to fix:** Step 1.11 implementation.
+
+---
+
+#### L4 — `featureGate` with `scope='system'` returns 404 to authenticated and unauthenticated callers alike; information disclosure through distinguishable error codes
+
+**File:** `backend/src/shared/middleware/require-permission.ts` lines 115–117
+
+```ts
+if (ctx.systemFeatures[featureCode] === false) {
+  return next(new AppError(404, 'Не найдено'));
+}
+```
+
+Returning 404 for a disabled system feature is intentional (endpoint "doesn't exist"). However, this 404 is returned before authentication in the planned middleware order for module-level gates (plan §Permission middleware design: `featureGate('FEEDBACK_WIDGET', 'system') → authenticate → ...`). An unauthenticated caller receives 404 when the feature is disabled and would receive 401 when it is enabled — this distinguishes whether a feature is enabled or not without authentication, leaking system configuration to external observers.
+
+**Severity context:** For internal enterprise deployments this is LOW; for SaaS where users should not know which modules are active this is MEDIUM. Flagged as LOW here because the current deployment context (FlowTask standalone) is internal.
+
+**Fix (this PR or Phase 2):**
+Move `featureGate` to always come after `authenticate`, or return 401 for unauthenticated requests before checking the feature flag. The 404 behaviour is preserved for authenticated users (matching the spec intent).
+
+**Where to fix:** Phase 2 (when featureGate is applied to existing endpoints). Document the ordering requirement.
+
+---
+
+#### L5 — `invalidateUser` and `invalidateWorkspace` iterate all secondary index entries to clean cross-references; O(N) iteration over all users or workspaces in cache
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` lines 159–178
+
+```ts
+export function invalidateUser(userId: string): void {
+  const keys = byUser.get(userId);
+  if (!keys) return;
+  for (const key of keys) {
+    cache.delete(key);
+    for (const set of byWorkspace.values()) set.delete(key); // O(W) per key
+  }
+  byUser.delete(userId);
+}
+```
+
+`invalidateUser` iterates every workspace's index set to remove the deleted key. If there are W active workspaces cached and U keys per user, this is O(U × W). Under load (10k cached entries, 500 active workspaces), an invalidation storm (e.g. a bulk role change for many users) could cause a spike. This is not a security vulnerability per se, but it creates a potential DoS vector if an attacker triggers many role changes in rapid succession.
+
+**Fix (low effort, this PR or follow-up):**
+Maintain a `keyToUserWorkspace` reverse index: `Map<cacheKey, { userId, workspaceId }>`. `indexRemove` then becomes O(1). Alternatively, store the userId and workspaceId in the `CacheEntry` itself.
+
+**Where to fix:** This PR or a dedicated performance follow-up before load testing.
+
+---
+
+#### L6 — `system:member` seed in migration includes `TASK_BULK_EDIT` and `TASK_EXPORT` but the plan Step 1.2 commentary says TASK_EXPORT is excluded from member
+
+**File:** `backend/src/prisma/migrations/.../migration.sql` lines 168–181; `tasks/feature-permissions-acl/plan.md` Step 1.2
+
+The plan commentary for `system:member` explicitly says "without TASK_EXPORT — plan §Open Q1". However the migration seed for `system:member` does NOT include `TASK_EXPORT` — this is actually correct. But `TASK_BULK_EDIT` is included in `system:member`, which the plan also lists. Cross-checking with `system:owner`: the seed includes `TASK_EXPORT` only in the owner preset (line 192). This is consistent with the plan. No actual discrepancy for the DB data.
+
+However: the plan Step 1.2 commentary at line 136 says `system:member` gets `TASK_BULK_EDIT`, which is in the seed. But Open Q1 is about TASK_EXPORT — the plan table says it is excluded from member. The seed is correct. This is a documentation ambiguity — the open question commentary is about TASK_EXPORT, and the seed correctly excludes it from member. **No code change needed**, but add a comment to the seed to make the exclusion explicit.
+
+**Where to fix:** Documentation / inline comment in migration seed (this PR).
+
+---
+
+#### L7 — `loadBoardAccessContextFromDb` returns a permissive context when the board exists but the user is not found, rather than treating it as fully denied
+
+**File:** `backend/src/shared/utils/permissions-loader.ts` lines 113–124
+
+```ts
+if (!board || !user) {
+  return {
+    isSuperadmin: user?.isSuperadmin ?? false,
+    workspaceDeletedAt: null,
+    isWorkspaceMember: false,
+    isWorkspaceOwner: false,
+    workspaceRolePresetId: null,
+    isGuest: false,
+    boardIsPrivate: false,   // ← defaults private to false
+    boardMember: null,
+  };
+}
+```
+
+When `!user` is true (user not found or deleted), `boardIsPrivate: false` is returned. In `decideBoardAccess`, if `isSuperadmin=false`, `isWorkspaceMember=false`, this hits rule 0c and returns `{ allowed: false }` — correct. So the current code is safe via rule 0c. But the `boardIsPrivate: false` value is misleading — the actual privacy state of the board is unknown. If rule ordering ever changes in a future refactor, this false default could cause a private board to appear public to a non-existent user.
+
+**Fix (this PR, minimal):**
+When `!user || !board`, return `boardIsPrivate: true` as the conservative default (or better, only return the actual board's `isPrivate` when the board was found):
+
+```ts
+if (!board || !user) {
+  return {
+    ...
+    boardIsPrivate: board?.isPrivate ?? true, // conservative default: unknown = private
+    ...
+  };
+}
+```
+
+**Where to fix:** This PR.
+
+---
+
+#### L8 — No rate limiting on the new permission-read path; `requirePermission` can be triggered multiple times per request if mounted on multiple middleware layers
+
+**File:** `backend/src/shared/middleware/require-permission.ts`
+
+In Phase 2, some route chains may have both `requireBoardAccess` and `requireBoardAction` mounted. Each calls `canAccessBoard`. If `req.boardAccess` is already set (line 168: `const access = req.boardAccess ?? ...`), the second call is short-circuited. However, if `requirePermission` (workspace check) and `requireBoardAction` (board check) are both mounted on the same route, `isAllowed` will be called twice for the same user, causing two cache lookups (two hits or two misses). This is not a security issue but a correctness / performance pattern that needs documentation.
+
+**Fix (documentation):** Add JSDoc to `requirePermission` and `requireBoardAction` stating they should not both be mounted on the same route and clarifying their composition contract.
+
+**Where to fix:** This PR (JSDoc only).
+
+---
+
+### INFO / NIT
+
+---
+
+#### I1 — `__clearCacheForTests` is exported from production cache module
+
+**File:** `backend/src/shared/utils/permissions-cache.ts` lines 187–190
+
+The `__clearCacheForTests` function is prefixed with `__` by convention but is exported from the production module without any environment guard. If an internal module ever calls it by mistake, the permission cache is silently wiped. Consider moving it to a separate `permissions-cache.test-helpers.ts` file that is conditionally imported only in test environments, or guard it with `if (process.env.NODE_ENV !== 'production') throw new Error(...)`.
+
+**Where to fix:** This PR (low-risk but should be cleaned up).
+
+---
+
+#### I2 — `decide()` in `permissions.ts` is not exported; makes targeted unit testing of the pure algorithm without async overhead impossible
+
+**File:** `backend/src/shared/utils/permissions.ts` lines 85–124
+
+The `decide()` function is the pure synchronous heart of the permission algorithm. It is currently private (not exported). Tests in `is-allowed.test.ts` test it indirectly through `isAllowed()`, which adds async overhead and mocking complexity. Exporting `decide` (perhaps as `_decideForTest` or via a test-only export barrel) would allow the algorithm to be tested with zero mocking.
+
+**Where to fix:** This PR (minor refactor, test quality improvement).
+
+---
+
+#### I3 — `system:member` seed at migration step 4 duplicates all 8 viewer codes verbatim; future viewer permission additions won't automatically propagate to member
+
+**File:** `backend/src/prisma/migrations/.../migration.sql` lines 168–181
+
+The member preset seed copies the viewer permission list literally. If a future migration adds a new READ permission to `system:viewer`, it must also be manually added to `system:member` and `system:owner` seeds in a new migration. A comment to this effect is absent. This is a maintainability concern, not a security issue, but omitting a READ permission from member while it exists in viewer would create a confusing permission inversion.
+
+**Where to fix:** Document the pattern in a comment within the migration seed (this PR).
+
+---
+
+#### I4 — No validation that `opts.withRole` is a valid preset ID; arbitrary strings accepted
+
+**File:** `backend/src/shared/utils/permissions.ts` lines 114–118
+
+`isAllowed` accepts `opts.withRole` as a free string. If the caller passes an invalid preset ID, `ctx.presetPermissionsById?.[opts.withRole]` returns `undefined`, and with the current code the logic silently falls through. With the proposed fix in M2 (fail-closed when `withRole` is set but lookup fails), this becomes a deny — correct. But a log warning would help diagnose misconfiguration.
+
+**Where to fix:** Implement as part of M2 fix (this PR).
+
+---
+
+## Summary Table
+
+| ID | Severity | Title | Where to Fix |
+|----|----------|-------|--------------|
+| H1 | HIGH | Anonymous cache read in `featureGate`; disabled system features don't block unauthenticated requests | This PR |
+| H2 | HIGH | Second uncached DB round-trip for `workspaceId` in `requireBoardAction`; TOCTOU window | This PR |
+| H3 | HIGH | `WorkspaceMember/BoardMember → RolePreset` FK is `SET NULL`, not `RESTRICT`; DB-level integrity gap | This PR (new migration) |
+| M1 | MEDIUM | `featureCode` typed as `string`; typos bypass feature gates silently | This PR |
+| M2 | MEDIUM | `presetPermissionsById` not populated; board-override role silently skipped, global role used instead | This PR |
+| M3 | MEDIUM | BoardMember mutations don't increment `permissionsRev`; `isAllowed` uses stale context post-Phase 2 | Document now; fix in Step 1.8 |
+| M4 | MEDIUM | `user_permissions` unique index allows duplicate GLOBAL overrides on PG < 15 | Separate migration before override UI ships |
+| M5 | MEDIUM | `featureGate` workspace scope uses attacker-controlled `workspaceId` without membership check | This PR |
+| L1 | LOW | `PermissionCode` typed as `string` instead of Prisma-generated enum | This PR |
+| L2 | LOW | `BoardMember.addedBy` is untyped free-text, not an FK to `users` | Separate issue / pre-Phase 2 migration |
+| L3 | LOW | Audit log `targetId` is untyped; user-centric audit queries are fragile | Step 1.11 implementation |
+| L4 | LOW | `featureGate` 404 before auth leaks system feature state to unauthenticated callers | Phase 2 (ordering fix) |
+| L5 | LOW | `invalidateUser`/`invalidateWorkspace` are O(N×M); DoS vector under bulk role changes | This PR or perf follow-up |
+| L6 | LOW | Migration seed exclusion of TASK_EXPORT from member lacks inline comment (no code error) | This PR (comment only) |
+| L7 | LOW | `loadBoardAccessContextFromDb` defaults `boardIsPrivate: false` when user not found | This PR (conservative default) |
+| L8 | LOW | No documentation on `requirePermission` + `requireBoardAction` composition contract | This PR (JSDoc) |
+| I1 | INFO | `__clearCacheForTests` exported from production module without env guard | This PR |
+| I2 | INFO | `decide()` not exported; pure algorithm harder to unit-test directly | This PR |
+| I3 | INFO | Viewer→Member→Owner permission inheritance not documented in migration seed | This PR (comment) |
+| I4 | INFO | No warning logged when `withRole` resolves to undefined preset | Part of M2 fix |
+
+---
+
+## No Issues Found In
+
+- **SQL injection**: All seeds use `FROM (VALUES (...)) AS t(p)` with `p::"PermissionCode"` cast — values are literals from the migration, not user input. No injection surface.
+- **Hardcoded secrets**: No API keys, passwords, or tokens in any reviewed file.
+- **`permissionsRev` cache poisoning**: The field is not accepted from any API surface — it is server-side only, incremented via Prisma. The threat model item is correctly mitigated.
+- **`isSuperadmin` scope (Rule 0)**: The shortcut applies only to `permission.startsWith('ADMIN_')`. Non-admin permissions fall through the full algorithm. A superadmin without an explicit workspace role or override cannot perform workspace operations via the ADMIN_* shortcut alone. Correct.
+- **REVOKE wins over GRANT**: Rules 3 and 4 enforce this correctly. Rule 3 (revoke check) executes before Rule 4 (grant check). Both workspace and global scopes are checked in the correct order. The test `'REVOKE beats GRANT on same scope'` covers this.
+- **Guest scenarios (Rule 4)**: `boardMember: null` and `boardMember: undefined` are both falsy; the code checks `ctx.boardMember` at lines 176–186. Prisma returns `null` (not `undefined`) for missing relations when selected with `findUnique`. The guard `if (ctx.boardMember && ...)` correctly handles both the null case and the `{ rolePresetId: null }` (explicit deny) case without conflation.
+- **Migration idempotency**: `ON CONFLICT DO NOTHING` on all seed inserts. Backfill UPDATEs include `WHERE role_preset_id IS NULL` guard. Re-running is safe.
+- **FK cascade on `Board → BoardMember`**: `ON DELETE CASCADE` — correct; deleting a board removes its ACL entries.
+- **FK cascade on `User → UserPermission`**: `ON DELETE CASCADE` — correct; deleting a user removes their overrides.
+- **FK cascade on `Workspace → WorkspaceFeature`**: `ON DELETE CASCADE` — correct.


### PR DESCRIPTION
## Summary

Phase 1 critical path для системы feature-permissions + per-board ACL (по образцу `moex-portal`):

- Двухуровневая модель прав: 8 системных + 9 workspace feature toggles + 46 гранулярных `PermissionCode`
- Per-board ACL через новую таблицу `BoardMember` (override / explicit DENY)
- Flag `WorkspaceMember.isGuest` для пользователей-гостей одной доски (auto-create при добавлении в BoardMember)
- Cache layer race-safe (generation-counter защищает от in-flight stale writes)

## Что внутри (Step 1.1-1.5 из plan)

| Компонент | Файлы |
|-----------|-------|
| Prisma schema + миграция | `schema.prisma`, 2 migration файла, backfill 4 системных ролей |
| Permission engine | `permissions.ts` (190 строк) — isAllowed, canAccessBoard, canActOnBoard, deriveFeatureCode |
| DB loader | `permissions-loader.ts` — изолирован для mock-ability |
| Cache | `permissions-cache.ts` — LRU + TTL + invalidate hooks |
| Middleware | `require-permission.ts` — 4 factory: requirePermission, featureGate, requireBoardAccess, requireBoardAction |
| Tests | 98 unit-тестов в `__tests__/permissions/` |

## Что НЕ внутри

Phase 2 (замена `assertOwner` на 10 модулях), endpoints, frontend, OpenAPI, audit logging, performance benchmark — в follow-up issues #192-#207.

Phase 3 (drop legacy `WorkspaceRole` + `isSuperadmin` fallback) — issue #203, через 2-3 релиза.

## Документация

- SDD: [`docs/design/feature-permissions.md`](docs/design/feature-permissions.md), [`docs/design/board-acl.md`](docs/design/board-acl.md)
- BDD: [`specs/feature-permissions.feature`](specs/feature-permissions.feature), [`specs/board-acl.feature`](specs/board-acl.feature)
- Plan: [`tasks/feature-permissions-acl/plan.md`](tasks/feature-permissions-acl/plan.md)
- Reviews: [`code-review.md`](tasks/feature-permissions-acl/code-review.md), [`security-review.md`](tasks/feature-permissions-acl/security-review.md)

## G7 review highlights

5 HIGH findings зафиксил в этом PR:
- HIGH-1: board-override role был silently bypass'нут — переделал API на `withRolePermissions: ReadonlySet<string>` с fail-closed
- HIGH-2: in-flight cache race — generation-counter, тест-кейс «invalidate во время DB fetch» зелёный
- H1: `featureGate` anonymous bypass — убрал `'anonymous'` fallback, прямой prisma query
- H2: TOCTOU board fetch — `BoardAccessResult.workspaceId`, убран второй query
- H3: FK `SET NULL` → `RESTRICT` для всех RolePreset relations (новая миграция)

MEDIUM/LOW деферрены в issue #207 со скоупом каждого фикса.

## Test plan

- [x] `npx prisma validate` — schema valid
- [x] `npx prisma migrate dev` — обе миграции применяются, backfill: 4 system roles + 8 system features + 5/5 workspace_members с rolePresetId
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 330/333 (3 pre-existing skipped, 98 новых zelёных)
- [ ] CI зелёный
- [ ] Code review approve

Refs #191